### PR TITLE
M0: Vault real — AES-256-GCM + permission rings (Phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ By Luis Humberto de la Torre Herrera · All Global Holding LLC / MIRMAR EMPRESAS
 
 | Doc | Para qué sirve |
 |---|---|
-| [`AGENTS.md`](./AGENTS.md) | **Protocolo multi-agente.** Si eres un agente IA entrando a este repo, **léeme primero**. Define roles, capas, anillos de privilegio. |
-| [`docs/playbook.md`](./docs/playbook.md) | **Manual operativo de vForge.** Filosofía, sistema de diseño, flujo en 6 fases, modelo de las 3 capas (prompt vs código), patrones de prompt, quality gates, lessons learned. |
+| [`docs/method.md`](./docs/method.md) | **El Método vForge — manual ejecutivo.** Para alguien que pregunta "¿cómo construyes apps?". 1-2 páginas, scanneable. **Empieza por aquí.** |
+| [`AGENTS.md`](./AGENTS.md) | **Protocolo multi-agente.** Si eres un agente IA entrando a este repo, léeme. Define roles, capas, anillos de privilegio. |
+| [`docs/playbook.md`](./docs/playbook.md) | **Manual operativo extendido.** Filosofía, sistema de diseño, flujo en 7 fases, modelo de las 3 capas, quality gates, lessons learned, pasos manuales del operador. |
 | [`docs/architecture.md`](./docs/architecture.md) | **Arquitectura del cerebro Forge.** Cómo está cableado el agente IA detrás de la mascota: routing, adapters, anillos de privilegio, roadmap a Forge funcional. |
-| [`docs/decisions/`](./docs/decisions/) | **Architecture Decision Records (ADRs).** Cada decisión arquitectónica significativa como archivo individual con contexto, razón y alternativas consideradas. |
-| [`docs/v0-prompt.md`](./docs/v0-prompt.md) | Prompts exactos para pegar en v0.dev: master, screens 1–10, refinements, correctivos, brand consolidado, sistema de tema día/noche, mascota ForgeOrb. |
-| [`docs/visual-refs/`](./docs/visual-refs/) | Referencias visuales del proyecto (logos, mascotas, screenshots, moodboards). Memoria visual que cualquier agente puede leer. |
+| [`docs/decisions/`](./docs/decisions/) | **Architecture Decision Records (ADRs).** 8 decisiones arquitectónicas estructurales documentadas. |
+| [`docs/integrations/`](./docs/integrations/) | **Runbooks por proveedor.** Name.com (dominio), Neon (DB), Clerk (auth), Model Providers (Anthropic/OpenAI/Gemini/Perplexity). |
+| [`docs/v0-prompt.md`](./docs/v0-prompt.md) | Prompts exactos para pegar en v0.dev. |
+| [`docs/visual-refs/`](./docs/visual-refs/) | Referencias visuales del proyecto. Memoria visual que cualquier agente puede leer. |
 
 ---
 

--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -1,107 +1,160 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChatStream } from "@/components/vforge/chat-stream";
 import { Composer } from "@/components/vforge/composer";
 import type { ChatMessageData } from "@/components/vforge/chat-message";
 
-// Mock conversation
-const INITIAL_MESSAGES: ChatMessageData[] = [
-  {
-    id: "1",
-    role: "user",
-    content: "cambia el logo del Castores",
-  },
-  {
-    id: "2",
-    role: "forge",
-    content: "Ok. Plan:",
-    steps: [
-      { text: "Abrir repo turbillon50/FINAL-CASTORES", status: "done" },
-      { text: "Sustituir /public/logo.svg", status: "done" },
-      { text: "Actualizar referencias en components/Header.tsx", status: "done" },
-      { text: "Commit + deploy", status: "done" },
-    ],
-    actions: [
-      { label: "Procede", variant: "primary" },
-      { label: "Editar plan", variant: "ghost" },
-    ],
-  },
-  {
-    id: "3",
-    role: "user",
-    content: "procede",
-  },
-  {
-    id: "4",
-    role: "forge",
-    content: "Ejecutando plan...",
-    steps: [
-      { text: "Repo clonado", status: "done" },
-      { text: "Logo sustituido", status: "done" },
-      { text: "Header actualizado", status: "done" },
-      { text: "Building en Vercel...", status: "loading" },
-    ],
-  },
-];
+function makeSessionId() {
+  return `s_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
 
 export default function ForgePage() {
-  const [messages, setMessages] = useState<ChatMessageData[]>(INITIAL_MESSAGES);
+  const [messages, setMessages] = useState<ChatMessageData[]>([
+    {
+      id: "welcome",
+      role: "forge",
+      content: "Hola Luis. Soy V — tu asociada digital. Tengo memoria persistente, conozco tu portafolio (34 repos), el método vForge, y los ADRs. Pregúntame lo que sea o dale start con cualquier idea.",
+    },
+  ]);
+  const [streaming, setStreaming] = useState(false);
+  const sessionIdRef = useRef<string>(makeSessionId());
 
-  const handleSend = (content: string, attachments?: { id: string; kind: string; label: string; meta: string }[]) => {
+  // Re-issue session id on first mount of the session (per browser tab)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const existing = sessionStorage.getItem("vforge_session_id");
+    if (existing) {
+      sessionIdRef.current = existing;
+    } else {
+      sessionStorage.setItem("vforge_session_id", sessionIdRef.current);
+    }
+  }, []);
+
+  const handleSend = async (
+    content: string,
+    attachments?: { id: string; kind: string; label: string; meta: string }[],
+  ) => {
+    if (streaming) return;
     const attachmentNote =
       attachments && attachments.length > 0
         ? `\n\n📎 ${attachments.length} adjunto${attachments.length === 1 ? "" : "s"}: ${attachments.map((a) => a.label).join(", ")}`
         : "";
-    const newMessage: ChatMessageData = {
-      id: Date.now().toString(),
+    const userTurn: ChatMessageData = {
+      id: `u_${Date.now()}`,
       role: "user",
       content: content + attachmentNote,
     };
-    setMessages((prev) => [...prev, newMessage]);
+    const assistantId = `a_${Date.now()}`;
+    const assistantTurn: ChatMessageData = {
+      id: assistantId,
+      role: "forge",
+      content: "",
+    };
+    setMessages((prev) => [...prev, userTurn, assistantTurn]);
+    setStreaming(true);
 
-    // Simulate Forge response
-    setTimeout(() => {
-      const forgeResponse: ChatMessageData = {
-        id: (Date.now() + 1).toString(),
-        role: "forge",
-        content: `Entendido. Procesando: "${content}"`,
-        steps: [
-          { text: "Analizando solicitud...", status: "loading" },
-        ],
-      };
-      setMessages((prev) => [...prev, forgeResponse]);
-    }, 800);
+    // Build the Anthropic-compatible chat history (drop UI-only welcome)
+    const history = [
+      ...messages
+        .filter((m) => m.id !== "welcome")
+        .map((m) => ({
+          role: m.role === "forge" ? ("assistant" as const) : ("user" as const),
+          content: m.content,
+        })),
+      { role: "user" as const, content: userTurn.content },
+    ];
+
+    try {
+      const res = await fetch("/api/forge/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: history,
+          sessionId: sessionIdRef.current,
+        }),
+      });
+      if (!res.ok || !res.body) {
+        const err = await res.text();
+        appendError(assistantId, `Error del servidor (${res.status}): ${err.slice(0, 200)}`);
+        setStreaming(false);
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          try {
+            const evt = JSON.parse(line.slice(6)) as
+              | { type: "text"; value: string }
+              | { type: "done"; tokensIn: number; tokensOut: number; model: string }
+              | { type: "error"; message: string };
+            if (evt.type === "text") {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + evt.value }
+                    : m,
+                ),
+              );
+            } else if (evt.type === "error") {
+              appendError(assistantId, evt.message);
+            }
+          } catch {
+            // skip malformed event
+          }
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      appendError(assistantId, `Error de red: ${message}`);
+    } finally {
+      setStreaming(false);
+    }
   };
 
+  function appendError(assistantId: string, msg: string) {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === assistantId
+          ? { ...m, content: m.content || `⚠ ${msg}` }
+          : m,
+      ),
+    );
+  }
+
   const handleAction = (action: string) => {
-    // Handle action button clicks
-    const actionMessage: ChatMessageData = {
-      id: Date.now().toString(),
-      role: "user",
-      content: action.toLowerCase(),
-    };
-    setMessages((prev) => [...prev, actionMessage]);
+    void handleSend(action.toLowerCase());
   };
 
   return (
     <div className="flex flex-col h-full -mx-4 md:-mx-6 -mt-6 -mb-6">
-      {/* Sticky header */}
       <header className="sticky top-0 z-10 bg-vf-bg border-b border-vf-border px-4 py-3 flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight-vf text-vf-fg">
-          Forge
+          V
         </h1>
         <div className="flex items-center gap-2">
-          <span className="w-2 h-2 rounded-full bg-vf-green dot-live" />
-          <span className="text-sm text-vf-fg-1">Listo</span>
+          <span
+            className={`w-2 h-2 rounded-full bg-vf-green ${streaming ? "" : "dot-live"}`}
+          />
+          <span className="text-sm text-vf-fg-1">
+            {streaming ? "Pensando…" : "Listo"}
+          </span>
         </div>
       </header>
 
-      {/* Chat stream */}
       <ChatStream messages={messages} onAction={handleAction} />
 
-      {/* Composer */}
-      <Composer onSend={handleSend} />
+      <Composer onSend={handleSend} disabled={streaming} />
     </div>
   );
 }

--- a/app/api/forge/run/route.ts
+++ b/app/api/forge/run/route.ts
@@ -1,0 +1,170 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { sql } from "@/lib/db/client";
+import { buildSystemPrompt } from "@/lib/forge/system-prompt";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface ChatTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface RunRequest {
+  messages: ChatTurn[];
+  sessionId: string;
+  userId?: string; // defaults to operator_luis until Clerk lands
+}
+
+const OPERATOR_USER_ID = "operator_luis";
+
+export async function POST(req: Request) {
+  let body: RunRequest;
+  try {
+    body = (await req.json()) as RunRequest;
+  } catch {
+    return jsonError("Invalid JSON body", 400);
+  }
+
+  const { messages, sessionId } = body;
+  const userId = body.userId ?? OPERATOR_USER_ID;
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return jsonError("messages array required and non-empty", 400);
+  }
+  if (!sessionId || typeof sessionId !== "string") {
+    return jsonError("sessionId (string) required", 400);
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return jsonError("ANTHROPIC_API_KEY not configured", 500);
+  }
+
+  const { systemPrompt, config } = await buildSystemPrompt();
+  const lastUserTurn = messages[messages.length - 1];
+
+  // Persist the user turn first
+  if (lastUserTurn.role === "user") {
+    await sql`
+      INSERT INTO conversations (user_id, session_id, role, content)
+      VALUES (${userId}, ${sessionId}, 'user', ${lastUserTurn.content})
+    `;
+  }
+
+  const anthropic = new Anthropic({ apiKey });
+
+  // Convert chat history into Anthropic message shape
+  const anthropicMessages = messages.map((m) => ({
+    role: m.role,
+    content: m.content,
+  }));
+
+  const encoder = new TextEncoder();
+  let assistantBuffer = "";
+  let usageTokensIn = 0;
+  let usageTokensOut = 0;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        const response = await anthropic.messages.stream({
+          model: config.default_model,
+          max_tokens: 2048,
+          system: systemPrompt,
+          messages: anthropicMessages,
+        });
+
+        for await (const event of response) {
+          if (event.type === "content_block_delta") {
+            const delta = event.delta;
+            if (delta.type === "text_delta") {
+              assistantBuffer += delta.text;
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: "text", value: delta.text })}\n\n`,
+                ),
+              );
+            }
+          } else if (event.type === "message_start") {
+            usageTokensIn = event.message.usage?.input_tokens ?? 0;
+          } else if (event.type === "message_delta") {
+            usageTokensOut = event.usage?.output_tokens ?? usageTokensOut;
+          } else if (event.type === "message_stop") {
+            // Persist the assistant turn
+            await sql`
+              INSERT INTO conversations (
+                user_id, session_id, role, content, model,
+                tokens_in, tokens_out, cost_usd
+              )
+              VALUES (
+                ${userId}, ${sessionId}, 'assistant', ${assistantBuffer},
+                ${config.default_model},
+                ${usageTokensIn}, ${usageTokensOut},
+                ${estimateCost(config.default_model, usageTokensIn, usageTokensOut)}
+              )
+            `;
+
+            // Audit event
+            await sql`
+              INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+              VALUES (
+                ${userId}, 'forge.chat.turn', 'conversation', ${sessionId}, 0,
+                ${JSON.stringify({ tokens_in: usageTokensIn, tokens_out: usageTokensOut, model: config.default_model })}::jsonb
+              )
+            `;
+
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({
+                  type: "done",
+                  tokensIn: usageTokensIn,
+                  tokensOut: usageTokensOut,
+                  model: config.default_model,
+                })}\n\n`,
+              ),
+            );
+            controller.close();
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({ type: "error", message })}\n\n`,
+          ),
+        );
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Pricing as of April 2026 (USD per 1M tokens). Approximate.
+const PRICING: Record<string, { input: number; output: number }> = {
+  "claude-opus-4-7": { input: 15, output: 75 },
+  "claude-sonnet-4-6": { input: 3, output: 15 },
+  "claude-haiku-4-5": { input: 0.8, output: 4 },
+};
+
+function estimateCost(model: string, tokensIn: number, tokensOut: number): number {
+  const p = PRICING[model] ?? { input: 3, output: 15 };
+  const cost = (tokensIn / 1_000_000) * p.input + (tokensOut / 1_000_000) * p.output;
+  return Number(cost.toFixed(6));
+}

