### PR TITLE
fix(v): persistencia + scopes + Send button + transcripción audio

### DIFF
--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -67,10 +67,10 @@ export default function ForgePage() {
   useEffect(() => {
     if (typeof window === "undefined" || !scope) return;
     localStorage.setItem(SCOPE_STORAGE_KEY, scope);
-    let sid = sessionStorage.getItem(sessionKeyFor(scope));
+    let sid = localStorage.getItem(sessionKeyFor(scope));
     if (!sid) {
       sid = makeSessionId();
-      sessionStorage.setItem(sessionKeyFor(scope), sid);
+      localStorage.setItem(sessionKeyFor(scope), sid);
     }
     sessionIdRef.current = sid;
 
@@ -115,7 +115,7 @@ export default function ForgePage() {
 
   function newSession() {
     const sid = makeSessionId();
-    sessionStorage.setItem(sessionKeyFor(scope), sid);
+    localStorage.setItem(sessionKeyFor(scope), sid);
     sessionIdRef.current = sid;
     setMessages([welcomeFor(scope)]);
   }

--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -5,17 +5,30 @@ import { ChatStream } from "@/components/vforge/chat-stream";
 import { Composer } from "@/components/vforge/composer";
 import type { ChatMessageData } from "@/components/vforge/chat-message";
 
-const SESSION_STORAGE_KEY = "vforge_session_id";
+const SCOPE_STORAGE_KEY = "vforge_chat_scope"; // 'general' | projectId
+const SESSION_PREFIX = "vforge_session_id_";
 
-const WELCOME: ChatMessageData = {
+const WELCOME_GENERAL: ChatMessageData = {
   id: "welcome",
   role: "forge",
   content:
-    "Hola Luis. Soy V — tu asociada digital. Tengo memoria persistente, conozco tu portafolio (34 repos), el método vForge, y los ADRs. Pregúntame lo que sea o dale start con cualquier idea.",
+    "Hola Luis. Soy V — tu asociada digital. Estamos en modo general: tengo memoria persistente, conozco los 34 proyectos, el método vForge y los ADRs. Si quieres enfocar la conversación en un proyecto específico, escógelo del selector arriba. Si no, pregúntame lo que sea.",
 };
+
+function welcomeForProject(name: string): ChatMessageData {
+  return {
+    id: "welcome",
+    role: "forge",
+    content: `Conversación enfocada en **${name}**. Cualquier pregunta que hagas la voy a interpretar respecto a este proyecto a menos que cambies de tema explícitamente. ¿Qué quieres revisar de ${name}?`,
+  };
+}
 
 function makeSessionId() {
   return `s_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sessionKeyFor(scope: string) {
+  return SESSION_PREFIX + scope;
 }
 
 interface PersistedTurn {
@@ -25,25 +38,45 @@ interface PersistedTurn {
   created_at: string;
 }
 
+interface ProjectOption {
+  id: string;
+  name: string;
+  category: string;
+}
+
 export default function ForgePage() {
-  const [messages, setMessages] = useState<ChatMessageData[]>([WELCOME]);
+  const [scope, setScope] = useState<string>("general");
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  const [messages, setMessages] = useState<ChatMessageData[]>([WELCOME_GENERAL]);
   const [streaming, setStreaming] = useState(false);
   const [hydrating, setHydrating] = useState(true);
   const sessionIdRef = useRef<string>("");
 
-  // Resolve session id from sessionStorage (per-tab persistence) + hydrate
-  // history of conversations from the DB on mount.
+  // Load scope from storage and project list on first mount.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    let sid = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    const saved = localStorage.getItem(SCOPE_STORAGE_KEY) ?? "general";
+    setScope(saved);
+    void fetch("/api/projects", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : { projects: [] }))
+      .then((d: { projects: ProjectOption[] }) => setProjects(d.projects))
+      .catch(() => undefined);
+  }, []);
+
+  // Whenever scope changes, resolve its session id and rehydrate history.
+  useEffect(() => {
+    if (typeof window === "undefined" || !scope) return;
+    localStorage.setItem(SCOPE_STORAGE_KEY, scope);
+    let sid = sessionStorage.getItem(sessionKeyFor(scope));
     if (!sid) {
       sid = makeSessionId();
-      sessionStorage.setItem(SESSION_STORAGE_KEY, sid);
+      sessionStorage.setItem(sessionKeyFor(scope), sid);
     }
     sessionIdRef.current = sid;
 
+    setHydrating(true);
     void hydrate(sid);
-  }, []);
+  }, [scope]);
 
   async function hydrate(sessionId: string) {
     try {
@@ -52,30 +85,39 @@ export default function ForgePage() {
         { cache: "no-store" },
       );
       if (!res.ok) {
-        setHydrating(false);
+        setMessages([welcomeFor(scope)]);
         return;
       }
       const { turns } = (await res.json()) as { turns: PersistedTurn[] };
       if (turns.length > 0) {
-        const restored: ChatMessageData[] = turns.map((t) => ({
-          id: t.id,
-          role: t.role === "assistant" ? "forge" : "user",
-          content: t.content,
-        }));
-        setMessages(restored);
+        setMessages(
+          turns.map((t) => ({
+            id: t.id,
+            role: t.role === "assistant" ? "forge" : "user",
+            content: t.content,
+          })),
+        );
+      } else {
+        setMessages([welcomeFor(scope)]);
       }
     } catch {
-      // Network or parse error — silently keep the welcome stub.
+      setMessages([welcomeFor(scope)]);
     } finally {
       setHydrating(false);
     }
   }
 
+  function welcomeFor(s: string): ChatMessageData {
+    if (s === "general") return WELCOME_GENERAL;
+    const p = projects.find((x) => x.id === s);
+    return welcomeForProject(p?.name ?? s);
+  }
+
   function newSession() {
     const sid = makeSessionId();
-    sessionStorage.setItem(SESSION_STORAGE_KEY, sid);
+    sessionStorage.setItem(sessionKeyFor(scope), sid);
     sessionIdRef.current = sid;
-    setMessages([WELCOME]);
+    setMessages([welcomeFor(scope)]);
   }
 
   const handleSend = async (
@@ -119,6 +161,7 @@ export default function ForgePage() {
         body: JSON.stringify({
           messages: history,
           sessionId: sessionIdRef.current,
+          projectId: scope === "general" ? null : scope,
         }),
       });
       if (!res.ok || !res.body) {
@@ -183,26 +226,56 @@ export default function ForgePage() {
     void handleSend(action.toLowerCase());
   };
 
+  const projectsByCategory = projects.reduce<Record<string, ProjectOption[]>>(
+    (acc, p) => {
+      (acc[p.category] ||= []).push(p);
+      return acc;
+    },
+    {},
+  );
+
   return (
     <div className="flex flex-col h-full -mx-4 md:-mx-6 -mt-6 -mb-6">
-      <header className="sticky top-0 z-10 bg-vf-bg border-b border-vf-border px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <h1 className="text-lg font-semibold tracking-tight-vf text-vf-fg">
+      <header className="sticky top-0 z-10 bg-vf-bg border-b border-vf-border px-4 py-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <h1 className="text-lg font-semibold tracking-tight-vf text-vf-fg flex-shrink-0">
             V
           </h1>
-          <span
-            className="text-xs font-mono text-vf-fg-2 hidden sm:inline-block"
-            title={sessionIdRef.current}
+          <select
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            disabled={streaming}
+            className="bg-vf-bg-2 border border-vf-border-1 rounded-md px-2 py-1.5 text-sm text-vf-fg focus:outline-none focus:border-vf-border-2 max-w-[180px] truncate"
+            title="Modo de conversación"
           >
-            sesión {sessionIdRef.current.slice(2, 10)}
-          </span>
+            <option value="general">🌐 General</option>
+            {(["produccion", "activo", "en_revision", "en_pausa", "archivo"] as const).map((cat) => {
+              const items = projectsByCategory[cat] ?? [];
+              if (items.length === 0) return null;
+              return (
+                <optgroup
+                  key={cat}
+                  label={
+                    cat === "produccion" ? "🟢 Producción" :
+                    cat === "activo" ? "🔵 Activo" :
+                    cat === "en_revision" ? "🟡 En revisión" :
+                    cat === "en_pausa" ? "⏸️ En pausa" : "📦 Archivo"
+                  }
+                >
+                  {items.map((p) => (
+                    <option key={p.id} value={p.id}>{p.name}</option>
+                  ))}
+                </optgroup>
+              );
+            })}
+          </select>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-shrink-0">
           <button
             type="button"
             onClick={newSession}
             className="text-xs text-vf-fg-2 hover:text-vf-fg transition-colors"
-            title="Empezar una conversación nueva (limpia memoria de sesión)"
+            title="Empezar una conversación nueva en este modo"
           >
             Nueva
           </button>
@@ -211,11 +284,7 @@ export default function ForgePage() {
               className={`w-2 h-2 rounded-full bg-vf-green ${streaming ? "" : "dot-live"}`}
             />
             <span className="text-sm text-vf-fg-1">
-              {hydrating
-                ? "Cargando…"
-                : streaming
-                  ? "Pensando…"
-                  : "Listo"}
+              {hydrating ? "Cargando…" : streaming ? "Pensando…" : "Listo"}
             </span>
           </div>
         </div>

--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -5,31 +5,78 @@ import { ChatStream } from "@/components/vforge/chat-stream";
 import { Composer } from "@/components/vforge/composer";
 import type { ChatMessageData } from "@/components/vforge/chat-message";
 
+const SESSION_STORAGE_KEY = "vforge_session_id";
+
+const WELCOME: ChatMessageData = {
+  id: "welcome",
+  role: "forge",
+  content:
+    "Hola Luis. Soy V — tu asociada digital. Tengo memoria persistente, conozco tu portafolio (34 repos), el método vForge, y los ADRs. Pregúntame lo que sea o dale start con cualquier idea.",
+};
+
 function makeSessionId() {
   return `s_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-export default function ForgePage() {
-  const [messages, setMessages] = useState<ChatMessageData[]>([
-    {
-      id: "welcome",
-      role: "forge",
-      content: "Hola Luis. Soy V — tu asociada digital. Tengo memoria persistente, conozco tu portafolio (34 repos), el método vForge, y los ADRs. Pregúntame lo que sea o dale start con cualquier idea.",
-    },
-  ]);
-  const [streaming, setStreaming] = useState(false);
-  const sessionIdRef = useRef<string>(makeSessionId());
+interface PersistedTurn {
+  id: string;
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+  created_at: string;
+}
 
-  // Re-issue session id on first mount of the session (per browser tab)
+export default function ForgePage() {
+  const [messages, setMessages] = useState<ChatMessageData[]>([WELCOME]);
+  const [streaming, setStreaming] = useState(false);
+  const [hydrating, setHydrating] = useState(true);
+  const sessionIdRef = useRef<string>("");
+
+  // Resolve session id from sessionStorage (per-tab persistence) + hydrate
+  // history of conversations from the DB on mount.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const existing = sessionStorage.getItem("vforge_session_id");
-    if (existing) {
-      sessionIdRef.current = existing;
-    } else {
-      sessionStorage.setItem("vforge_session_id", sessionIdRef.current);
+    let sid = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (!sid) {
+      sid = makeSessionId();
+      sessionStorage.setItem(SESSION_STORAGE_KEY, sid);
     }
+    sessionIdRef.current = sid;
+
+    void hydrate(sid);
   }, []);
+
+  async function hydrate(sessionId: string) {
+    try {
+      const res = await fetch(
+        `/api/forge/conversations?sessionId=${encodeURIComponent(sessionId)}&limit=100`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) {
+        setHydrating(false);
+        return;
+      }
+      const { turns } = (await res.json()) as { turns: PersistedTurn[] };
+      if (turns.length > 0) {
+        const restored: ChatMessageData[] = turns.map((t) => ({
+          id: t.id,
+          role: t.role === "assistant" ? "forge" : "user",
+          content: t.content,
+        }));
+        setMessages(restored);
+      }
+    } catch {
+      // Network or parse error — silently keep the welcome stub.
+    } finally {
+      setHydrating(false);
+    }
+  }
+
+  function newSession() {
+    const sid = makeSessionId();
+    sessionStorage.setItem(SESSION_STORAGE_KEY, sid);
+    sessionIdRef.current = sid;
+    setMessages([WELCOME]);
+  }
 
   const handleSend = async (
     content: string,
@@ -139,22 +186,44 @@ export default function ForgePage() {
   return (
     <div className="flex flex-col h-full -mx-4 md:-mx-6 -mt-6 -mb-6">
       <header className="sticky top-0 z-10 bg-vf-bg border-b border-vf-border px-4 py-3 flex items-center justify-between">
-        <h1 className="text-lg font-semibold tracking-tight-vf text-vf-fg">
-          V
-        </h1>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
+          <h1 className="text-lg font-semibold tracking-tight-vf text-vf-fg">
+            V
+          </h1>
           <span
-            className={`w-2 h-2 rounded-full bg-vf-green ${streaming ? "" : "dot-live"}`}
-          />
-          <span className="text-sm text-vf-fg-1">
-            {streaming ? "Pensando…" : "Listo"}
+            className="text-xs font-mono text-vf-fg-2 hidden sm:inline-block"
+            title={sessionIdRef.current}
+          >
+            sesión {sessionIdRef.current.slice(2, 10)}
           </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={newSession}
+            className="text-xs text-vf-fg-2 hover:text-vf-fg transition-colors"
+            title="Empezar una conversación nueva (limpia memoria de sesión)"
+          >
+            Nueva
+          </button>
+          <div className="flex items-center gap-2">
+            <span
+              className={`w-2 h-2 rounded-full bg-vf-green ${streaming ? "" : "dot-live"}`}
+            />
+            <span className="text-sm text-vf-fg-1">
+              {hydrating
+                ? "Cargando…"
+                : streaming
+                  ? "Pensando…"
+                  : "Listo"}
+            </span>
+          </div>
         </div>
       </header>
 
       <ChatStream messages={messages} onAction={handleAction} />
 
-      <Composer onSend={handleSend} disabled={streaming} />
+      <Composer onSend={handleSend} disabled={streaming || hydrating} />
     </div>
   );
 }

--- a/app/api/forge/conversations/route.ts
+++ b/app/api/forge/conversations/route.ts
@@ -1,0 +1,55 @@
+import { queryAll } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Turn {
+  id: string;
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+  created_at: string;
+  tokens_in: number | null;
+  tokens_out: number | null;
+}
+
+const OPERATOR_USER_ID = "operator_luis";
+
+/**
+ * GET /api/forge/conversations?sessionId=...&limit=50
+ *
+ * Returns the most-recent N turns of a conversation session, in
+ * chronological order, so the /forge UI can rehydrate the chat after
+ * a reload, navigation away, or new device.
+ */
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const sessionId = searchParams.get("sessionId");
+  const userId = searchParams.get("userId") ?? OPERATOR_USER_ID;
+  const limitParam = searchParams.get("limit") ?? "100";
+  const limit = Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 200);
+
+  if (!sessionId) {
+    return jsonError("sessionId required", 400);
+  }
+
+  const rows = await queryAll<Turn>(
+    `SELECT id::text, role, content, created_at, tokens_in, tokens_out
+       FROM conversations
+       WHERE user_id = $1 AND session_id = $2
+       ORDER BY created_at ASC
+       LIMIT $3`,
+    [userId, sessionId, limit],
+  );
+
+  return new Response(JSON.stringify({ turns: rows }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/api/forge/conversations/route.ts
+++ b/app/api/forge/conversations/route.ts
@@ -32,12 +32,19 @@ export async function GET(req: Request) {
     return jsonError("sessionId required", 400);
   }
 
+  // Take the most recent N turns (DESC + LIMIT in subquery), then re-sort
+  // ascending for chronological replay. ASC + LIMIT would return the
+  // earliest turns, dropping recent context once a session exceeds the cap.
   const rows = await queryAll<Turn>(
     `SELECT id::text, role, content, created_at, tokens_in, tokens_out
-       FROM conversations
-       WHERE user_id = $1 AND session_id = $2
-       ORDER BY created_at ASC
-       LIMIT $3`,
+       FROM (
+         SELECT id, role, content, created_at, tokens_in, tokens_out
+           FROM conversations
+           WHERE user_id = $1 AND session_id = $2
+           ORDER BY created_at DESC
+           LIMIT $3
+       ) AS recent
+       ORDER BY created_at ASC`,
     [userId, sessionId, limit],
   );
 

--- a/app/api/forge/run/route.ts
+++ b/app/api/forge/run/route.ts
@@ -14,6 +14,7 @@ interface RunRequest {
   messages: ChatTurn[];
   sessionId: string;
   userId?: string; // defaults to operator_luis until Clerk lands
+  projectId?: string | null; // optional project focus
 }
 
 const OPERATOR_USER_ID = "operator_luis";
@@ -41,7 +42,9 @@ export async function POST(req: Request) {
     return jsonError("ANTHROPIC_API_KEY not configured", 500);
   }
 
-  const { systemPrompt, config } = await buildSystemPrompt();
+  const { systemPrompt, config } = await buildSystemPrompt({
+    projectId: body.projectId ?? null,
+  });
   const lastUserTurn = messages[messages.length - 1];
 
   // Persist the user turn first

--- a/app/api/forge/transcribe/route.ts
+++ b/app/api/forge/transcribe/route.ts
@@ -1,0 +1,105 @@
+import OpenAI from "openai";
+import { sql } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const OPERATOR_USER_ID = "operator_luis";
+const MAX_BYTES = 25 * 1024 * 1024; // 25 MB — OpenAI limit
+
+/**
+ * POST /api/forge/transcribe
+ * Body: multipart/form-data with field "audio" (Blob) and optional
+ *       "language" (BCP-47 tag, default "es").
+ *
+ * Returns { text } with the Whisper transcription. Costs ~$0.006/min.
+ *
+ * Audio is ephemeral: never persisted to disk or DB. We only log the
+ * resulting text length and duration in audit_events.
+ */
+export async function POST(req: Request) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return jsonError("OPENAI_API_KEY not configured", 500);
+  }
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return jsonError("Body must be multipart/form-data", 400);
+  }
+
+  const audio = form.get("audio");
+  const language = (form.get("language") as string | null) ?? "es";
+
+  if (!(audio instanceof Blob)) {
+    return jsonError("'audio' field is required and must be a Blob", 400);
+  }
+  if (audio.size === 0) {
+    return jsonError("audio is empty", 400);
+  }
+  if (audio.size > MAX_BYTES) {
+    return jsonError(
+      `audio too large (${(audio.size / 1024 / 1024).toFixed(1)} MB). Max ${MAX_BYTES / 1024 / 1024} MB.`,
+      413,
+    );
+  }
+
+  const openai = new OpenAI({ apiKey });
+
+  // Determine filename from MIME type so OpenAI's multipart upload
+  // names the part with a recognizable extension.
+  const mime = audio.type || "audio/webm";
+  const ext = mimeToExt(mime);
+  const file = new File([audio], `voice.${ext}`, { type: mime });
+
+  try {
+    const transcript = await openai.audio.transcriptions.create({
+      file,
+      model: "whisper-1",
+      language,
+      response_format: "json",
+    });
+
+    const text = transcript.text?.trim() ?? "";
+
+    // Audit event (no audio bytes saved — just metadata)
+    await sql`
+      INSERT INTO audit_events (user_id, action, resource_type, ring, payload)
+      VALUES (
+        ${OPERATOR_USER_ID}, 'forge.transcribe', 'audio', 0,
+        ${JSON.stringify({
+          bytes: audio.size,
+          mime,
+          language,
+          text_chars: text.length,
+        })}::jsonb
+      )
+    `;
+
+    return new Response(JSON.stringify({ text }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonError(`Whisper error: ${message}`, 502);
+  }
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mimeToExt(mime: string): string {
+  if (mime.includes("webm")) return "webm";
+  if (mime.includes("mp4") || mime.includes("m4a")) return "m4a";
+  if (mime.includes("mpeg")) return "mp3";
+  if (mime.includes("wav")) return "wav";
+  if (mime.includes("ogg")) return "ogg";
+  return "webm";
+}

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,41 @@
+import { queryAll } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  category: string;
+  status: string;
+  github_repo: string | null;
+  vercel_url: string | null;
+}
+
+/**
+ * GET /api/projects
+ *
+ * Returns the live catalog from the projects table for UI selectors
+ * and dashboards. Replaces the static lib/mock-data.ts PROJECTS.
+ */
+export async function GET() {
+  const rows = await queryAll<ProjectRow>(
+    `SELECT id, name, category, status, github_repo, vercel_url
+       FROM projects
+       ORDER BY
+         CASE category
+           WHEN 'produccion' THEN 1
+           WHEN 'activo' THEN 2
+           WHEN 'en_revision' THEN 3
+           WHEN 'en_pausa' THEN 4
+           WHEN 'archivo' THEN 5
+           WHEN 'pendiente_borrado' THEN 6
+           ELSE 99
+         END,
+         name`,
+  );
+  return new Response(JSON.stringify({ projects: rows }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/components/vforge/composer.tsx
+++ b/components/vforge/composer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Paperclip, Camera, Mic, X } from "lucide-react";
+import { Paperclip, Camera, Mic, X, Send } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   CameraCapture,
@@ -119,7 +119,11 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    // Cmd/Ctrl + Enter always submits (works on both desktop and mobile
+    // hardware keyboards). Plain Enter inserts a newline so users can
+    // multi-line freely on mobile virtual keyboards. The explicit Send
+    // button is the canonical submit affordance.
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       handleSubmit();
     }
@@ -218,9 +222,10 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Dile a Forge qué hacer…"
+            placeholder="Dile a V qué hacer…  ·  ⌘/Ctrl + Enter para enviar"
             disabled={disabled}
             rows={1}
+            enterKeyHint="enter"
             className={cn(
               "w-full bg-vf-bg-2 border border-vf-border-1 rounded-md",
               "px-4 py-3 text-sm text-vf-fg placeholder:text-vf-fg-2",
@@ -231,20 +236,40 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
           />
         </div>
 
-        {/* Mic button */}
-        <button
-          type="button"
-          onClick={() => setShowVoice(true)}
-          className={cn(
-            "w-10 h-10 flex-shrink-0 flex items-center justify-center rounded-full",
-            "bg-vf-green text-black",
-            "hover:bg-vf-green/90 transition-colors duration-150",
-            "voice-button green-glow-sm",
-          )}
-          aria-label="Grabar voz"
-        >
-          <Mic className="w-5 h-5" />
-        </button>
+        {/* Voice + Send buttons */}
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          <button
+            type="button"
+            onClick={() => setShowVoice(true)}
+            disabled={disabled}
+            className={cn(
+              "w-10 h-10 flex items-center justify-center rounded-full",
+              "bg-vf-bg-2 border border-vf-border-1 text-vf-fg-1",
+              "hover:bg-vf-bg-3 hover:text-vf-fg transition-colors duration-150",
+              "disabled:opacity-40 disabled:cursor-not-allowed",
+            )}
+            aria-label="Grabar voz"
+            title="Grabar audio"
+          >
+            <Mic className="w-5 h-5" />
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={disabled || (!value.trim() && attachments.length === 0)}
+            className={cn(
+              "w-10 h-10 flex items-center justify-center rounded-full",
+              "bg-vf-green text-black",
+              "hover:bg-vf-green/90 transition-colors duration-150",
+              "voice-button green-glow-sm",
+              "disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-vf-green",
+            )}
+            aria-label="Enviar mensaje"
+            title="Enviar (⌘/Ctrl + Enter)"
+          >
+            <Send className="w-5 h-5" />
+          </button>
+        </div>
       </div>
 
       {/* Modals */}

--- a/components/vforge/composer.tsx
+++ b/components/vforge/composer.tsx
@@ -35,6 +35,8 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [showCamera, setShowCamera] = useState(false);
   const [showVoice, setShowVoice] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -91,14 +93,45 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
     setAttachments((prev) => [...prev, att]);
   }
 
-  function handleVoiceCapture(r: VoiceRecorderResult) {
-    const att: ComposerAttachment = {
-      id: makeId(),
-      kind: "audio",
-      label: `Audio ${r.durationSec.toFixed(1)}s`,
-      meta: r.mimeType.split(";")[0],
-    };
-    setAttachments((prev) => [...prev, att]);
+  async function handleVoiceCapture(r: VoiceRecorderResult) {
+    setVoiceError(null);
+    setTranscribing(true);
+    try {
+      const form = new FormData();
+      form.append("audio", r.blob, `voice.${guessExt(r.mimeType)}`);
+      form.append("language", "es");
+      const res = await fetch("/api/forge/transcribe", {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: "fail" }));
+        setVoiceError(body.error || `Transcripción falló (${res.status})`);
+        return;
+      }
+      const { text } = (await res.json()) as { text: string };
+      const trimmed = text.trim();
+      if (!trimmed) {
+        setVoiceError("No se detectó voz. Intenta de nuevo.");
+        return;
+      }
+      setValue((v) => (v ? `${v} ${trimmed}` : trimmed));
+      // Focus the textarea so the user can edit before sending
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setVoiceError(`Error de red: ${message}`);
+    } finally {
+      setTranscribing(false);
+    }
+  }
+
+  function guessExt(mime: string): string {
+    if (mime.includes("webm")) return "webm";
+    if (mime.includes("mp4") || mime.includes("m4a")) return "m4a";
+    if (mime.includes("mpeg")) return "mp3";
+    if (mime.includes("wav")) return "wav";
+    return "webm";
   }
 
   function removeAttachment(id: string) {
@@ -137,6 +170,38 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
 
   return (
     <div className="sticky bottom-0 bg-vf-bg-1 border-t border-vf-border p-3 pb-safe">
+      {/* Voice transcription status / error banner */}
+      {(transcribing || voiceError) && (
+        <div
+          className={cn(
+            "mb-2 px-3 py-2 rounded-md text-xs font-mono flex items-center gap-2",
+            transcribing
+              ? "bg-vf-bg-2 border border-vf-border-1 text-vf-fg-1"
+              : "bg-vf-bg-2 border border-vf-error/40 text-vf-error",
+          )}
+          role="status"
+        >
+          {transcribing ? (
+            <>
+              <span className="dot-live w-2 h-2 rounded-full bg-vf-green" />
+              Transcribiendo audio…
+            </>
+          ) : (
+            <>
+              <span>⚠</span>
+              {voiceError}
+              <button
+                onClick={() => setVoiceError(null)}
+                className="ml-auto text-vf-fg-2 hover:text-vf-fg"
+                aria-label="Cerrar"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
       {/* Attachment chips */}
       {attachments.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-2">
@@ -241,7 +306,7 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
           <button
             type="button"
             onClick={() => setShowVoice(true)}
-            disabled={disabled}
+            disabled={disabled || transcribing}
             className={cn(
               "w-10 h-10 flex items-center justify-center rounded-full",
               "bg-vf-bg-2 border border-vf-border-1 text-vf-fg-1",
@@ -249,7 +314,7 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
               "disabled:opacity-40 disabled:cursor-not-allowed",
             )}
             aria-label="Grabar voz"
-            title="Grabar audio"
+            title="Grabar audio (Whisper transcribe a texto)"
           >
             <Mic className="w-5 h-5" />
           </button>
@@ -283,8 +348,8 @@ export function Composer({ onSend, disabled = false }: ComposerProps) {
       )}
       {showVoice && (
         <VoiceRecorder
-          title="Dictar a Forge"
-          hint="Tu mensaje en audio se adjunta como archivo"
+          title="Dictar a V"
+          hint="Tu voz se transcribe con Whisper y aparece en el cuadro de texto para que la edites antes de enviar"
           maxDurationSec={120}
           onCapture={handleVoiceCapture}
           onClose={() => setShowVoice(false)}

--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -1,4 +1,4 @@
-import { queryOne, queryAll } from "@/lib/db/client";
+import { queryAll, queryOne } from "@/lib/db/client";
 
 interface SystemConfig {
   ai_name: string;
@@ -16,6 +16,20 @@ interface KnowledgeEntry {
   tags: string[];
 }
 
+interface ProjectFocus {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  status: string;
+  github_repo: string | null;
+  github_url: string | null;
+  github_private: boolean;
+  github_language: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+}
+
 /**
  * Build the system prompt for V by combining:
  *  1. Core personality from system_config
@@ -23,8 +37,11 @@ interface KnowledgeEntry {
  *  3. Method + key ADRs (always included)
  *  4. Recent lessons (last 10)
  *  5. Project catalog summary (counts + names by category)
+ *  6. Optional: focused project context when conversation is project-scoped
  */
-export async function buildSystemPrompt(): Promise<{
+export async function buildSystemPrompt(
+  options: { projectId?: string | null } = {},
+): Promise<{
   systemPrompt: string;
   config: SystemConfig;
 }> {
@@ -66,8 +83,42 @@ export async function buildSystemPrompt(): Promise<{
      ORDER BY category`,
   );
 
+  // Optional focused project context
+  let projectFocus: ProjectFocus | null = null;
+  if (options.projectId) {
+    projectFocus = await queryOne<ProjectFocus>(
+      `SELECT id, name, description, category, status,
+              github_repo, github_url, github_private, github_language,
+              vercel_url, domain
+         FROM projects WHERE id = $1`,
+      [options.projectId],
+    );
+  }
+
   const knowledgeSection = formatKnowledge([...coreKnowledge, ...lessons]);
   const projectSection = formatProjects(projectSummary);
+  const focusSection = projectFocus
+    ? [
+        "─────────────────────────────────────────",
+        `PROYECTO EN FOCO — ${projectFocus.name}`,
+        "─────────────────────────────────────────",
+        `id:           ${projectFocus.id}`,
+        `descripción:  ${projectFocus.description ?? "(sin descripción)"}`,
+        `categoría:    ${projectFocus.category}`,
+        `estado:       ${projectFocus.status}`,
+        `repo:         ${projectFocus.github_repo ?? "—"}${projectFocus.github_private ? " (privado)" : ""}`,
+        `lenguaje:     ${projectFocus.github_language ?? "—"}`,
+        `URL deploy:   ${projectFocus.vercel_url ?? "—"}`,
+        `dominio:      ${projectFocus.domain ?? "—"}`,
+        "",
+        `Esta conversación está enfocada en este proyecto. Cuando Luis pregunte algo sin especificar proyecto, asume que se refiere a ${projectFocus.name}. Si Luis cambia explícitamente de tema, sigue el flujo natural.`,
+      ].join("\n")
+    : [
+        "─────────────────────────────────────────",
+        "MODO CONVERSACIÓN",
+        "─────────────────────────────────────────",
+        "Modo general: la conversación NO está enfocada en un proyecto específico. Si Luis menciona un proyecto, identifícalo del catálogo. Si la pregunta es ambigua, pregunta a cuál se refiere.",
+      ].join("\n");
 
   const systemPrompt = [
     config.ai_personality,
@@ -81,6 +132,8 @@ export async function buildSystemPrompt(): Promise<{
     "CATÁLOGO DE PROYECTOS (real, cross-checked GitHub + Vercel)",
     "─────────────────────────────────────────",
     projectSection,
+    "",
+    focusSection,
     "",
     "─────────────────────────────────────────",
     "CONFIGURACIÓN ACTUAL",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "lucide-react": "^0.564.0",
         "next": "16.2.4",
         "next-themes": "^0.4.6",
+        "openai": "^6.35.0",
         "react": "^19",
         "react-day-picker": "9.13.2",
         "react-dom": "^19",
@@ -7554,6 +7555,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
+      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lucide-react": "^0.564.0",
     "next": "16.2.4",
     "next-themes": "^0.4.6",
+    "openai": "^6.35.0",
     "react": "^19",
     "react-day-picker": "9.13.2",
     "react-dom": "^19",


### PR DESCRIPTION
## Resumen

4 fixes críticos que Luis pidió tras primera prueba en producción:

1. **Persistencia de conversación** — endpoint GET /api/forge/conversations + hidratación al montar /forge. Cierras la PWA, vuelves a abrir, sigue donde estaba.
2. **Modo de chat General | Por proyecto** — selector con optgroup por categoría. Cada scope tiene su propio sessionId. System prompt incluye contexto del proyecto cuando hay foco.
3. **Botón Send explícito + Enter mobile-friendly** — Enter ahora hace newline (natural para teclados virtuales). Cmd/Ctrl+Enter envía. Botón verde de avión siempre visible.
4. **Transcripción audio con Whisper** — POST /api/forge/transcribe + VoiceRecorder cablea. Audio se transcribe a texto y se inyecta al textarea.

## Test plan

- [x] `npm run build` verde
- [x] `npx tsc --noEmit` verde
- [ ] Manual: cerrar PWA → reabrir → conversación persiste
- [ ] Manual: cambiar de scope → conversación independiente
- [ ] Manual: Cmd/Ctrl+Enter manda en desktop, Send button manda en mobile
- [ ] Manual: dictar voz en español → texto aparece en composer

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_