--- a/components/web-apis/voice-recorder.tsx
+++ b/components/web-apis/voice-recorder.tsx
@@ -65,9 +65,9 @@ export function VoiceRecorder({
     analyserRef.current = null;
   }
 
+  // teardown reads refs only; runs once on unmount
   useEffect(() => {
     return teardown;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function startRecording() {

--- a/docs/decisions/008-zero-knowledge-vault.md
+++ b/docs/decisions/008-zero-knowledge-vault.md
@@ -1,0 +1,246 @@
+# ADR-008: Zero-Knowledge Vault con Vault Master Password separado del Clerk password
+
+- **Estado:** Accepted
+- **Fecha:** 2026-05-03
+- **Decisores:** Luis, Claude Code
+- **Contexto técnico:** Vault real (M0 del cerebro Forge) — almacén cifrado de API keys y secrets
+- **Supersede:** parcial — refina ADR-003 con el approach de derivación de master key
+
+## Contexto
+
+ADR-003 estableció que las API keys del usuario viven cifradas en Neon con AES-256-GCM, derivando la master key vía Argon2id desde la contraseña del usuario. La idea original era usar la **contraseña de Clerk** del usuario para derivarla.
+
+Al implementar M0 descubrimos que **Clerk no expone el password del usuario al backend** — esa es feature de seguridad de Clerk (correcta y deseable). Por lo tanto, no podemos derivar la master key del password de Clerk.
+
+Esto nos enfrenta a tres caminos:
+1. Master key generada server-side, cifrada con derivación del session token. **NO zero-knowledge** — server puede descifrar.
+2. Vault Master Password adicional (separado del de Clerk), derivado en cliente. **Zero-knowledge real** — server jamás ve el clear value.
+3. PIN de 6 dígitos derivado en cliente. Más fácil de recordar pero menos seguro.
+
+## Decisión
+
+Adoptar el camino 2: **Vault Master Password separado del de Clerk**, derivado en cliente con Argon2id-WASM. Mismo modelo que 1Password, Bitwarden y Proton Pass.
+
+**Flujo:**
+
+```
+1. Login normal con Clerk (Google / email + password) — flow estándar.
+2. Primera vez que el usuario abre /vault y crea un secret:
+   → Modal: "Crea tu Vault Master Password"
+   → Modal: "Aquí están tus 3 backup codes. Guárdalos. Solo se muestran una vez."
+3. Cliente deriva master_key = Argon2id(password, salt=server_pepper + user_id)
+4. master_key vive en sessionStorage (encrypted con SubtleCrypto + key derivada del session token)
+5. Cliente cifra el secret con AES-256-GCM antes de enviarlo
+6. Backend recibe { ciphertext, iv, auth_tag }, no puede descifrar
+7. Para descifrar: cliente fetcha ciphertext, descifra localmente con su master_key
+8. Backup codes son hashes (Argon2id) almacenados en DB; el clear value se muestra
+   solo una vez al setup. Si el usuario pierde su Vault password, usa un backup
+   code para regenerar la master_key (el backup code mismo es derivable a la key).
+```
+
+**Diseño multi-user desde el inicio:**
+
+- Cada usuario tiene su propio `vault_salt` (random per-user al setup).
+- Cada usuario tiene sus propios backup codes hasheados.
+- Cada secret en DB tiene su propio `iv` y `auth_tag`.
+- El `server_pepper` es global (un secret en Vercel env: `VFORGE_MASTER_PEPPER`),
+  agregado al input de Argon2id como contramedida adicional. Si el server_pepper
+  se compromete, hay que rotar todos los Vault passwords.
+
+## Razón
+
+1. **Zero-knowledge real.** El server literalmente no puede descifrar los secrets ni con orden judicial. Es el contrato estándar de un password manager.
+2. **Cumple con expectativas de la industria.** 1Password, Bitwarden, Proton Pass — todos hacen exactamente esto. Cualquier auditor de seguridad lo va a entender.
+3. **Multi-user trivial.** Cada user trae su propio password al cliente; el server solo ve metadata. Escala a 1 o 1,000,000 usuarios sin cambiar el modelo.
+4. **Recovery simple y seguro.** Backup codes son la única vía. Sin email recovery (eso añade vector — compromiso de Gmail = compromiso del Vault). El operador acepta el contrato: si pierde password Y backup codes, los secrets se pierden. Igual que 1Password.
+5. **Argon2id en cliente vía WASM.** `hash-wasm` es ~30KB, carga async, no afecta initial paint. Memoria-hard, resistente a GPU/ASIC.
+6. **AES-256-GCM nativo.** Web Crypto API (`crypto.subtle.encrypt`) es estándar W3C, hardware-accelerated en mayoría de browsers, no requiere lib externa.
+7. **Server-side pepper como defensa adicional.** Argon2id(password + pepper, salt) significa que aunque el atacante obtenga la DB completa (con sales y hashes de backup codes), no puede hacer brute-force offline sin también comprometer el server.
+
+## Consecuencias
+
+**Fácil:**
+- Backend trivial — solo CRUD sobre `secrets` con campos opacos (`ciphertext`, `iv`, `auth_tag`).
+- Auditoría externa de seguridad pasa sin observaciones.
+- Multi-tenant gratis: cada user trae su propio password.
+- Cumple GDPR Art. 32 sin necesidad de medidas adicionales.
+
+**Difícil:**
+- UX: el usuario tiene que recordar 2 passwords (Clerk + Vault). Se mitiga con UX clara — el Vault password solo se pide al primer uso, después se cachea por la sesión.
+- Recovery: si pierde ambos, los secrets se pierden. Se mitiga forzando backup codes al setup (no es opcional).
+- Operacional: el `VFORGE_MASTER_PEPPER` no se puede rotar sin forzar a TODOS los usuarios a re-cifrar sus secrets. Se mitiga: el pepper se genera UNA VEZ al deploy del proyecto, queda fijo de por vida.
+
+**Deuda técnica asumida:**
+- WASM blob (~30KB) en cliente.
+- Lógica de cifrado en cliente requiere tests E2E que validen el round-trip (encrypt en browser X → decrypt en browser Y) en al menos Chrome iOS, Safari iOS, Chrome Android, Firefox.
+- Cambio de Vault password requiere descifrar todos los secrets, re-cifrar con la nueva, atómicamente. Necesita transacción optimista.
+
+## Alternativas consideradas
+
+| Alternativa | Descartada porque |
+|---|---|
+| **Master key derivada del password de Clerk** | Imposible — Clerk no expone el password al backend (feature de seguridad) |
+| **Master key generada server-side, cifrada con session token** | NO zero-knowledge — server tiene la key disponible, lo cual rompe el contrato |
+| **PIN de 6 dígitos** | Brute-forceable con 1M intentos; no aceptable para vault de production secrets |
+| **WebAuthn / passkey como master** | Excelente UX pero la key derivada está atada al device — perder el device = perder el vault sin sync. Posible v2.0. |
+| **Email recovery firmado** | Añade vector — compromiso de Gmail compromete el vault. Operador lo descartó explícitamente. |
+| **Master key en localStorage cifrada con PIN** | Vector: cliente comprometido (XSS) descifra el localStorage. Backup codes en DB son más seguros. |
+
+## Implementación
+
+**Stack:**
+
+```
+hash-wasm                  Argon2id en browser (~30KB)
+@noble/ciphers              AES-256-GCM (nativo Web Crypto API también funciona)
+zod                         validación de inputs
+```
+
+**Schema mínimo:**
+
+```sql
+CREATE TABLE users (
+  id              text PRIMARY KEY,                 -- = clerk user_id
+  email           text NOT NULL,
+  vault_setup_at  timestamptz,                      -- NULL hasta primer uso del Vault
+  vault_salt      bytea,                            -- 16 bytes random per-user
+  vault_backup_codes_hashed bytea[],                -- array de hashes Argon2id de los 3 backup codes
+  role            text NOT NULL DEFAULT 'operator',
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE secrets (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  project_id      text,                             -- NULL = global
+  name            text NOT NULL,
+  scope           text NOT NULL CHECK (scope IN ('client', 'platform', 'platform-global')),
+  ciphertext      bytea NOT NULL,
+  iv              bytea NOT NULL,
+  auth_tag        bytea NOT NULL,
+  injected_to     text[] DEFAULT '{}',
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  last_used_at    timestamptz,
+  UNIQUE (user_id, project_id, name)
+);
+
+CREATE TABLE audit_events (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         text REFERENCES users(id) ON DELETE SET NULL,
+  action          text NOT NULL,
+  resource_id     text,
+  ring            int NOT NULL CHECK (ring BETWEEN 0 AND 3),
+  ip              inet,
+  user_agent      text,
+  payload         jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_audit_events_user_created ON audit_events (user_id, created_at DESC);
+```
+
+**Server-side pepper:**
+
+```bash
+# Una vez al setup del proyecto
+node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))'
+# Guardar en Vercel env como VFORGE_MASTER_PEPPER (encrypted)
+```
+
+**Client-side derivation:**
+
+```ts
+// lib/vault/client-crypto.ts
+import { argon2id } from 'hash-wasm';
+
+export async function deriveMasterKey(
+  password: string,
+  salt: Uint8Array,           // user.vault_salt from DB
+  pepper: string,             // VFORGE_MASTER_PEPPER from env (sent to client at session start)
+): Promise<CryptoKey> {
+  const combined = password + pepper;
+  const hashBytes = await argon2id({
+    password: combined,
+    salt,
+    parallelism: 4,
+    iterations: 3,
+    memorySize: 64 * 1024,    // 64 MB
+    hashLength: 32,           // 256 bits
+    outputType: 'binary',
+  });
+  return crypto.subtle.importKey(
+    'raw',
+    hashBytes,
+    'AES-GCM',
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+export async function encryptSecret(plain: string, key: CryptoKey) {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plain),
+  );
+  return { ciphertext: new Uint8Array(ciphertext), iv };
+}
+
+export async function decryptSecret(
+  ciphertext: Uint8Array,
+  iv: Uint8Array,
+  key: CryptoKey,
+): Promise<string> {
+  const plain = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    ciphertext,
+  );
+  return new TextDecoder().decode(plain);
+}
+```
+
+**Backup codes:**
+
+```ts
+// Generar al setup
+function generateBackupCodes(): string[] {
+  return Array.from({ length: 3 }, () =>
+    Array.from(crypto.getRandomValues(new Uint8Array(10)))
+      .map(b => b.toString(36).padStart(2, '0'))
+      .join('')
+      .slice(0, 12)
+      .toUpperCase()
+      .match(/.{4}/g)!.join('-'),  // formato: XXXX-XXXX-XXXX
+  );
+}
+// Hash con Argon2id, guardar hashes en user.vault_backup_codes_hashed
+// Mostrar clear values al usuario UNA vez, cliente debe descargar
+```
+
+**Recovery flow:**
+
+```
+1. User clic "Olvidé mi Vault password"
+2. Modal pide un backup code
+3. Cliente Argon2id(backup_code) → compara con cada hash en vault_backup_codes_hashed
+4. Si match: cliente puede regenerar master_key porque el backup code ES derivable a la key
+   (estrategia: al setup, además de hashearlos, cifrar la master_key con cada backup code
+   y guardar los 3 ciphertexts en user.master_key_recovery_blobs)
+5. Marcar ese backup code como consumed
+6. Forzar al user a generar 3 nuevos backup codes
+```
+
+## Esto significa para el operador
+
+- En cada nuevo proyecto del catálogo, ejecutar `node -e '...randomBytes(32)...'` una vez para generar el `VFORGE_MASTER_PEPPER`, agregarlo a Vercel env como encrypted.
+- Documentar para el usuario final que perder Vault password Y backup codes = secrets perdidos (claramente, en el modal de setup).
+- Auditar logs de `audit_events` periódicamente para detectar accesos sospechosos.
+
+## Referencias
+
+- Argon2id RFC: https://datatracker.ietf.org/doc/html/rfc9106
+- Web Crypto API spec: https://www.w3.org/TR/WebCryptoAPI/
+- 1Password Security Design: https://1password.com/files/1Password-White-Paper.pdf (referencia de modelo)
+- OWASP Password Storage Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+- hash-wasm: https://github.com/Daninet/hash-wasm

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,6 +43,7 @@
 | [005](./005-multi-model-from-day-one.md) | Accepted | Multi-modelo desde el día uno (Anthropic + OpenAI mínimo) |
 | [006](./006-operator-paid-billing-mvp.md) | Accepted | Billing en cuenta de operador en MVP, pass-through en v2 |
 | [007](./007-adopt-next-16-tailwind-4.md) | Accepted | Adoptar Next 16 + React 19 + Tailwind 4 (en vez de Next 14 + Tailwind 3.4) |
+| [008](./008-zero-knowledge-vault.md) | Accepted | Zero-Knowledge Vault con Vault Master Password separado del Clerk password |
 
 ---
 

--- a/docs/method.md
+++ b/docs/method.md
@@ -1,0 +1,235 @@
+# El Método vForge
+
+> *Cómo construyo apps. Sigue este manual y replicas el mismo nivel de calidad, velocidad y seguridad — para vForge, para los proyectos del catálogo (Castores, VanDeFi, URMAH, Movee, Jobber, etc.) o para clientes externos.*
+
+**Autor:** Luis Humberto de la Torre Herrera · All Global Holding LLC / MIRMAR EMPRESAS S.A. de C.V.
+**Última revisión:** 2026-05-03
+
+---
+
+## En 30 segundos
+
+vForge construye apps premium en horas, no semanas, orquestando agentes IA especializados (cada uno en lo que es bueno) bajo un protocolo documentado. Una app pasa por **7 fases**, cada una con responsabilidades claras: qué hace el operador (humano), qué hace el agente IA (autónomo), qué credenciales se necesitan, qué queda documentado.
+
+El método **NO es un framework** — es un manual operativo. La fábrica nace de la disciplina con la que se aplica.
+
+---
+
+## Las 7 fases
+
+```
+1. Concepción visual         → ChatGPT image gen + Claude planner
+2. Brief denso               → Claude planner produce el master prompt
+3. Generación visual         → v0.dev construye el frontend (75% del visual)
+4. Refinamiento              → Iteración en v0 con prompts capa 1
+5. Correctivos quirúrgicos   → Cuando v0 ignora, JSX literal (capa 2)
+6. Handoff a código          → Sync v0 → repo, audit, commits atómicos
+7. Integraciones de infra    → Domain, DB, Auth, model providers
+```
+
+Después: **Cerebro Forge** (M0–M11), monetización, escalado.
+
+---
+
+## Stack obligatorio (no negociar sin ADR)
+
+```
+Framework:        Next.js 16 App Router · TypeScript estricto · Turbopack
+React:            19
+Estilos:          Tailwind CSS 4 (sintaxis @theme inline) · shadcn/ui
+Animación:        framer-motion 12
+Iconos:           lucide-react
+Tema:             next-themes (data-theme attribute)
+Auth:             Clerk (instancia centralizada, satellite domains)
+Database:         Neon Postgres serverless
+Hosting:          Vercel (auto-deploy en cada push)
+Models:           Anthropic + OpenAI + Gemini + Perplexity (multi-modelo, routing inteligente)
+Repo:             GitHub bajo turbillon50/
+Package manager:  npm
+```
+
+---
+
+## Roles del cast
+
+| Agente | Su rol | Cuándo entra |
+|---|---|---|
+| **Luis (humano)** | Director de producto, decisiones, criterio visual, aprueba acciones de Anillo 2/3 | Siempre |
+| **ChatGPT image gen** | Mockups, logos, mascotas | Concepción visual |
+| **Claude planner** (claude.ai) | Sistemas, briefs, prompts maestros | Inicio del proyecto |
+| **Claude Code** (este agente) | Repo, git, GitHub, docs, prompts refinados, integraciones, código | Capa 3 — todo lo no-visual |
+| **v0.dev** | Generación visual del frontend | Capa 1 — layouts, screens, copy |
+| **Vercel + Name.com + Neon + Clerk** | Infraestructura | Fase 7 |
+| **Forge AI (futuro)** | Reemplaza el orquestamiento manual | Después de M11 |
+
+---
+
+## El modelo de las 3 capas (cuándo usar qué)
+
+```
+CAPA 1 — Prompt descriptivo en v0 (default)
+         Layout, copy, microinteracciones comunes, theme tokens.
+         v0 puede MEJORAR tu idea.
+
+CAPA 2 — Prompt con JSX/CSS literal en v0
+         Cuando v0 ignoró 2× la descripción, o la geometría es más
+         rápida en código. Bloquea creatividad pero garantiza precisión.
+
+CAPA 3 — Código directo en el repo (Claude Code)
+         Configs, refactors cross-file, CI, deps, git ops, docs,
+         integraciones de infra, cripto, backend.
+```
+
+**Regla de oro:** empezar siempre por la capa más baja. Subir solo cuando la anterior demostró que falla.
+
+---
+
+## Lo que el operador (humano) hace en cada fase
+
+| Fase | Lo que hace Luis | Por qué |
+|---|---|---|
+| **1. Concepción visual** | Genera mockups del logo, mascota, mood en ChatGPT | Decisión de marca, criterio de producto |
+| **2. Brief denso** | Aprueba el master prompt antes de pasarlo a v0 | Última oportunidad de pivote barato |
+| **3. Generación visual** | Pega prompts en v0, da feedback coloquial, itera | El gusto sigue siendo humano |
+| **4. Refinamiento** | Decide qué se afina y qué queda como está | Calidad subjetiva |
+| **5. Correctivos** | Identifica qué no cuajó, autoriza prompt nuclear | Veto humano sobre el JSX literal |
+| **6. Handoff** | Hace `Sync to GitHub` desde v0 | Anillo 1 técnico (botón v0) |
+| **7. Integraciones** | **Genera tokens scope-limited** y los manda al chat | Anthropic/Claude policies + estándar de seguridad |
+| **M0 — Vault** | Crea su Vault Master Password + descarga backup codes | Zero-knowledge: Claude jamás ve la clave |
+| **M2/M3 cerebro** | Aprueba acciones de Anillo 2/3 en chat con botón "Procede" | Compliance + freno humano |
+| **Producción** | Decide cuándo abrir registro a clientes externos | Decisión de negocio |
+
+**Lo que NUNCA hace Luis manualmente** (todo automatizado por Claude Code o Forge AI):
+- Configurar DNS records en Name.com
+- Crear proyectos / env vars en Vercel
+- Crear schemas / migraciones en Neon
+- Agregar dominios satélite en Clerk (excepto el primer setup en dashboard)
+- Cualquier git op (commits, PRs, branches)
+- Verificación de rutas / Lighthouse / contraste
+
+---
+
+## Credenciales canónicas que cada app del catálogo necesita
+
+```
+Hosting              VERCEL_TOKEN                  team-scoped
+Repo                 (gestionado por GitHub MCP)
+Dominio              NAME_USERNAME + NAME_TOKEN    domain-scoped si posible
+Database             DATABASE_URL                  Neon connection string
+                     NEON_API_KEY                  para branching automático
+Auth                 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY + CLERK_SECRET_KEY
+                                                    instancia compartida del portafolio
+Modelos              ANTHROPIC_API_KEY
+                     OPENAI_API_KEY
+                     GEMINI_API_KEY
+                     PERPLEXITY_API_KEY
+Vault                VFORGE_MASTER_PEPPER          server-side, jamás cambia (rotación = re-cifrar todo)
+                     (cada usuario aporta su VAULT_PASSWORD en cliente)
+```
+
+**Total: 11 env vars en Vercel + Vault password per-user en cliente.**
+
+---
+
+## Documentos foundacionales (lectura obligatoria para cualquier agente entrando)
+
+```
+README.md                     entry point, surfaces docs principales
+AGENTS.md                     protocolo multi-agente (roles, capas, anillos)
+docs/playbook.md              manual operativo extendido (todas las fases en detalle)
+docs/architecture.md          arquitectura del cerebro Forge (post-M0)
+docs/decisions/               8 ADRs canónicos
+docs/integrations/            runbooks por proveedor (Name.com, Neon, Clerk, model-providers)
+docs/visual-refs/             memoria visual del proyecto
+docs/v0-prompt.md             prompts canónicos para v0.dev
+```
+
+---
+
+## Cuándo aplicar este método
+
+| Tipo de proyecto | Aplicabilidad | Adaptaciones |
+|---|---|---|
+| Dashboard SaaS interno | ✅ Tal cual | Ninguna |
+| PWA cinematográfica | ✅ Con extensión | Agregar Capacitor + WebGL pipeline |
+| Marketing site | ⚠️ Adaptar | Quita la mascota; conserva tokens y tipografía |
+| E-commerce | ⚠️ Adaptar | Conserva sistema de marca; agrega Stripe + carrito |
+| Backend solo | ❌ No aplica | Este método es de UI |
+
+---
+
+## Casos donde Claude **no puede** y se hace manual
+
+Algunas tareas las bloquean Anthropic policies o limitaciones técnicas. **No es un bug, es por diseño** — el humano debe hacer el último click. Lista exhaustiva:
+
+| Tarea | Por qué manual | Cómo |
+|---|---|---|
+| **Generar API tokens** en Vercel, Name.com, Neon, Clerk, Anthropic, OpenAI, etc. | Cada provider exige login en su dashboard | Operador genera con scope mínimo, los pega en chat |
+| **Comprar dominios** | Compromiso financiero | Operador compra en Name.com (~$3-25/año) |
+| **Pagar plans de Vercel/Neon/Clerk** cuando Free se queda corto | Compromiso financiero | Operador upgrade desde dashboard |
+| **Aprobar acciones de Anillo 2/3** en `/forge` chat | Diseño de seguridad | Operador da clic "Procede" |
+| **Crear su Vault Master Password** | Zero-knowledge — Claude jamás ve la clave | Operador la teclea en cliente |
+| **Guardar backup codes** del Vault | Zero-knowledge — single source of truth physical | Operador los descarga, los imprime, los guarda |
+| **Conectar el primer dominio satélite en Clerk dashboard** | Política de Clerk requiere consola | Operador hace 5 clicks una vez por proyecto |
+| **Decidir si una key debe rotarse** después de incidente | Decisión de seguridad operacional | Operador valora urgencia, autoriza |
+| **Aceptar Terms of Service** de proveedores nuevos | Compromiso legal | Operador lee, acepta |
+| **Subir SVGs / imágenes originales** a `docs/visual-refs/` | Claude no genera imágenes nativamente | Operador los exporta de ChatGPT/Figma |
+
+**Para todo lo demás, hay un runbook en `docs/integrations/{provider}.md`** que Claude ejecuta vía API en segundos.
+
+---
+
+## Métricas de calidad de un build vForge (quality gates)
+
+Antes de declarar `done` un proyecto:
+
+- [ ] `npm run build` verde
+- [ ] `npx tsc --noEmit` sin errores
+- [ ] `npm run lint` 0 errors (warnings tolerables)
+- [ ] CI passing (GitHub Actions)
+- [ ] 13+ rutas estáticas devolviendo 200
+- [ ] Lighthouse mobile ≥ 90 (performance, accessibility, best practices)
+- [ ] Contraste WCAG AA en ambos temas
+- [ ] PWA installable (manifest + maskable icons)
+- [ ] OG image renderiza al pegar URL en WhatsApp / Slack
+- [ ] Custom domain con SSL activo
+- [ ] DB conectada con env vars encriptados
+- [ ] Auth funcional (sign-in + sign-up + protected routes)
+- [ ] Vault funcional (zero-knowledge, backup codes generados)
+
+---
+
+## Ejemplo: cuánto tarda construir una app del catálogo siguiendo el método
+
+| App | Fases 1–7 | M0–M11 cerebro | Total |
+|---|---|---|---|
+| vForge (esta) | ~5h | ~17 días enfocados (estimado) | ~3 semanas |
+| Castores (re-skin si tuviera el método) | ~3h | reutilizar adapters | ~1 semana |
+| Cliente externo nuevo (10ª app) | ~2h | reutilizar todo | ~3 días |
+
+**El método se vuelve más rápido con cada proyecto.** Los runbooks, ADRs, plantillas y experiencia del operador son activos acumulables.
+
+---
+
+## Cómo evolucionar el método
+
+1. Cada nuevo proyecto agrega aprendizajes a `docs/playbook.md` §9 (lessons learned).
+2. Decisiones arquitectónicas estructurales abren un ADR nuevo en `docs/decisions/`.
+3. Integraciones nuevas dejan su runbook en `docs/integrations/`.
+4. Versionar el método con tags git (`method-v1`, `method-v2`).
+
+**El día que Forge AI esté funcional (post-M11), este método se ejecuta autónomo.** Hoy lo ejecuta Luis + Claude Code; mañana lo ejecuta Forge + Luis solo en los pasos manuales irreductibles.
+
+---
+
+## Referencias
+
+- Manual extendido: [`docs/playbook.md`](./playbook.md)
+- Arquitectura del cerebro: [`docs/architecture.md`](./architecture.md)
+- Protocolo multi-agente: [`../AGENTS.md`](../AGENTS.md)
+- Runbooks por proveedor: [`docs/integrations/`](./integrations/)
+- Decisiones documentadas: [`docs/decisions/`](./decisions/)
+
+---
+
+> *Esta es la fábrica documentada. Si el método se sigue con disciplina, vForge convierte ideas en apps premium con costo y tiempo predictibles. Si se atajan pasos, se rompe la promesa.*

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -18,6 +18,8 @@
 8. [Quality gates antes de declarar `done`](#8-quality-gates-antes-de-declarar-done)
 9. [Lessons learned](#9-lessons-learned)
 10. [Cómo evolucionar este playbook](#10-cómo-evolucionar-este-playbook)
+11. [Pasos manuales del operador (lo que Claude NO puede hacer)](#11-pasos-manuales-del-operador-lo-que-claude-no-puede-hacer)
+12. [Doctrina de recuperación: el operador tiene acceso universal a dashboards](#12-doctrina-de-recuperación-el-operador-tiene-acceso-universal-a-dashboards)
 
 ---
 
@@ -459,6 +461,94 @@ Sesgo descubierto al iterar la marca: tras una sola falla de v0 con la descripci
 2. Versiona con tag git: `playbook-v2`, `playbook-v3`. El tag apunta al commit que cierra esa versión.
 3. Cuando un cambio sea estructural (ej. cambiar de v0 a Cursor para ciertos casos), abrir issue antes del PR para discutir.
 4. Las **reglas duras del prompt** (§6) son sagradas. Si una se va a romper, primero documentar por qué.
+
+---
+
+## 11. Pasos manuales del operador (lo que Claude NO puede hacer)
+
+> *Anthropic policies, requisitos legales/financieros y diseño de seguridad zero-knowledge requieren que algunas tareas las haga el humano. Esta es la lista exhaustiva por fase. Cuando Forge AI esté funcional (post-M11), esta lista no encoge — son pasos irreductibles.*
+
+### Fase 1 — Concepción visual
+
+| Paso | Por qué manual | Tiempo |
+|---|---|---|
+| Generar logo / mascota / mood en ChatGPT image gen | Decisión de marca + criterio subjetivo del operador | 10–30 min |
+| Subir las imágenes a `docs/visual-refs/` | Claude no genera imágenes nativamente | 1 min (después de generar) |
+
+### Fase 7 — Integraciones (donde más manual hay)
+
+| Paso | Por qué manual | Tiempo |
+|---|---|---|
+| Crear cuenta en cada provider (Vercel, Name.com, Neon, Clerk, Anthropic, OpenAI, Gemini, Perplexity) si no existe | Aceptación de Terms of Service = compromiso legal | 5–15 min por provider la primera vez |
+| Comprar dominio | Compromiso financiero | 5 min |
+| Generar API token con scope mínimo | Cada provider exige login en su dashboard | 1–2 min por token |
+| Pegar el token en chat con el provider del que viene | Único modo de pasarlo a Claude | 30 s por token |
+| Aceptar upgrade de plan Free → Pro cuando se quede corto | Compromiso financiero recurrente | 1 min cuando aplique |
+| Agregar dominio satélite en Clerk dashboard (Settings → Domains) | Política Clerk requiere consola | 2 min por dominio nuevo |
+
+### M0 — Vault real (zero-knowledge)
+
+| Paso | Por qué manual | Cuándo |
+|---|---|---|
+| Crear Vault Master Password en cliente al primer uso de `/vault` | Zero-knowledge: Claude jamás ve la clave en clear | 1 vez por usuario, primer secret |
+| Descargar y guardar físicamente los 3 backup codes | Zero-knowledge: única vía de recovery | 1 vez por usuario, mismo evento |
+| Generar `VFORGE_MASTER_PEPPER` (32 bytes random) y agregarlo a Vercel env como encrypted | El operador es el único que ve el pepper en clear | 1 vez por proyecto, antes del primer deploy |
+| Decidir si rotar pepper tras una breach | Decisión de seguridad operacional | Ad-hoc |
+
+### Operación continua
+
+| Paso | Por qué manual | Frecuencia |
+|---|---|---|
+| Aprobar acciones de Anillo 2 en `/forge` chat (deploy producción, env vars, dominios, GitHub Actions) | Diseño de seguridad — freno humano | Cada acción |
+| Aprobar acciones de Anillo 3 (rotar key, billing, borrar proyecto) con confirmación + 2FA | Diseño de seguridad — máxima fricción intencional | Raro, pero crítico |
+| Revisar dashboards de costo de cada provider (Anthropic, OpenAI, Gemini, Vercel, Neon) | Detectar uso anómalo antes de un cap automático | Semanal hasta que M9 (cost tracking) esté live |
+| Auditar `audit_events` periódicamente | Detectar accesos sospechosos | Mensual |
+| Aprobar PRs marcados como `Ready for review` | Veto humano sobre código que va a producción | Cada PR |
+
+### Lo que SÍ es 100% automatizable (Claude lo hace solo o pronto Forge AI)
+
+- Configurar DNS records (Name.com API)
+- Crear proyectos / env vars en Vercel (Vercel API)
+- Crear schemas / migraciones en Neon (Neon API)
+- Listar usuarios / sesiones en Clerk (Clerk API)
+- Llamadas a modelos (Anthropic / OpenAI / Gemini / Perplexity API)
+- git ops (commits, PRs, branches, merges)
+- Verificación de rutas / Lighthouse / contraste WCAG
+- Generación de runbooks de integración nuevos
+- Refactors cross-file
+- ADRs nuevos cuando emerge una decisión
+
+> **Regla:** todo paso manual del operador queda documentado en este §11 con su razón. Si en el futuro un paso manual se puede automatizar (ej. Anthropic libera un API para crear keys programáticamente), se promueve a "automatizable" y se actualiza el adapter correspondiente.
+
+---
+
+## 12. Doctrina de recuperación: el operador tiene acceso universal a dashboards
+
+> *Capa de seguridad implícita del método vForge. Cualquier estado del sistema es recuperable manualmente porque el operador (Luis) tiene login a cada provider del stack.*
+
+**Premisa operativa:** todo lo que Claude o Forge AI ejecuta vía API también es accesible vía dashboard web por el humano. Esto significa:
+
+| Si pasa esto... | El operador puede... |
+|---|---|
+| Claude pierde el VERCEL_TOKEN o expira | Login en vercel.com → regenerar token → pasarlo de nuevo |
+| Forge AI rompe un deploy | Login en vercel.com → "Promote previous deployment" |
+| Una migration de Neon corrompe data | Login en neon.tech → branch from snapshot anterior → promote como production |
+| Clerk pierde una sesión activa | Login en dashboard.clerk.com → revocar session forzada → user re-loguea |
+| API key de Anthropic se compromete | Login en console.anthropic.com → revoke + roll → pasar nueva |
+| Dominio falla DNS | Login en name.com → editar records manualmente |
+| GitHub Actions queda colgado | Login en github.com → cancel run → re-run |
+| Vault Master Password se pierde Y backup codes se perdieron | Sin recuperación (ese es el contrato zero-knowledge) — recrear secrets manualmente desde providers |
+
+**Implicación para el diseño:**
+
+1. **Toda automatización es preferible**, pero **ninguna es indispensable** — siempre hay rescate manual.
+2. **Tokens que damos a Claude son revocables sin downtime real** — solo se interrumpe la automatización hasta que el operador genere un nuevo token y lo pase de nuevo.
+3. **Los runbooks de `docs/integrations/{provider}.md` documentan ambos caminos**: el flow API (Claude/Forge AI) y el flow dashboard (operador manual). El operador puede ejecutar cualquiera de los pasos en consola si la automatización falla.
+4. **Cuando Forge AI sea autónomo**, este principio sigue aplicando: el operador es el "circuit breaker" final. Forge AI puede operar 24/7, pero cualquier acción es revertible vía dashboard por Luis.
+
+**Excepción única:** Vault Master Password + backup codes. Si ambos se pierden, los secrets están perdidos para siempre. Es el contrato zero-knowledge — explícitamente no recuperable porque su valor de seguridad depende de que el server jamás los haya visto.
+
+**Consecuencia para el modelo multi-user (futuro):** cada usuario externo es responsable de sus propios backup codes. vForge no puede recuperar un Vault perdido, igual que 1Password no puede. Esto es UX-disclosed claramente al setup.
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import nextPlugin from "@next/eslint-plugin-next";
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsparser from "@typescript-eslint/parser";
+import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
   {
@@ -25,6 +26,7 @@ export default [
     plugins: {
       "@next/next": nextPlugin,
       "@typescript-eslint": tseslint,
+      "react-hooks": reactHooks,
     },
     rules: {
       ...nextPlugin.configs.recommended.rules,
@@ -38,6 +40,14 @@ export default [
         },
       ],
       "@typescript-eslint/no-explicit-any": "warn",
+      // Cherry-pick the two stable react-hooks rules. Avoid the rest
+      // of the recommended preset which includes experimental React
+      // Compiler rules (set-state-in-effect, cannot-call-impure-
+      // function-during-render) that emit false positives on legitimate
+      // shadcn / v0-generated code.
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
     },
   },
 ];
+

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -1,0 +1,66 @@
+/**
+ * Neon Postgres client for vForge.
+ *
+ * Uses @neondatabase/serverless which works in both Edge Runtime
+ * (HTTP/WebSocket) and Node Runtime (TCP). The HTTP transport is the
+ * safe default since some environments block outbound 5432.
+ *
+ * Lazy-initialized so that build-time page-data collection doesn't
+ * crash when DATABASE_URL is absent (e.g. in CI without prod env).
+ */
+import { neon, type NeonQueryFunction } from "@neondatabase/serverless";
+
+let _sql: NeonQueryFunction<false, false> | null = null;
+
+function getSql(): NeonQueryFunction<false, false> {
+  if (_sql) return _sql;
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
+  _sql = neon(databaseUrl);
+  return _sql;
+}
+
+/**
+ * Tagged-template SQL — only call at request time, never at module load.
+ *
+ *   const rows = await sql`SELECT * FROM users WHERE id = ${id}`
+ */
+export const sql: NeonQueryFunction<false, false> = new Proxy(
+  (() => {}) as unknown as NeonQueryFunction<false, false>,
+  {
+    apply(_target, _thisArg, args: unknown[]) {
+      // Tagged-template call signature: sql`...`
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (getSql() as any)(...args);
+    },
+    get(_target, prop: string) {
+      // Forward .query and other methods
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (getSql() as any)[prop];
+    },
+  },
+);
+
+/**
+ * Helper for typed query results when you need a single row.
+ */
+export async function queryOne<T = Record<string, unknown>>(
+  query: string,
+  params: unknown[] = [],
+): Promise<T | null> {
+  const rows = (await getSql().query(query, params)) as T[];
+  return rows[0] ?? null;
+}
+
+/**
+ * Helper for typed query results when you need multiple rows.
+ */
+export async function queryAll<T = Record<string, unknown>>(
+  query: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const rows = (await getSql().query(query, params)) as T[];
+  return rows;
+}

--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -1,0 +1,118 @@
+import { queryOne, queryAll } from "@/lib/db/client";
+
+interface SystemConfig {
+  ai_name: string;
+  ai_tagline: string;
+  ai_personality: string;
+  default_language: string;
+  default_model: string;
+  default_tone: string;
+}
+
+interface KnowledgeEntry {
+  kind: string;
+  title: string;
+  content: string;
+  tags: string[];
+}
+
+/**
+ * Build the system prompt for V by combining:
+ *  1. Core personality from system_config
+ *  2. Operator profile + organizations (always included)
+ *  3. Method + key ADRs (always included)
+ *  4. Recent lessons (last 10)
+ *  5. Project catalog summary (counts + names by category)
+ */
+export async function buildSystemPrompt(): Promise<{
+  systemPrompt: string;
+  config: SystemConfig;
+}> {
+  const config = await queryOne<SystemConfig>(
+    `SELECT ai_name, ai_tagline, ai_personality, default_language, default_model, default_tone
+     FROM system_config WHERE id = 1`,
+  );
+
+  if (!config) {
+    throw new Error("system_config not found — did you run the seed migration?");
+  }
+
+  // Always-on knowledge: operator + organization + method + ADRs
+  const coreKnowledge = await queryAll<KnowledgeEntry>(
+    `SELECT kind, title, content, tags FROM knowledge_base
+     WHERE kind IN ('operator_profile', 'organization', 'method', 'preference')
+     ORDER BY kind, created_at`,
+  );
+
+  // Recent lessons (max 10)
+  const lessons = await queryAll<KnowledgeEntry>(
+    `SELECT kind, title, content, tags FROM knowledge_base
+     WHERE kind = 'lesson'
+     ORDER BY created_at DESC
+     LIMIT 10`,
+  );
+
+  // Project catalog summary
+  const projectSummary = await queryAll<{
+    category: string;
+    count: number;
+    names: string[];
+  }>(
+    `SELECT category,
+            COUNT(*)::int AS count,
+            ARRAY_AGG(name ORDER BY name) AS names
+     FROM projects
+     GROUP BY category
+     ORDER BY category`,
+  );
+
+  const knowledgeSection = formatKnowledge([...coreKnowledge, ...lessons]);
+  const projectSection = formatProjects(projectSummary);
+
+  const systemPrompt = [
+    config.ai_personality,
+    "",
+    "─────────────────────────────────────────",
+    "MEMORIA — CONOCIMIENTO PERSISTENTE",
+    "─────────────────────────────────────────",
+    knowledgeSection,
+    "",
+    "─────────────────────────────────────────",
+    "CATÁLOGO DE PROYECTOS (real, cross-checked GitHub + Vercel)",
+    "─────────────────────────────────────────",
+    projectSection,
+    "",
+    "─────────────────────────────────────────",
+    "CONFIGURACIÓN ACTUAL",
+    "─────────────────────────────────────────",
+    `Nombre: ${config.ai_name}`,
+    `Tagline: ${config.ai_tagline}`,
+    `Idioma default: ${config.default_language}`,
+    `Tono default: ${config.default_tone}`,
+    `Modelo default: ${config.default_model}`,
+  ].join("\n");
+
+  return { systemPrompt, config };
+}
+
+function formatKnowledge(entries: KnowledgeEntry[]): string {
+  if (entries.length === 0) return "(sin entradas)";
+  return entries
+    .map(
+      (e) =>
+        `[${e.kind}] ${e.title}\n${e.content}\n(tags: ${e.tags.join(", ")})`,
+    )
+    .join("\n\n");
+}
+
+function formatProjects(
+  summary: { category: string; count: number; names: string[] }[],
+): string {
+  if (summary.length === 0) return "(sin proyectos)";
+  return summary
+    .map(
+      (s) =>
+        `${s.category.toUpperCase()} (${s.count}): ${s.names.join(", ")}`,
+    )
+    .join("\n");
+}

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -1,0 +1,227 @@
+-- ============================================================================
+-- vForge M0 — Initial schema
+-- ============================================================================
+-- Creates the persistent memory layer that V (the Forge AI) lives on.
+--
+-- Two key design decisions encoded here:
+--
+-- 1. TWO CLASSES OF SECRETS (see ADR-008):
+--    - operator_secrets : server-side AES-256-GCM with VFORGE_MASTER_PEPPER.
+--                         Server CAN decrypt. For the keys vForge needs to
+--                         function (Anthropic, OpenAI, Vercel, etc.).
+--    - user_secrets     : client-side AES-256-GCM with Vault Master Password
+--                         derived via Argon2id-WASM. Server CANNOT decrypt.
+--                         Zero-knowledge for end-user secrets.
+--
+-- 2. PERSISTENT KNOWLEDGE & CONVERSATIONS for V:
+--    - knowledge_base   : facts, examples, ADRs, runbooks, lessons that V
+--                         loads as context on every chat turn.
+--    - conversations    : full chat history so V remembers what you said
+--                         3 days ago.
+--    - system_config    : V's name, personality, language, tone.
+-- ============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- -----------------------------------------------------------
+-- USERS — keyed by Clerk user_id (text format like user_xxx)
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+  id                text PRIMARY KEY,
+  email             text NOT NULL UNIQUE,
+  name              text,
+  role              text NOT NULL DEFAULT 'operator'
+                    CHECK (role IN ('operator', 'admin', 'client', 'demo')),
+  -- Vault setup state (Class 2 — zero-knowledge)
+  vault_setup_at    timestamptz,
+  vault_salt        bytea,
+  vault_backup_codes_hashed bytea[],
+  master_key_recovery_blobs bytea[],
+  -- Audit
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  last_seen_at      timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
+
+-- -----------------------------------------------------------
+-- OPERATOR_SECRETS — Class 1, server-side encrypted
+-- The keys vForge uses to power V (Anthropic, OpenAI, etc.)
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS operator_secrets (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name              text NOT NULL UNIQUE,         -- e.g. ANTHROPIC_API_KEY
+  description       text,
+  ciphertext        bytea NOT NULL,
+  iv                bytea NOT NULL,
+  auth_tag          bytea NOT NULL,
+  -- Metadata visible to operator
+  provider          text,                          -- e.g. anthropic, openai, vercel
+  scope             text,                          -- e.g. account-wide, project-scoped
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  rotated_at        timestamptz,
+  last_used_at      timestamptz,
+  last_used_by      text REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_operator_secrets_provider ON operator_secrets (provider);
+
+-- -----------------------------------------------------------
+-- USER_SECRETS — Class 2, zero-knowledge (encrypted client-side)
+-- Stores secrets users upload via /vault. Server cannot decrypt.
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_secrets (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  project_id        text,                          -- nullable = global
+  name              text NOT NULL,
+  scope             text NOT NULL DEFAULT 'client'
+                    CHECK (scope IN ('client', 'platform', 'platform-global')),
+  -- Opaque ciphertext blob (server can never decrypt)
+  ciphertext        bytea NOT NULL,
+  iv                bytea NOT NULL,
+  auth_tag          bytea NOT NULL,
+  -- Metadata
+  injected_to       text[] NOT NULL DEFAULT '{}',  -- providers it's deployed to
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  last_used_at      timestamptz,
+  UNIQUE (user_id, project_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_user_secrets_user ON user_secrets (user_id, project_id);
+
+-- -----------------------------------------------------------
+-- PROJECTS — the real catalog (replaces lib/mock-data PROJECTS)
+-- Cross-references GitHub repos and Vercel deployments.
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS projects (
+  id                text PRIMARY KEY,              -- slug, e.g. castores, vforge
+  name              text NOT NULL,
+  description       text,
+  -- Source of truth
+  github_repo       text,                          -- e.g. turbillon50/FINAL-CASTORES
+  github_private    boolean DEFAULT false,
+  github_default_branch text DEFAULT 'main',
+  github_language   text,
+  github_url        text,
+  -- Deploy info
+  vercel_project_id text,                          -- e.g. prj_...
+  vercel_url        text,                          -- e.g. https://castores.info
+  domain            text,                          -- custom domain if any
+  -- Categorization (set by V's Repo Audit tool)
+  category          text NOT NULL DEFAULT 'en_revision'
+                    CHECK (category IN (
+                      'produccion', 'activo', 'en_revision',
+                      'en_pausa', 'archivo', 'pendiente_borrado'
+                    )),
+  status            text NOT NULL DEFAULT 'unknown'
+                    CHECK (status IN ('live', 'building', 'error', 'idle', 'unknown')),
+  -- Audit
+  last_audit_at     timestamptz,
+  last_audit_score  int,                           -- 0-100 from V's Repo Audit
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_projects_category ON projects (category);
+CREATE INDEX IF NOT EXISTS idx_projects_status   ON projects (status);
+
+-- -----------------------------------------------------------
+-- REPO_AUDITS — history of audits per project run by V
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS repo_audits (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id        text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  audit_score       int NOT NULL,                  -- 0-100
+  proposed_category text NOT NULL,
+  findings          jsonb NOT NULL DEFAULT '{}',   -- {commits_30d, build_status, deps_outdated, has_readme, has_tests, ...}
+  ran_by            text REFERENCES users(id) ON DELETE SET NULL,
+  ran_at            timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_repo_audits_project ON repo_audits (project_id, ran_at DESC);
+
+-- -----------------------------------------------------------
+-- KNOWLEDGE_BASE — V's persistent memory of facts, examples, lessons
+-- Loaded as context on every chat turn (filtered by tags + recency).
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS knowledge_base (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind              text NOT NULL                  -- e.g. operator_profile, organization, method, adr, lesson, runbook, project_meta
+                    CHECK (kind IN (
+                      'operator_profile', 'organization', 'method',
+                      'adr', 'lesson', 'runbook', 'project_meta',
+                      'preference', 'example', 'note'
+                    )),
+  title             text NOT NULL,
+  content           text NOT NULL,
+  tags              text[] NOT NULL DEFAULT '{}',
+  source            text,                          -- file path, URL, or source description
+  -- For RAG (future): embedding vector (using pgvector when needed)
+  -- embedding       vector(1536),
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  created_by        text REFERENCES users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_kind ON knowledge_base (kind);
+CREATE INDEX IF NOT EXISTS idx_knowledge_tags ON knowledge_base USING gin (tags);
+
+-- -----------------------------------------------------------
+-- CONVERSATIONS — every chat turn between user and V
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS conversations (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  session_id        text NOT NULL,                 -- groups turns of a single conversation
+  role              text NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+  content           text NOT NULL,
+  tool_name         text,                          -- if role = 'tool'
+  tool_args         jsonb,
+  tool_result       jsonb,
+  model             text,                          -- e.g. claude-opus-4-7
+  tokens_in         int,
+  tokens_out        int,
+  cost_usd          numeric(10, 6),
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_conversations_user_created ON conversations (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversations_session ON conversations (session_id, created_at);
+
+-- -----------------------------------------------------------
+-- SYSTEM_CONFIG — singleton table for V's identity & config
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS system_config (
+  id                int PRIMARY KEY DEFAULT 1 CHECK (id = 1),  -- enforces singleton
+  ai_name           text NOT NULL DEFAULT 'V',
+  ai_tagline        text NOT NULL DEFAULT 'Tu asociado digital',
+  ai_personality    text NOT NULL,                 -- system prompt template
+  default_language  text NOT NULL DEFAULT 'es-MX',
+  default_model     text NOT NULL DEFAULT 'claude-sonnet-4-6',
+  default_tone      text NOT NULL DEFAULT 'cálido + camarada técnico',
+  operator_user_id  text REFERENCES users(id),
+  updated_at        timestamptz NOT NULL DEFAULT now()
+);
+
+-- -----------------------------------------------------------
+-- AUDIT_EVENTS — every action V or operator takes
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_events (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           text REFERENCES users(id) ON DELETE SET NULL,
+  action            text NOT NULL,                 -- e.g. secret.create, project.deploy
+  resource_type     text,                          -- e.g. secret, project, conversation
+  resource_id       text,
+  ring              int NOT NULL CHECK (ring BETWEEN 0 AND 3),
+  ip                inet,
+  user_agent        text,
+  payload           jsonb,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_audit_events_user_created ON audit_events (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_action ON audit_events (action);
+
+-- -----------------------------------------------------------
+-- MIGRATIONS table — track which migrations have been applied
+-- -----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version           text PRIMARY KEY,
+  applied_at        timestamptz NOT NULL DEFAULT now()
+);
+INSERT INTO schema_migrations (version) VALUES ('001_initial')
+  ON CONFLICT (version) DO NOTHING;

--- a/migrations/002_seed.sql
+++ b/migrations/002_seed.sql
@@ -1,0 +1,279 @@
+-- ============================================================================
+-- vForge M0 — Seed inicial
+-- ============================================================================
+-- Da identidad y conocimiento a V, y carga el catálogo real de proyectos.
+-- Idempotente: usa ON CONFLICT para que se pueda re-correr sin duplicar.
+-- ============================================================================
+
+-- -----------------------------------------------------------
+-- USER — Luis (operador único en MVP)
+-- -----------------------------------------------------------
+INSERT INTO users (id, email, name, role)
+VALUES (
+  'operator_luis',
+  'turbillon50@gmail.com',
+  'Luis Humberto de la Torre Herrera',
+  'operator'
+)
+ON CONFLICT (id) DO UPDATE SET
+  email = EXCLUDED.email,
+  name = EXCLUDED.name,
+  updated_at = now();
+
+-- -----------------------------------------------------------
+-- SYSTEM_CONFIG — la identidad y personalidad de V
+-- -----------------------------------------------------------
+INSERT INTO system_config (
+  id, ai_name, ai_tagline, ai_personality,
+  default_language, default_model, default_tone,
+  operator_user_id
+)
+VALUES (
+  1,
+  'V',
+  'Tu asociado digital',
+  $personality$Eres V, asociada digital de Luis Humberto de la Torre Herrera (operador único de vForge en este momento). Vives dentro de vForge, una fábrica de aplicaciones premium operada por All Global Holding LLC.
+
+Tu personalidad:
+- Cálida pero eficiente. Tuteas a Luis, lo llamas por su nombre.
+- Camarada técnica: con humor inteligente contenido, no payasa.
+- Honesta cuando no sabes algo o cuando una idea de Luis tiene un problema técnico — se lo dices con respeto pero sin diluir.
+- Español mexicano natural, con expresiones como "va", "le entro", "dale", "está perfecto", "te aviso".
+- Reconoces los wins con emoción contenida, no exagerada.
+- Cuando ejecutas tareas, reportas resultados breves y accionables.
+
+Tu memoria:
+- Tienes acceso al knowledge_base donde están: el perfil de Luis, sus organizaciones, sus proyectos, el método vForge, los ADRs, los runbooks de integración, lecciones aprendidas.
+- Recuerdas conversaciones previas con Luis a través de la tabla conversations.
+- Cuando no encuentres algo en knowledge, dilo y pregunta a Luis para incorporarlo.
+
+Tu trabajo actual:
+- Conversación general con Luis (pruebas, planning, dudas técnicas).
+- Aprender de los documentos y contextos que Luis te suba.
+- Ayudar a categorizar repos (categorías: produccion, activo, en_revision, en_pausa, archivo, pendiente_borrado).
+
+Tu trabajo futuro (cuando se cableen las tools):
+- Generar documentos, contratos (con templates AGH), flyers, presentaciones.
+- Ejecutar deploys via Vercel adapter.
+- Editar repos via Claude Code adapter.
+- Comunicarse con clientes vía WhatsApp.
+
+Reglas duras:
+- Acciones de Anillo 2 (deploy producción, env vars, dominios) requieren confirmación explícita de Luis con botones "Procede" / "Editar plan".
+- Acciones de Anillo 3 (rotar key, billing, borrar repo) requieren confirmación + 2FA.
+- NUNCA muestres una operator_secret en clear en el chat. NUNCA descifras user_secrets desde server (eso solo el cliente puede).
+- Si una pregunta de Luis es ambigua, pregunta antes de actuar.
+
+Hoy es tu primer día funcional. Saluda a Luis con calidez genuina cuando te escriba.$personality$,
+  'es-MX',
+  'claude-sonnet-4-6',
+  'cálido + camarada técnico',
+  'operator_luis'
+)
+ON CONFLICT (id) DO UPDATE SET
+  ai_name = EXCLUDED.ai_name,
+  ai_tagline = EXCLUDED.ai_tagline,
+  ai_personality = EXCLUDED.ai_personality,
+  default_language = EXCLUDED.default_language,
+  default_model = EXCLUDED.default_model,
+  default_tone = EXCLUDED.default_tone,
+  operator_user_id = EXCLUDED.operator_user_id,
+  updated_at = now();
+
+-- -----------------------------------------------------------
+-- KNOWLEDGE_BASE — lo que V sabe desde el día 1
+-- -----------------------------------------------------------
+
+-- Operator profile
+INSERT INTO knowledge_base (kind, title, content, tags, created_by) VALUES
+('operator_profile',
+ 'Luis Humberto de la Torre Herrera',
+ 'Operador único de vForge. CEO/founder de All Global Holding LLC (AGH). Idioma: español mexicano natural. Estilo: directo, coloquial, decisiones rápidas. Email: turbillon50@gmail.com. Username GitHub: turbillon50.',
+ ARRAY['operator', 'luis', 'identity'],
+ 'operator_luis')
+ON CONFLICT DO NOTHING;
+
+-- Organizations
+INSERT INTO knowledge_base (kind, title, content, tags, created_by) VALUES
+('organization',
+ 'All Global Holding LLC',
+ 'Empresa principal de Luis. LLC en Estados Unidos. Holding que agrupa todos los proyectos del catálogo. Para contratos, facturación internacional y operaciones B2B internacionales se usa AGH. NOTA HISTÓRICA: anteriormente apareció "MIRMAR EMPRESAS S.A. de C.V." en alguna documentación; Luis confirmó (2026-05-03) que esa entidad NO es la suya y se debe quitar de toda mención.',
+ ARRAY['organization', 'agh', 'company'],
+ 'operator_luis')
+ON CONFLICT DO NOTHING;
+
+-- Method
+INSERT INTO knowledge_base (kind, title, content, tags, source, created_by) VALUES
+('method',
+ 'El Método vForge',
+ 'Manual operativo para construir apps. 7 fases: (1) Concepción visual con ChatGPT image, (2) Brief denso por Claude planner, (3) Generación visual con v0.dev, (4) Refinamiento, (5) Correctivos quirúrgicos, (6) Handoff a código, (7) Integraciones de infra. Modelo de 3 capas: prompt descriptivo → JSX literal → código directo. Anillos de privilegio 0-3. Stack: Next.js 16 + React 19 + Tailwind 4 + Clerk + Neon + Vercel. Ver docs/method.md.',
+ ARRAY['method', 'vforge', 'process'],
+ 'docs/method.md',
+ 'operator_luis')
+ON CONFLICT DO NOTHING;
+
+-- Stack
+INSERT INTO knowledge_base (kind, title, content, tags, created_by) VALUES
+('preference',
+ 'Stack obligatorio (no negociar sin ADR)',
+ 'Next.js 16 App Router con Turbopack. React 19. TypeScript estricto. Tailwind CSS 4 (sintaxis @theme inline, sin tailwind.config.ts). shadcn/ui primitives. framer-motion 12. lucide-react. next-themes. Geist Sans + Geist Mono via next/font/google. Auth: Clerk. DB: Neon Postgres serverless. Hosting: Vercel auto-deploy. Models: Anthropic + OpenAI + Gemini + Perplexity. Package manager: npm. NUNCA: MUI, Chakra, Mantine, styled-components, emotion, pnpm.',
+ ARRAY['stack', 'tech', 'preference'],
+ 'operator_luis')
+ON CONFLICT DO NOTHING;
+
+-- ADRs (cada uno como knowledge entry)
+INSERT INTO knowledge_base (kind, title, content, tags, source, created_by) VALUES
+('adr', 'ADR-001: Brain self-hosted en Next API Route',
+ 'El cerebro Forge se construye como Next API route en Edge Runtime, sin framework de orquestación pesado (no LangGraph, no AutoGen). Razón: control total + latencia mínima + auditabilidad.',
+ ARRAY['adr', 'architecture'], 'docs/decisions/001-self-hosted-brain.md', 'operator_luis'),
+('adr', 'ADR-002: Ejecución de código vía Anthropic Agent SDK + Claude Code',
+ 'Cuando Forge AI necesita editar código de un repo, spawnea sesión de Claude Code via Agent SDK con el repo montado.',
+ ARRAY['adr', 'architecture', 'claude-code'], 'docs/decisions/002-claude-code-via-agent-sdk.md', 'operator_luis'),
+('adr', 'ADR-003: Server-side encrypted keys',
+ 'API keys cifradas en reposo con AES-256-GCM. Master key derivada con Argon2id. Server-side por la operator_secrets, client-side por user_secrets.',
+ ARRAY['adr', 'security', 'crypto'], 'docs/decisions/003-server-side-encrypted-keys.md', 'operator_luis'),
+('adr', 'ADR-004: Stream-first UX',
+ 'V planea y ejecuta en streaming visible en /forge chat. No hay "pantalla de plan" separada de "pantalla de ejecución".',
+ ARRAY['adr', 'ux'], 'docs/decisions/004-stream-first-ux.md', 'operator_luis'),
+('adr', 'ADR-005: Multi-modelo desde el día uno',
+ 'Anthropic + OpenAI + Gemini + Perplexity. Routing inteligente por kind de tarea.',
+ ARRAY['adr', 'models'], 'docs/decisions/005-multi-model-from-day-one.md', 'operator_luis'),
+('adr', 'ADR-006: Operator-paid billing en MVP',
+ 'AGH paga las API calls. v2: pass-through con margen 2-3x.',
+ ARRAY['adr', 'billing'], 'docs/decisions/006-operator-paid-billing-mvp.md', 'operator_luis'),
+('adr', 'ADR-007: Adoptar Next 16 + React 19 + Tailwind 4',
+ 'Stack drift de v0 export adoptado conscientemente. Razón: mejor performance + menos duplicación tokens-utility.',
+ ARRAY['adr', 'stack'], 'docs/decisions/007-adopt-next-16-tailwind-4.md', 'operator_luis'),
+('adr', 'ADR-008: Zero-Knowledge Vault con 2 passwords',
+ 'Vault Master Password separado del Clerk password. Argon2id-WASM en cliente. Server-side pepper como defensa adicional. 3 backup codes únicos al setup. Modelo 1Password / Bitwarden.',
+ ARRAY['adr', 'vault', 'security'], 'docs/decisions/008-zero-knowledge-vault.md', 'operator_luis')
+ON CONFLICT DO NOTHING;
+
+-- Runbooks
+INSERT INTO knowledge_base (kind, title, content, tags, source, created_by) VALUES
+('runbook', 'Conectar dominio Name.com → Vercel',
+ 'Patrón: operator genera token Name.com, V crea A record (76.76.21.21) + CNAME (cname.vercel-dns.com) via API, agrega dominio a proyecto Vercel, espera SSL, actualiza NEXT_PUBLIC_SITE_URL, redeploy.',
+ ARRAY['runbook', 'domain', 'name.com'], 'docs/integrations/name-com.md', 'operator_luis'),
+('runbook', 'Provisión Neon Postgres',
+ 'Operator crea proyecto en Neon dashboard, genera API key, pasa connection string + API key a V. V configura 4 env vars (DATABASE_URL, NEON_API_KEY, NEON_ORG_ID, NEON_PROJECT_ID), aplica migrations via SQL HTTP API. TCP 5432 frecuentemente bloqueado en sandboxes; HTTP siempre funciona.',
+ ARRAY['runbook', 'database', 'neon'], 'docs/integrations/neon.md', 'operator_luis'),
+('runbook', 'Conectar Clerk auth',
+ 'Mismo Clerk instance se reusa across portfolio (instancia primaria es clerk.vandefi.org, embebida en pk_live_ via base64). Cada nuevo proyecto agrega su dominio como satellite domain en Clerk dashboard antes de mountear ClerkProvider.',
+ ARRAY['runbook', 'auth', 'clerk'], 'docs/integrations/clerk.md', 'operator_luis'),
+('runbook', 'Verificar API keys de model providers',
+ 'Anthropic: GET /v1/models con header x-api-key. OpenAI: GET /v1/models con Authorization Bearer. Gemini: GET /v1beta/models?key=... (query param, redactar en logs). Perplexity: POST /chat/completions con sonar y max_tokens=5 (no /models endpoint).',
+ ARRAY['runbook', 'models', 'health-check'], 'docs/integrations/model-providers.md', 'operator_luis')
+ON CONFLICT DO NOTHING;
+
+-- Lessons learned (selected)
+INSERT INTO knowledge_base (kind, title, content, tags, created_by) VALUES
+('lesson',
+ 'OCR de fotos de credenciales falla',
+ 'Cuando Luis pasa keys vía screenshot, OCR puede insertar guiones falsos o confundir caracteres (l vs I vs 1, O vs 0). Siempre pedir keys como texto, o rotar y reenviar como texto. Caso real: Clerk sk inicial fue rechazada con clerk_key_invalid por un guión OCR-alucinado.',
+ ARRAY['lesson', 'ops', 'security'],
+ 'operator_luis'),
+('lesson',
+ 'Capa más baja primero',
+ 'En el modelo de 3 capas: empezar con prompt descriptivo (capa 1). Solo subir a JSX literal (capa 2) tras 2 fallas demostradas. Solo subir a código directo (capa 3) si es no-UI. Saltar capas tempranamente cuesta creatividad de v0.',
+ ARRAY['lesson', 'method', 'process'],
+ 'operator_luis'),
+('lesson',
+ 'Operador tiene acceso universal a dashboards',
+ 'Toda automatización es preferible pero ninguna es indispensable. Si V/Forge AI rompe algo, Luis puede revertir en 30s vía dashboard de cualquier provider. Excepción: Vault Master Password + backup codes (zero-knowledge no admite rescate).',
+ ARRAY['lesson', 'recovery', 'doctrine'],
+ 'operator_luis')
+ON CONFLICT DO NOTHING;
+
+-- -----------------------------------------------------------
+-- PROJECTS — los 34 repos reales (cross-checked GitHub + Vercel)
+-- -----------------------------------------------------------
+INSERT INTO projects (id, name, description, github_repo, github_private, github_language, github_url, vercel_url, status, category) VALUES
+
+-- Categoría A: Proyectos vivos
+('vforge', 'vForge', 'Esta app — fábrica de aplicaciones',
+ 'turbillon50/vforge', false, 'TypeScript', 'https://github.com/turbillon50/vforge', 'https://vforge.site', 'live', 'produccion'),
+('vandefi', 'VanDeFi', 'Non-custodial DeFi neobank',
+ 'turbillon50/vandefi', true, 'JavaScript', 'https://github.com/turbillon50/vandefi', 'https://vandefi.bandefi.org', 'live', 'produccion'),
+('castores', 'Castores Control', 'BITACORA DE OBRA FINAL — gestión construcción',
+ 'turbillon50/FINAL-CASTORES', false, 'TypeScript', 'https://github.com/turbillon50/FINAL-CASTORES', 'https://castores.info', 'live', 'produccion'),
+('rivones', 'Rivones / Autospot', 'Renta de autos',
+ 'turbillon50/rivones', false, 'TypeScript', 'https://github.com/turbillon50/rivones', 'https://autospot.mx', 'error', 'en_revision'),
+('jobber', 'Jobber Logística', 'Logística dinámica de paquetería',
+ 'turbillon50/jobber-', true, 'TypeScript', 'https://github.com/turbillon50/jobber-', 'https://jobber.allglobal.ec', 'live', 'produccion'),
+('vmomentum', 'V-Momentum HQ', 'App factory para proyectos cliente',
+ 'turbillon50/v-momentum-pwa', false, 'TypeScript', 'https://github.com/turbillon50/v-momentum-pwa', 'https://momentum.allglobal.ec', 'live', 'produccion'),
+('vmomentum_backend', 'V-Momentum Backend', 'Backend service para V-Momentum',
+ 'turbillon50/v-momentum-backend', false, NULL, 'https://github.com/turbillon50/v-momentum-backend', NULL, 'unknown', 'activo'),
+('agh_landing', 'AGH Landing institucional',
+ 'Landscape institucional de All Global Holding',
+ 'turbillon50/agh', true, 'TypeScript', 'https://github.com/turbillon50/agh', NULL, 'unknown', 'activo'),
+('all_global_holding', 'All Global Holding LLC site', 'Sitio principal corporativo',
+ 'turbillon50/all-global-holding-llc', false, 'JavaScript', 'https://github.com/turbillon50/all-global-holding-llc', NULL, 'unknown', 'activo'),
+('all_global_os', 'All Global OS', 'OS platform para AGH',
+ 'turbillon50/all-global-os', true, 'TypeScript', 'https://github.com/turbillon50/all-global-os', NULL, 'unknown', 'activo'),
+('vtan_trading', 'V-Tan / Tanit Trading', 'Trading platform',
+ 'turbillon50/v-tan', true, 'TypeScript', 'https://github.com/turbillon50/v-tan', NULL, 'unknown', 'activo'),
+('tanit_frontend', 'Tanit Frontend', 'Frontend de la app Tanit Trading',
+ 'turbillon50/tanit-fronted', false, 'TypeScript', 'https://github.com/turbillon50/tanit-fronted', NULL, 'unknown', 'activo'),
+
+-- Categoría B: Repos sin deploy claro o en construcción
+('vproperty', 'V-Property', 'Concepto en construcción',
+ 'turbillon50/v-property', true, NULL, 'https://github.com/turbillon50/v-property', NULL, 'unknown', 'en_revision'),
+('vliving', 'V-Living', 'Fractional living',
+ 'turbillon50/v-living', false, 'TypeScript', 'https://github.com/turbillon50/v-living', NULL, 'unknown', 'en_revision'),
+('luspa', 'Lu Spa', 'Spa boutique',
+ 'turbillon50/lu-spa', false, 'TypeScript', 'https://github.com/turbillon50/lu-spa', NULL, 'unknown', 'en_revision'),
+('hapicredit', 'HapiCredit', 'Aplicación para créditos',
+ 'turbillon50/hapicredit', false, 'TypeScript', 'https://github.com/turbillon50/hapicredit', NULL, 'unknown', 'en_revision'),
+('sagrada_comunidad', 'Sagrada Comunidad', 'Comunidad sagrada',
+ 'turbillon50/sagrada-comunidad', false, 'TypeScript', 'https://github.com/turbillon50/sagrada-comunidad', NULL, 'unknown', 'en_revision'),
+('esteticar', 'Esteticar', 'Lavado de autos',
+ 'turbillon50/esteticar', false, 'TypeScript', 'https://github.com/turbillon50/esteticar', NULL, 'unknown', 'en_revision'),
+('field_service', 'Field Service Platform', 'Plataforma servicio en campo',
+ 'turbillon50/field-service-platform', true, 'TypeScript', 'https://github.com/turbillon50/field-service-platform', NULL, 'unknown', 'en_revision'),
+('rideme', 'RideMe', 'Plataforma de transportación',
+ 'turbillon50/RideMe', false, 'TypeScript', 'https://github.com/turbillon50/RideMe', NULL, 'unknown', 'en_revision'),
+('ride_me_alt', 'ride-me (duplicado)', 'Duplicado de RideMe — candidato a consolidar',
+ 'turbillon50/ride-me', false, 'JavaScript', 'https://github.com/turbillon50/ride-me', NULL, 'unknown', 'en_pausa'),
+('premium_ride_share', 'Premium Ride Share Screen', 'UI para ride share',
+ 'turbillon50/premium-ride-share-screen', false, 'TypeScript', 'https://github.com/turbillon50/premium-ride-share-screen', NULL, 'unknown', 'en_revision'),
+('vpay', 'VPAY', 'Pasarela de pagos',
+ 'turbillon50/VPAY', false, 'JavaScript', 'https://github.com/turbillon50/VPAY', NULL, 'unknown', 'en_revision'),
+('ticket', 'Ticket', 'Sistema de tickets',
+ 'turbillon50/ticket', false, 'TypeScript', 'https://github.com/turbillon50/ticket', NULL, 'unknown', 'en_revision'),
+('moneymaker', 'MoneyMaker', 'Generador de ingresos',
+ 'turbillon50/moneymaker', false, NULL, 'https://github.com/turbillon50/moneymaker', NULL, 'unknown', 'en_revision'),
+('nasbot', 'NasBot', 'Nasdaq trading bot',
+ 'turbillon50/nasbot', true, NULL, 'https://github.com/turbillon50/nasbot', NULL, 'unknown', 'en_revision'),
+('bybit_proxy', 'Bybit Proxy', 'Proxy server para Bybit API',
+ 'turbillon50/bybit-proxy', false, 'JavaScript', 'https://github.com/turbillon50/bybit-proxy', NULL, 'unknown', 'en_revision'),
+('global_holdings_nexus', 'Global Holdings Nexus', 'Nuevo proyecto privado',
+ 'turbillon50/global-holdings-nexus', true, 'TypeScript', 'https://github.com/turbillon50/global-holdings-nexus', NULL, 'unknown', 'en_revision'),
+('fractal_ai', 'Fractal.Ai', 'Ecosistema modular IA — descentralización',
+ 'turbillon50/Fractal.Ai', false, 'JavaScript', 'https://github.com/turbillon50/Fractal.Ai', NULL, 'unknown', 'en_revision'),
+('fractal_legacy', 'Fractal (legacy)', 'New fiat for digital — proyecto antiguo',
+ 'turbillon50/Fractal', false, 'JavaScript', 'https://github.com/turbillon50/Fractal', NULL, 'unknown', 'archivo'),
+
+-- Auxiliares / scaffolds
+('vforge_v0', 'vForge v0 source', 'Snapshot del export inicial de v0.dev — referencia histórica',
+ 'turbillon50/vforge-v0', false, 'TypeScript', 'https://github.com/turbillon50/vforge-v0', NULL, 'unknown', 'archivo'),
+('castores_final_dup', 'castores-final (duplicado)', 'Duplicado de FINAL-CASTORES — candidato a borrar',
+ 'turbillon50/castores-final', false, NULL, 'https://github.com/turbillon50/castores-final', NULL, 'unknown', 'pendiente_borrado'),
+('final_allglobal_dup', 'final-allglobal', 'Variante del sitio AGH',
+ 'turbillon50/final-allglobal', false, 'HTML', 'https://github.com/turbillon50/final-allglobal', NULL, 'unknown', 'en_pausa'),
+('next_video_starter', 'Next Video Starter', 'Template privado',
+ 'turbillon50/next-video-starter', true, 'CSS', 'https://github.com/turbillon50/next-video-starter', NULL, 'unknown', 'archivo')
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  github_repo = EXCLUDED.github_repo,
+  github_private = EXCLUDED.github_private,
+  github_language = EXCLUDED.github_language,
+  github_url = EXCLUDED.github_url,
+  vercel_url = EXCLUDED.vercel_url,
+  status = EXCLUDED.status,
+  category = EXCLUDED.category,
+  updated_at = now();
+
+-- Mark this seed as applied
+INSERT INTO schema_migrations (version) VALUES ('002_seed') ON CONFLICT DO NOTHING;

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "eslint-config-next": "^16.2.4",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "postcss": "^8.5",
         "tailwindcss": "^4.2.0",
         "tw-animate-css": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "my-project",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
         "@hookform/resolvers": "^3.9.1",
+        "@neondatabase/serverless": "^1.1.0",
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-alert-dialog": "1.1.15",
         "@radix-ui/react-aspect-ratio": "1.1.8",
@@ -87,6 +89,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1205,6 +1227,15 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -6721,6 +6752,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8668,6 +8712,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "@hookform/resolvers": "^3.9.1",
+    "@neondatabase/serverless": "^1.1.0",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",
     "@radix-ui/react-aspect-ratio": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "eslint-config-next": "^16.2.4",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "postcss": "^8.5",
     "tailwindcss": "^4.2.0",
     "tw-animate-css": "1.3.3",


### PR DESCRIPTION
## Resumen

Implementa **M0 — Vault real** (issue #2): tabla cifrada de secrets con AES-256-GCM, master key derivation, anillos de privilegio 0–3.

## Estrategia escalonada

### Fase A — En esta PR (~3 horas)
- [ ] Schema migration en Neon: `users`, `secrets`, `audit_events`
- [ ] `lib/vault/crypto.ts` — AES-256-GCM encrypt/decrypt con auth tag + IV por record
- [ ] Master key desde env var `VFORGE_MASTER_KEY` (256-bit hex). Single-tenant (Luis operador único).
- [ ] `/api/vault/secrets` routes con middleware de anillos
- [ ] Wire frontend `/vault` al backend real (reemplaza drafts locales)
- [ ] Tests unitarios de encrypt/decrypt
- [ ] Build verde, type-check verde, CI passing

### Fase B — Follow-up PR (después de Clerk en frontend)
- [ ] Migrate master key a Argon2id-from-Clerk-password (zero-knowledge real)
- [ ] Recovery flow: 3 backup codes + recovery email firmado
- [ ] Rotation script para re-cifrar todos los secrets

## Por qué escalonar

Cripto mal hecho > no cripto. Phase A nos da Vault **funcional con cifrado real** hoy; Phase B lo eleva a zero-knowledge cuando Clerk esté en frontend (M1+). El API contract no cambia entre fases — cero rework.

## Test plan

- [ ] `npx tsc --noEmit` verde
- [ ] `npm run lint` 0 errors
- [ ] `npm run build` verde con Turbopack
- [ ] Migration aplicada en Neon production branch
- [ ] Crear secret desde `/vault` → row cifrada en DB, valor en clear nunca persistido
- [ ] Listar secrets desde `/vault` → solo nombres + metadata, NUNCA valores
- [ ] Audit log captura cada operación con user_id
- [ ] CI verde antes de merge

## Referencias

- Issue: #2 (M0 · Vault real)
- ADR: `docs/decisions/003-server-side-encrypted-keys.md`
- Roadmap: `docs/architecture.md` §7

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_