### PR TITLE
chore: limpiar tablero + dashboard DB-driven con empty states

### DIFF
--- a/app/(dashboard)/hub/page.tsx
+++ b/app/(dashboard)/hub/page.tsx
@@ -1,20 +1,64 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { StatCard } from "@/components/vforge/stat-card";
 import { SectionHeader } from "@/components/vforge/section-header";
-import { ProjectRow } from "@/components/vforge/project-row";
-import { ActivityRow } from "@/components/vforge/activity-row";
-import { PROJECTS, ACTIVITY, HUB_STATS } from "@/lib/mock-data";
 import {
   FolderKanban,
   Rocket,
   Sparkles,
   TrendingUp,
+  Plus,
 } from "lucide-react";
+import Link from "next/link";
+
+interface Stats {
+  total_projects: number;
+  produccion: number;
+  activo: number;
+  en_revision: number;
+  en_pausa: number;
+  archivo: number;
+  pendiente_borrado: number;
+  forge_turns: number;
+  forge_cost_today_usd: number;
+}
+
+interface Project {
+  id: string;
+  name: string;
+  category: string;
+  status: string;
+  github_repo: string | null;
+  vercel_url: string | null;
+}
 
 export default function HubPage() {
-  const recentProjects = PROJECTS.slice(0, 4);
-  const recentActivity = ACTIVITY.slice(0, 3);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void Promise.all([
+      fetch("/api/stats", { cache: "no-store" }).then((r) =>
+        r.ok ? r.json() : null,
+      ),
+      fetch("/api/projects", { cache: "no-store" }).then((r) =>
+        r.ok ? r.json() : { projects: [] },
+      ),
+    ])
+      .then(([s, p]) => {
+        setStats(s);
+        setProjects(p.projects ?? []);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const subtitle = stats
+    ? stats.total_projects === 0
+      ? "Tu fábrica está en ceros — dale de alta tu primer proyecto"
+      : `${stats.total_projects} proyecto${stats.total_projects === 1 ? "" : "s"} · ${stats.produccion} en producción · ${stats.en_revision} en revisión`
+    : "Cargando…";
 
   return (
     <div className="space-y-8">
@@ -36,7 +80,7 @@ export default function HubPage() {
           className="text-vf-fg-1 stagger-fade-up"
           style={{ animationDelay: "100ms" }}
         >
-          8 proyectos · 6 en producción · 2 en construcción
+          {subtitle}
         </p>
       </header>
 
@@ -45,33 +89,37 @@ export default function HubPage() {
         <StatCard
           icon={FolderKanban}
           label="Proyectos activos"
-          value={HUB_STATS.activeProjects.value}
-          deltaLabel={HUB_STATS.activeProjects.delta}
-          deltaTone={HUB_STATS.activeProjects.tone}
+          value={stats ? stats.produccion + stats.activo : "—"}
+          deltaLabel={
+            stats ? `${stats.total_projects} en total` : "cargando…"
+          }
+          deltaTone="neutral"
           delay={150}
         />
         <StatCard
           icon={Rocket}
-          label="Deploys hoy"
-          value={HUB_STATS.deploysToday.value}
-          deltaLabel={HUB_STATS.deploysToday.delta}
-          deltaTone={HUB_STATS.deploysToday.tone}
+          label="En producción"
+          value={stats ? stats.produccion : "—"}
+          deltaLabel={stats ? "live + dominio" : "cargando…"}
+          deltaTone="positive"
           delay={200}
         />
         <StatCard
           icon={Sparkles}
-          label="Forge runs"
-          value={HUB_STATS.forgeRuns.value}
-          deltaLabel={HUB_STATS.forgeRuns.delta}
-          deltaTone={HUB_STATS.forgeRuns.tone}
+          label="Turnos con V (24h)"
+          value={stats ? stats.forge_turns : "—"}
+          deltaLabel={
+            stats ? `$${stats.forge_cost_today_usd.toFixed(4)} costo` : "cargando…"
+          }
+          deltaTone="positive"
           delay={250}
         />
         <StatCard
           icon={TrendingUp}
-          label="Uptime promedio"
-          value={HUB_STATS.uptime.value}
-          deltaLabel={HUB_STATS.uptime.delta}
-          deltaTone={HUB_STATS.uptime.tone}
+          label="En revisión"
+          value={stats ? stats.en_revision : "—"}
+          deltaLabel={stats ? "necesitan auditoría" : "cargando…"}
+          deltaTone="warning"
           delay={300}
         />
       </section>
@@ -79,35 +127,44 @@ export default function HubPage() {
       {/* Recent Projects */}
       <section>
         <SectionHeader
-          title="Proyectos recientes"
+          title="Proyectos"
           rightCta={{ label: "Ver todos", href: "/projects" }}
         />
-        <div className="divide-y divide-vf-border">
-          {recentProjects.map((project, index) => (
-            <ProjectRow
-              key={project.id}
-              project={project}
-              delay={350 + index * 50}
-            />
-          ))}
-        </div>
-      </section>
-
-      {/* Recent Activity */}
-      <section>
-        <SectionHeader
-          title="Actividad reciente"
-          rightCta={{ label: "Ver todo", href: "/activity" }}
-        />
-        <div className="divide-y divide-vf-border/50">
-          {recentActivity.map((item, index) => (
-            <ActivityRow
-              key={item.id}
-              item={item}
-              delay={550 + index * 50}
-            />
-          ))}
-        </div>
+        {!loading && projects.length === 0 ? (
+          <div className="border border-dashed border-vf-border-1 rounded-xl px-6 py-12 text-center space-y-3">
+            <p className="text-vf-fg">Aún no hay proyectos en el tablero.</p>
+            <p className="text-vf-fg-2 text-sm">
+              Da de alta tu primer proyecto para que aparezca aquí.
+            </p>
+            <Link
+              href="/projects"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-vf-green text-black text-sm font-medium"
+            >
+              <Plus className="w-4 h-4" />
+              Dar de alta proyecto
+            </Link>
+          </div>
+        ) : (
+          <div className="divide-y divide-vf-border">
+            {projects.slice(0, 4).map((p) => (
+              <Link
+                key={p.id}
+                href={`/projects/${p.id}`}
+                className="flex items-center justify-between py-3 hover:bg-vf-bg-1 transition-colors px-2 -mx-2 rounded"
+              >
+                <div className="min-w-0">
+                  <div className="text-vf-fg font-medium truncate">{p.name}</div>
+                  <div className="font-mono text-[11px] text-vf-fg-2 truncate">
+                    {p.github_repo ?? "(sin repo)"}
+                  </div>
+                </div>
+                <span className="font-mono text-[10px] uppercase text-vf-fg-2 ml-3 flex-shrink-0">
+                  {p.category}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/app/(dashboard)/projects/[slug]/page.tsx
+++ b/app/(dashboard)/projects/[slug]/page.tsx
@@ -1,14 +1,54 @@
 "use client";
 
-import { PROJECTS, VAULT_SECRETS, ACTIVITY } from "@/lib/mock-data";
-import { ProjectFavicon } from "@/components/vforge/project-favicon";
-import { StatusPill } from "@/components/vforge/status-pill";
-import { SectionHeader } from "@/components/vforge/section-header";
-import { ActivityRow } from "@/components/vforge/activity-row";
+import { useEffect, useState, use } from "react";
 import { Button } from "@/components/ui/button";
 import { notFound } from "next/navigation";
-import { use } from "react";
-import { ExternalLink, Rocket, Activity, Clock, Zap, Key, Lock } from "lucide-react";
+import {
+  ExternalLink,
+  Rocket,
+  Clock,
+  GitBranch,
+  Lock,
+  Trash2,
+} from "lucide-react";
+import Link from "next/link";
+
+interface ProjectDetail {
+  id: string;
+  name: string;
+  description: string | null;
+  github_repo: string | null;
+  github_url: string | null;
+  github_private: boolean;
+  github_language: string | null;
+  github_default_branch: string;
+  vercel_project_id: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+  category: string;
+  status: string;
+  last_audit_at: string | null;
+  last_audit_score: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const CATEGORY_LABEL: Record<string, string> = {
+  produccion: "🟢 Producción",
+  activo: "🔵 Activo",
+  en_revision: "🟡 En revisión",
+  en_pausa: "⏸️ En pausa",
+  archivo: "📦 Archivo",
+  pendiente_borrado: "🗑️ Pendiente borrado",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  live: "Live",
+  building: "Building",
+  error: "Error",
+  idle: "Idle",
+  unknown: "Sin verificar",
+};
 
 export default function ProjectDetailPage({
   params,
@@ -16,38 +56,91 @@ export default function ProjectDetailPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = use(params);
-  const project = PROJECTS.find((p) => p.slug === slug);
+  const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [status, setStatus] = useState<"loading" | "ok" | "404" | "error">(
+    "loading",
+  );
 
-  if (!project) {
+  useEffect(() => {
+    void fetch(`/api/projects/${encodeURIComponent(slug)}`, {
+      cache: "no-store",
+    })
+      .then(async (r) => {
+        if (r.status === 404) {
+          setStatus("404");
+          return;
+        }
+        if (!r.ok) {
+          setStatus("error");
+          return;
+        }
+        const data = (await r.json()) as { project: ProjectDetail };
+        setProject(data.project);
+        setStatus("ok");
+      })
+      .catch(() => setStatus("error"));
+  }, [slug]);
+
+  if (status === "loading") {
+    return (
+      <div className="text-vf-fg-2 text-sm py-12 text-center font-mono">
+        Cargando proyecto…
+      </div>
+    );
+  }
+
+  if (status === "404") {
     notFound();
   }
 
-  // Filter secrets for this project
-  const projectSecrets = VAULT_SECRETS.filter((s) => s.project === project.id);
-
-  // Filter activity for this project
-  const projectActivity = ACTIVITY.filter((a) => a.project === project.id);
+  if (status === "error" || !project) {
+    return (
+      <div className="text-vf-error text-sm py-12 text-center font-mono">
+        Error cargando el proyecto.
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-8">
       {/* Header */}
-      <header
-        className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between stagger-fade-up"
-        style={{ animationDelay: "0ms" }}
-      >
-        <div className="flex items-center gap-4">
-          <ProjectFavicon project={project} size="xl" />
-          <div>
-            <h1 className="text-3xl font-semibold tracking-tight text-vf-fg">
-              {project.name}
-            </h1>
-            <p className="font-mono text-sm text-vf-fg-2 mt-1">
-              {project.repo}
-            </p>
+      <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex items-start gap-4 min-w-0">
+          <span className="font-mono text-base text-vf-fg-2 px-3 py-2 rounded-md bg-vf-bg-2 border border-vf-border-1 flex-shrink-0">
+            {project.id.slice(0, 2).toUpperCase()}
+          </span>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h1 className="text-2xl md:text-3xl font-semibold tracking-tight text-vf-fg">
+                {project.name}
+              </h1>
+              {project.github_private && (
+                <Lock className="w-4 h-4 text-vf-fg-2" />
+              )}
+              <span className="font-mono text-[11px] uppercase text-vf-fg-2 ml-1">
+                {CATEGORY_LABEL[project.category] ?? project.category}
+              </span>
+            </div>
+            {project.github_repo && (
+              <p className="font-mono text-sm text-vf-fg-2 mt-1 truncate flex items-center gap-1.5">
+                <GitBranch className="w-3.5 h-3.5 flex-shrink-0" />
+                {project.github_repo}
+                {project.github_language && (
+                  <span className="ml-1 px-1.5 py-0 text-[10px] bg-vf-bg-2 rounded">
+                    {project.github_language}
+                  </span>
+                )}
+              </p>
+            )}
+            {project.description && (
+              <p className="text-vf-fg-1 text-sm mt-2 max-w-prose">
+                {project.description}
+              </p>
+            )}
           </div>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 flex-shrink-0">
           {project.domain ? (
             <Button
               variant="ghost"
@@ -60,144 +153,162 @@ export default function ProjectDetailPage({
                 rel="noopener noreferrer"
               >
                 <ExternalLink className="w-4 h-4 mr-2" />
-                Abrir dominio
+                {project.domain}
               </a>
             </Button>
-          ) : (
+          ) : project.vercel_url ? (
             <Button
               variant="ghost"
-              className="text-vf-fg-2 cursor-not-allowed opacity-50"
-              disabled
+              className="text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1"
+              asChild
             >
-              <ExternalLink className="w-4 h-4 mr-2" />
-              Sin dominio
+              <a
+                href={project.vercel_url.startsWith("http") ? project.vercel_url : `https://${project.vercel_url}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="w-4 h-4 mr-2" />
+                Deploy
+              </a>
+            </Button>
+          ) : null}
+          {project.github_url && (
+            <Button
+              variant="ghost"
+              className="text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1"
+              asChild
+            >
+              <a
+                href={project.github_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <GitBranch className="w-4 h-4 mr-2" />
+                Repo
+              </a>
             </Button>
           )}
-          <Button className="bg-vf-green text-black hover:bg-vf-green/90 font-medium">
-            <Rocket className="w-4 h-4 mr-2" />
-            Desplegar
-          </Button>
         </div>
       </header>
 
-      {/* Stat Cards */}
-      <section
-        className="grid grid-cols-1 sm:grid-cols-3 gap-4 stagger-fade-up"
-        style={{ animationDelay: "50ms" }}
-      >
-        <div className="bg-vf-bg-1 border border-vf-border rounded-lg p-5">
-          <div className="flex items-start justify-between mb-3">
-            <Activity className="w-5 h-5 text-vf-green" />
-          </div>
-          <div className="flex items-center gap-2">
-            <StatusPill status={project.status} />
-          </div>
-          <div className="mt-2 text-[11px] uppercase tracking-wide text-vf-fg-2">
-            Estado
-          </div>
-        </div>
-
-        <div className="bg-vf-bg-1 border border-vf-border rounded-lg p-5">
-          <div className="flex items-start justify-between mb-3">
-            <Clock className="w-5 h-5 text-vf-green" />
-          </div>
-          <div className="font-mono text-[32px] leading-none text-vf-fg tracking-tight">
-            {project.lastDeploy ?? "—"}
-          </div>
-          <div className="mt-2 text-[11px] uppercase tracking-wide text-vf-fg-2">
-            Último deploy
-          </div>
-          {!project.lastDeploy && (
-            <div className="mt-1 text-xs text-vf-fg-2">
-              Sin deploys aún
-            </div>
-          )}
-        </div>
-
-        <div className="bg-vf-bg-1 border border-vf-border rounded-lg p-5">
-          <div className="flex items-start justify-between mb-3">
-            <Zap className="w-5 h-5 text-vf-green" />
-          </div>
-          <div className="font-mono text-[32px] leading-none text-vf-fg tracking-tight">
-            {project.deploysToday}
-          </div>
-          <div className="mt-2 text-[11px] uppercase tracking-wide text-vf-fg-2">
-            Deploys hoy
-          </div>
-          {project.deploysToday === 0 && (
-            <div className="mt-1 text-xs text-vf-fg-2">
-              Ningún deploy hoy
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Secrets Section */}
-      <section
-        className="stagger-fade-up"
-        style={{ animationDelay: "100ms" }}
-      >
-        <SectionHeader
-          title="Secretos del proyecto"
-          rightCta={{ label: "Ver Vault", href: "/vault" }}
+      {/* Stat strip */}
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatBox label="Estado" value={STATUS_LABEL[project.status] ?? project.status} />
+        <StatBox
+          label="Último audit"
+          value={
+            project.last_audit_at
+              ? new Date(project.last_audit_at).toLocaleDateString("es-MX")
+              : "Sin auditar"
+          }
         />
-        {projectSecrets.length > 0 ? (
-          <div className="bg-vf-bg-1 border border-vf-border rounded-lg divide-y divide-vf-border">
-            {projectSecrets.map((secret) => (
-              <div
-                key={secret.name}
-                className="flex items-center gap-3 px-4 py-3"
-              >
-                <Key className="w-4 h-4 text-vf-green flex-shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <div className="font-mono text-sm text-vf-fg truncate">
-                    {secret.name}
-                  </div>
-                  <div className="text-xs text-vf-fg-2 mt-0.5">
-                    {secret.scope === "client" && "Cliente"}
-                    {secret.scope === "platform" && "Plataforma"}
-                    {secret.scope === "platform-global" && "Global"}
-                    {secret.lastUsed && ` · usado hace ${secret.lastUsed}`}
-                  </div>
-                </div>
-                <Lock className="w-3.5 h-3.5 text-vf-fg-2" />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="bg-vf-bg-1 border border-vf-border rounded-lg p-8 text-center">
-            <Key className="w-8 h-8 text-vf-fg-2 mx-auto mb-3 opacity-50" />
-            <p className="text-sm text-vf-fg-2">
-              Este proyecto no tiene secretos configurados
-            </p>
-          </div>
-        )}
+        <StatBox
+          label="Score"
+          value={project.last_audit_score !== null ? `${project.last_audit_score}/100` : "—"}
+        />
+        <StatBox
+          label="Branch"
+          value={project.github_default_branch ?? "main"}
+        />
       </section>
 
-      {/* Activity Section */}
-      <section
-        className="stagger-fade-up"
-        style={{ animationDelay: "150ms" }}
-      >
-        <SectionHeader
-          title="Actividad de este proyecto"
-          rightCta={{ label: "Ver todo", href: "/activity" }}
-        />
-        {projectActivity.length > 0 ? (
-          <div className="bg-vf-bg-1 border border-vf-border rounded-lg px-4 py-2">
-            {projectActivity.map((item, idx) => (
-              <ActivityRow key={item.id} item={item} delay={idx * 30} />
-            ))}
-          </div>
-        ) : (
-          <div className="bg-vf-bg-1 border border-vf-border rounded-lg p-8 text-center">
-            <Activity className="w-8 h-8 text-vf-fg-2 mx-auto mb-3 opacity-50" />
-            <p className="text-sm text-vf-fg-2">
-              Sin actividad reciente para este proyecto
-            </p>
-          </div>
-        )}
+      {/* TODO: secrets section pulls from operator_secrets+user_secrets when M0 Vault wires up */}
+      <section className="border border-dashed border-vf-border-1 rounded-xl p-6 text-vf-fg-2 text-sm">
+        <p className="font-medium text-vf-fg mb-1">Secretos del proyecto</p>
+        <p>
+          Cuando se cablee el Vault (Phase B de M0), aquí aparecen las API
+          keys de este proyecto con botón Ver/Copiar. Por ahora, las claves
+          viven en Vercel env vars del proyecto.
+        </p>
       </section>
+
+      {/* TODO: activity section pulls from audit_events filtered by resource_id when implemented */}
+      <section className="border border-dashed border-vf-border-1 rounded-xl p-6 text-vf-fg-2 text-sm">
+        <p className="font-medium text-vf-fg mb-1">Actividad</p>
+        <p>
+          La actividad por proyecto se filtrará desde audit_events cuando V
+          empiece a registrar acciones específicas (deploys, ediciones, etc.).
+        </p>
+      </section>
+
+      {/* Quick links */}
+      <section className="flex justify-between items-center pt-4 border-t border-vf-border">
+        <Link
+          href="/projects"
+          className="text-sm text-vf-fg-2 hover:text-vf-fg"
+        >
+          ← Volver al listado
+        </Link>
+        <DeleteButton id={project.id} name={project.name} />
+      </section>
+    </div>
+  );
+}
+
+function StatBox({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="bg-vf-bg-1 border border-vf-border rounded-lg p-4">
+      <div className="text-vf-fg font-medium truncate">{value}</div>
+      <div className="mt-1 text-[10px] uppercase tracking-wide text-vf-fg-2 font-mono">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function DeleteButton({ id, name }: { id: string; name: string }) {
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function doDelete() {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/projects/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        window.location.href = "/projects";
+      } else {
+        setBusy(false);
+      }
+    } catch {
+      setBusy(false);
+    }
+  }
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="inline-flex items-center gap-1.5 text-xs text-vf-fg-3 hover:text-vf-error transition-colors"
+        title="Eliminar este proyecto del catálogo (Anillo 2)"
+      >
+        <Trash2 className="w-3.5 h-3.5" />
+        Quitar del tablero
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="text-vf-fg-2">¿Quitar &quot;{name}&quot;?</span>
+      <button
+        type="button"
+        onClick={() => setConfirming(false)}
+        disabled={busy}
+        className="px-2 py-1 rounded text-vf-fg-2 hover:text-vf-fg"
+      >
+        Cancelar
+      </button>
+      <button
+        type="button"
+        onClick={doDelete}
+        disabled={busy}
+        className="px-2 py-1 rounded bg-vf-error text-white disabled:opacity-50"
+      >
+        {busy ? "…" : "Sí, quitar"}
+      </button>
     </div>
   );
 }

--- a/app/(dashboard)/projects/page.tsx
+++ b/app/(dashboard)/projects/page.tsx
@@ -1,109 +1,363 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { ProjectRow } from "@/components/vforge/project-row";
-import { PROJECTS } from "@/lib/mock-data";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Plus, ExternalLink, GitBranch, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-type FilterType = "all" | "live" | "warning" | "error" | "v-family" | "v-momentum";
+interface Project {
+  id: string;
+  name: string;
+  category: string;
+  status: string;
+  github_repo: string | null;
+  github_url?: string | null;
+  github_private?: boolean;
+  github_language?: string | null;
+  vercel_url: string | null;
+  domain?: string | null;
+}
 
-const FILTERS: { id: FilterType; label: string }[] = [
-  { id: "all", label: "Todos" },
-  { id: "live", label: "Live" },
-  { id: "warning", label: "Warning" },
-  { id: "error", label: "Error" },
-  { id: "v-family", label: "V-Family" },
-  { id: "v-momentum", label: "V-Momentum" },
+type CategoryFilter =
+  | "all"
+  | "produccion"
+  | "activo"
+  | "en_revision"
+  | "en_pausa"
+  | "archivo"
+  | "pendiente_borrado";
+
+const CATEGORIES: { id: CategoryFilter; label: string; emoji: string }[] = [
+  { id: "all", label: "Todos", emoji: "•" },
+  { id: "produccion", label: "Producción", emoji: "🟢" },
+  { id: "activo", label: "Activo", emoji: "🔵" },
+  { id: "en_revision", label: "En revisión", emoji: "🟡" },
+  { id: "en_pausa", label: "En pausa", emoji: "⏸️" },
+  { id: "archivo", label: "Archivo", emoji: "📦" },
+  { id: "pendiente_borrado", label: "Pendiente borrado", emoji: "🗑️" },
 ];
 
 export default function ProjectsPage() {
-  const [activeFilter, setActiveFilter] = useState<FilterType>("all");
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [active, setActive] = useState<CategoryFilter>("all");
+  const [showAddModal, setShowAddModal] = useState(false);
 
-  const filteredProjects = useMemo(() => {
-    switch (activeFilter) {
-      case "live":
-        return PROJECTS.filter((p) => p.status === "live");
-      case "warning":
-        return PROJECTS.filter((p) => p.status === "building");
-      case "error":
-        return PROJECTS.filter((p) => p.status === "error");
-      case "v-family":
-        return PROJECTS.filter((p) => 
-          p.name.toLowerCase().startsWith("v") || p.slug.startsWith("v")
-        );
-      case "v-momentum":
-        return PROJECTS.filter((p) => p.slug === "vmomentum");
-      default:
-        return PROJECTS;
+  async function load() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/projects", { cache: "no-store" });
+      if (!res.ok) throw new Error("fetch failed");
+      const data = (await res.json()) as { projects: Project[] };
+      setProjects(data.projects);
+    } catch {
+      setProjects([]);
+    } finally {
+      setLoading(false);
     }
-  }, [activeFilter]);
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const filtered = useMemo(
+    () => (active === "all" ? projects : projects.filter((p) => p.category === active)),
+    [projects, active],
+  );
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <header className="space-y-1">
-        <p
-          className="font-mono text-[11px] uppercase tracking-wide text-vf-fg-2 stagger-fade-up"
-          style={{ animationDelay: "0ms" }}
-        >
+        <p className="font-mono text-[11px] uppercase tracking-wide text-vf-fg-2">
           Biblioteca
         </p>
-        <h1
-          className="text-2xl md:text-3xl font-semibold tracking-tight-vf text-vf-fg stagger-fade-up"
-          style={{ animationDelay: "50ms" }}
-        >
-          Tus {PROJECTS.length} proyectos
-        </h1>
-        <p
-          className="text-sm text-vf-fg-2 stagger-fade-up"
-          style={{ animationDelay: "100ms" }}
-        >
-          Filtra por estado o familia
+        <div className="flex items-baseline justify-between gap-3">
+          <h1 className="text-2xl md:text-3xl font-semibold tracking-tight-vf text-vf-fg">
+            {loading
+              ? "Cargando proyectos…"
+              : projects.length === 0
+                ? "Sin proyectos"
+                : `${projects.length} proyecto${projects.length === 1 ? "" : "s"}`}
+          </h1>
+          <button
+            type="button"
+            onClick={() => setShowAddModal(true)}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-vf-green text-black text-sm font-medium flex-shrink-0"
+          >
+            <Plus className="w-4 h-4" />
+            Dar de alta
+          </button>
+        </div>
+        <p className="text-sm text-vf-fg-2">
+          Filtra por categoría · da de alta los nuevos manualmente
         </p>
       </header>
 
-      {/* Filter Chips - Horizontal Scrollable */}
-      <div 
-        className="flex gap-2 overflow-x-auto pb-2 -mx-4 px-4 md:mx-0 md:px-0 scrollbar-hide stagger-fade-up"
-        style={{ animationDelay: "150ms" }}
-      >
-        {FILTERS.map((filter) => (
+      {/* Category chips */}
+      <div className="flex gap-2 overflow-x-auto pb-2 -mx-4 px-4 md:mx-0 md:px-0 scrollbar-hide">
+        {CATEGORIES.map((c) => (
           <button
-            key={filter.id}
+            key={c.id}
             type="button"
-            onClick={() => setActiveFilter(filter.id)}
+            onClick={() => setActive(c.id)}
             className={cn(
               "shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all duration-150",
               "min-h-[44px] touch-manipulation",
-              activeFilter === filter.id
+              active === c.id
                 ? "bg-vf-green text-black"
-                : "bg-vf-bg-1 text-vf-fg-1 hover:bg-vf-bg-2 active:bg-vf-bg-2"
+                : "bg-vf-bg-1 text-vf-fg-1 hover:bg-vf-bg-2",
             )}
           >
-            {filter.label}
+            <span className="mr-1.5">{c.emoji}</span>
+            {c.label}
           </button>
         ))}
       </div>
 
-      {/* Project List */}
-      <section className="stagger-fade-up" style={{ animationDelay: "200ms" }}>
-        {filteredProjects.length === 0 ? (
+      {/* List or empty state */}
+      <section>
+        {!loading && projects.length === 0 ? (
+          <EmptyState onAdd={() => setShowAddModal(true)} />
+        ) : !loading && filtered.length === 0 ? (
           <div className="py-12 text-center text-vf-fg-2">
-            No hay proyectos con este filtro
+            No hay proyectos en esta categoría.
           </div>
         ) : (
-          <div className="-mx-4 md:mx-0">
-            {filteredProjects.map((project, index) => (
-              <ProjectRow
-                key={project.id}
-                project={project}
-                delay={250 + index * 40}
-                showBorder={index > 0}
-              />
+          <div className="border-t border-vf-border">
+            {filtered.map((p) => (
+              <Link
+                key={p.id}
+                href={`/projects/${p.id}`}
+                className="flex items-center justify-between py-4 px-4 -mx-4 md:mx-0 hover:bg-vf-bg-1 transition-colors border-b border-vf-border"
+              >
+                <div className="min-w-0 flex-1 pr-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-vf-fg font-medium truncate">{p.name}</span>
+                    {p.github_private && (
+                      <Lock className="w-3 h-3 text-vf-fg-2 flex-shrink-0" />
+                    )}
+                  </div>
+                  <div className="font-mono text-[11px] text-vf-fg-2 truncate flex items-center gap-1.5 mt-0.5">
+                    <GitBranch className="w-3 h-3 flex-shrink-0" />
+                    {p.github_repo ?? "(sin repo)"}
+                    {p.github_language && (
+                      <span className="ml-1 px-1.5 py-0 text-[10px] bg-vf-bg-2 rounded">
+                        {p.github_language}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {p.vercel_url && <ExternalLink className="w-3.5 h-3.5 text-vf-green-quiet" />}
+                  <span className="font-mono text-[10px] uppercase text-vf-fg-2">
+                    {p.category}
+                  </span>
+                </div>
+              </Link>
             ))}
           </div>
         )}
       </section>
+
+      {showAddModal && (
+        <AddProjectModal
+          onClose={() => setShowAddModal(false)}
+          onAdded={() => {
+            setShowAddModal(false);
+            void load();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="border border-dashed border-vf-border-1 rounded-xl px-6 py-16 text-center space-y-4">
+      <div className="text-3xl">📭</div>
+      <div>
+        <h2 className="text-vf-fg font-semibold text-lg">El tablero está limpio</h2>
+        <p className="text-vf-fg-2 text-sm mt-1 max-w-md mx-auto">
+          Da de alta tus proyectos uno por uno. V los irá conociendo conforme
+          los agregues y podrá ayudarte con cada uno.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onAdd}
+        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-vf-green text-black text-sm font-medium"
+      >
+        <Plus className="w-4 h-4" />
+        Dar de alta el primer proyecto
+      </button>
+    </div>
+  );
+}
+
+function AddProjectModal({
+  onClose,
+  onAdded,
+}: {
+  onClose: () => void;
+  onAdded: () => void;
+}) {
+  const [form, setForm] = useState({
+    id: "",
+    name: "",
+    description: "",
+    github_repo: "",
+    vercel_url: "",
+    domain: "",
+    category: "en_revision",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!form.id.trim() || !form.name.trim()) {
+      setError("ID y nombre son requeridos");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          github_repo: form.github_repo || null,
+          vercel_url: form.vercel_url || null,
+          domain: form.domain || null,
+          description: form.description || null,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `error ${res.status}`);
+      }
+      onAdded();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-end sm:items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md bg-vf-bg-1 border border-vf-border rounded-xl p-5 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold text-vf-fg">Dar de alta proyecto</h2>
+        <form onSubmit={submit} className="space-y-3">
+          <Field
+            label="ID (slug, lowercase, sin espacios)"
+            value={form.id}
+            placeholder="ej. rideme"
+            onChange={(v) => setForm({ ...form, id: v.toLowerCase().replace(/[^a-z0-9_-]/g, "") })}
+          />
+          <Field
+            label="Nombre"
+            value={form.name}
+            placeholder="ej. RideMe"
+            onChange={(v) => setForm({ ...form, name: v })}
+          />
+          <Field
+            label="Descripción (opcional)"
+            value={form.description}
+            placeholder="Plataforma de transportación"
+            onChange={(v) => setForm({ ...form, description: v })}
+          />
+          <Field
+            label="Repo GitHub (turbillon50/...)"
+            value={form.github_repo}
+            placeholder="turbillon50/rideme"
+            onChange={(v) => setForm({ ...form, github_repo: v })}
+          />
+          <Field
+            label="URL deploy Vercel (opcional)"
+            value={form.vercel_url}
+            placeholder="https://..."
+            onChange={(v) => setForm({ ...form, vercel_url: v })}
+          />
+          <Field
+            label="Dominio custom (opcional)"
+            value={form.domain}
+            placeholder="rideme.allglobal.ec"
+            onChange={(v) => setForm({ ...form, domain: v })}
+          />
+          <div>
+            <label className="block text-xs text-vf-fg-2 mb-1">Categoría</label>
+            <select
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+              className="w-full bg-vf-bg-2 border border-vf-border-1 rounded-md px-3 py-2 text-sm text-vf-fg focus:outline-none focus:border-vf-border-2"
+            >
+              <option value="produccion">🟢 Producción</option>
+              <option value="activo">🔵 Activo</option>
+              <option value="en_revision">🟡 En revisión</option>
+              <option value="en_pausa">⏸️ En pausa</option>
+              <option value="archivo">📦 Archivo</option>
+            </select>
+          </div>
+
+          {error && (
+            <p className="text-xs text-vf-error font-mono" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 h-11 rounded-md border border-vf-border bg-vf-bg-2 text-vf-fg text-sm font-medium"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 h-11 rounded-md bg-vf-green text-black text-sm font-semibold disabled:opacity-50"
+            >
+              {submitting ? "Guardando…" : "Dar de alta"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label className="block text-xs text-vf-fg-2 mb-1">{label}</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full bg-vf-bg-2 border border-vf-border-1 rounded-md px-3 py-2 text-sm text-vf-fg placeholder:text-vf-fg-3 focus:outline-none focus:border-vf-border-2"
+      />
     </div>
   );
 }

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,0 +1,107 @@
+import { sql, queryOne } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface ProjectDetail {
+  id: string;
+  name: string;
+  description: string | null;
+  github_repo: string | null;
+  github_url: string | null;
+  github_private: boolean;
+  github_language: string | null;
+  github_default_branch: string;
+  vercel_project_id: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+  category: string;
+  status: string;
+  last_audit_at: string | null;
+  last_audit_score: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const OPERATOR_USER_ID = "operator_luis";
+
+/**
+ * GET /api/projects/{id}
+ *
+ * Returns full detail for a single project. Used by /projects/[slug].
+ * Returns 404 if not found.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const project = await queryOne<ProjectDetail>(
+    `SELECT id, name, description,
+            github_repo, github_url, github_private, github_language,
+            github_default_branch,
+            vercel_project_id, vercel_url, domain,
+            category, status,
+            last_audit_at, last_audit_score,
+            created_at, updated_at
+       FROM projects WHERE id = $1`,
+    [id],
+  );
+
+  if (!project) {
+    return new Response(JSON.stringify({ error: "project not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ project }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * DELETE /api/projects/{id}
+ *
+ * Removes a project from the catalog. Anillo 2 (project mutation).
+ * Cascades to repo_audits, user_secrets via FK.
+ */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  try {
+    const result = await sql`DELETE FROM projects WHERE id = ${id} RETURNING id, name`;
+    const rows = result as Array<{ id: string; name: string }>;
+
+    if (rows.length === 0) {
+      return new Response(JSON.stringify({ error: "project not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    await sql`
+      INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+      VALUES (
+        ${OPERATOR_USER_ID}, 'project.delete', 'project', ${id}, 2,
+        ${JSON.stringify({ deleted: rows[0] })}::jsonb
+      )
+    `;
+
+    return new Response(JSON.stringify({ deleted: rows[0] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ error: `db error: ${message}` }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,4 +1,4 @@
-import { queryAll } from "@/lib/db/client";
+import { sql, queryAll } from "@/lib/db/client";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -9,18 +9,33 @@ interface ProjectRow {
   category: string;
   status: string;
   github_repo: string | null;
+  github_private?: boolean;
+  github_language?: string | null;
   vercel_url: string | null;
+  domain?: string | null;
 }
+
+const VALID_CATEGORIES = new Set([
+  "produccion",
+  "activo",
+  "en_revision",
+  "en_pausa",
+  "archivo",
+  "pendiente_borrado",
+]);
+
+const OPERATOR_USER_ID = "operator_luis";
 
 /**
  * GET /api/projects
  *
- * Returns the live catalog from the projects table for UI selectors
- * and dashboards. Replaces the static lib/mock-data.ts PROJECTS.
+ * Returns the live catalog from the projects table.
  */
 export async function GET() {
   const rows = await queryAll<ProjectRow>(
-    `SELECT id, name, category, status, github_repo, vercel_url
+    `SELECT id, name, category, status,
+            github_repo, github_private, github_language,
+            vercel_url, domain
        FROM projects
        ORDER BY
          CASE category
@@ -36,6 +51,95 @@ export async function GET() {
   );
   return new Response(JSON.stringify({ projects: rows }), {
     status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * POST /api/projects
+ *
+ * Creates a new project. Used by the /projects "Dar de alta" modal.
+ * Validates id format and category enum, audit-logs the action.
+ */
+export async function POST(req: Request) {
+  let body: {
+    id?: string;
+    name?: string;
+    description?: string | null;
+    github_repo?: string | null;
+    vercel_url?: string | null;
+    domain?: string | null;
+    category?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonError("invalid JSON body", 400);
+  }
+
+  const id = (body.id ?? "").trim();
+  const name = (body.name ?? "").trim();
+  const category = (body.category ?? "en_revision").trim();
+
+  if (!id || !/^[a-z0-9][a-z0-9_-]*$/.test(id)) {
+    return jsonError("id required, lowercase a-z0-9_- only", 400);
+  }
+  if (!name) {
+    return jsonError("name required", 400);
+  }
+  if (!VALID_CATEGORIES.has(category)) {
+    return jsonError(
+      `category must be one of: ${[...VALID_CATEGORIES].join(", ")}`,
+      400,
+    );
+  }
+
+  const description = body.description ?? null;
+  const github_repo = body.github_repo ?? null;
+  const github_url = github_repo ? `https://github.com/${github_repo}` : null;
+  const vercel_url = body.vercel_url ?? null;
+  const domain = body.domain ?? null;
+
+  try {
+    await sql`
+      INSERT INTO projects (
+        id, name, description,
+        github_repo, github_url,
+        vercel_url, domain,
+        category, status
+      )
+      VALUES (
+        ${id}, ${name}, ${description},
+        ${github_repo}, ${github_url},
+        ${vercel_url}, ${domain},
+        ${category}, 'unknown'
+      )
+    `;
+
+    await sql`
+      INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+      VALUES (
+        ${OPERATOR_USER_ID}, 'project.create', 'project', ${id}, 1,
+        ${JSON.stringify({ name, category, github_repo })}::jsonb
+      )
+    `;
+
+    return new Response(JSON.stringify({ id, name }), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("duplicate") || message.includes("unique")) {
+      return jsonError(`project with id "${id}" already exists`, 409);
+    }
+    return jsonError(`db error: ${message}`, 500);
+  }
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
     headers: { "Content-Type": "application/json" },
   });
 }

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,4 +1,5 @@
-import { sql, queryAll } from "@/lib/db/client";
+import { queryAll } from "@/lib/db/client";
+import { neon } from "@neondatabase/serverless";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -100,29 +101,40 @@ export async function POST(req: Request) {
   const vercel_url = body.vercel_url ?? null;
   const domain = body.domain ?? null;
 
-  try {
-    await sql`
-      INSERT INTO projects (
-        id, name, description,
-        github_repo, github_url,
-        vercel_url, domain,
-        category, status
-      )
-      VALUES (
-        ${id}, ${name}, ${description},
-        ${github_repo}, ${github_url},
-        ${vercel_url}, ${domain},
-        ${category}, 'unknown'
-      )
-    `;
+  // Atomic: project.insert + audit_events.insert in one transaction.
+  // If either fails, neither commits — avoids the orphan-project /
+  // duplicate-id retry loop that would otherwise occur (Codex P2).
+  const dburl = process.env.DATABASE_URL;
+  if (!dburl) {
+    return jsonError("DATABASE_URL not configured", 500);
+  }
+  const txClient = neon(dburl);
+  const auditPayload = JSON.stringify({ name, category, github_repo });
 
-    await sql`
-      INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
-      VALUES (
-        ${OPERATOR_USER_ID}, 'project.create', 'project', ${id}, 1,
-        ${JSON.stringify({ name, category, github_repo })}::jsonb
-      )
-    `;
+  try {
+    await txClient.transaction([
+      txClient`
+        INSERT INTO projects (
+          id, name, description,
+          github_repo, github_url,
+          vercel_url, domain,
+          category, status
+        )
+        VALUES (
+          ${id}, ${name}, ${description},
+          ${github_repo}, ${github_url},
+          ${vercel_url}, ${domain},
+          ${category}, 'unknown'
+        )
+      `,
+      txClient`
+        INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+        VALUES (
+          ${OPERATOR_USER_ID}, 'project.create', 'project', ${id}, 1,
+          ${auditPayload}::jsonb
+        )
+      `,
+    ]);
 
     return new Response(JSON.stringify({ id, name }), {
       status: 201,
@@ -136,6 +148,7 @@ export async function POST(req: Request) {
     return jsonError(`db error: ${message}`, 500);
   }
 }
+
 
 function jsonError(message: string, status: number): Response {
   return new Response(JSON.stringify({ error: message }), {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,69 @@
+import { queryOne } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Stats {
+  total_projects: number;
+  produccion: number;
+  activo: number;
+  en_revision: number;
+  en_pausa: number;
+  archivo: number;
+  pendiente_borrado: number;
+  forge_turns: number;
+  forge_cost_today_usd: number;
+}
+
+/**
+ * GET /api/stats
+ *
+ * Live counts for the /hub dashboard. Replaces the static
+ * HUB_STATS that used to live in lib/mock-data.ts.
+ */
+export async function GET() {
+  const projectsByCategory = await queryOne<{
+    total: number;
+    produccion: number;
+    activo: number;
+    en_revision: number;
+    en_pausa: number;
+    archivo: number;
+    pendiente_borrado: number;
+  }>(
+    `SELECT
+       COUNT(*)::int AS total,
+       COUNT(*) FILTER (WHERE category = 'produccion')::int AS produccion,
+       COUNT(*) FILTER (WHERE category = 'activo')::int AS activo,
+       COUNT(*) FILTER (WHERE category = 'en_revision')::int AS en_revision,
+       COUNT(*) FILTER (WHERE category = 'en_pausa')::int AS en_pausa,
+       COUNT(*) FILTER (WHERE category = 'archivo')::int AS archivo,
+       COUNT(*) FILTER (WHERE category = 'pendiente_borrado')::int AS pendiente_borrado
+     FROM projects`,
+  );
+
+  const forgeStats = await queryOne<{ turns: number; cost: number }>(
+    `SELECT
+       COUNT(*)::int AS turns,
+       COALESCE(SUM(cost_usd), 0)::numeric AS cost
+     FROM conversations
+     WHERE role = 'assistant' AND created_at >= now() - interval '24 hours'`,
+  );
+
+  const stats: Stats = {
+    total_projects: projectsByCategory?.total ?? 0,
+    produccion: projectsByCategory?.produccion ?? 0,
+    activo: projectsByCategory?.activo ?? 0,
+    en_revision: projectsByCategory?.en_revision ?? 0,
+    en_pausa: projectsByCategory?.en_pausa ?? 0,
+    archivo: projectsByCategory?.archivo ?? 0,
+    pendiente_borrado: projectsByCategory?.pendiente_borrado ?? 0,
+    forge_turns: forgeStats?.turns ?? 0,
+    forge_cost_today_usd: Number(forgeStats?.cost ?? 0),
+  };
+
+  return new Response(JSON.stringify(stats), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/components/vforge/project-switcher.tsx
+++ b/components/vforge/project-switcher.tsx
@@ -1,24 +1,43 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { PROJECTS } from "@/lib/mock-data";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, FolderPlus } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ProjectFavicon } from "./project-favicon";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
 interface ProjectSwitcherProps {
   className?: string;
 }
 
+interface Project {
+  id: string;
+  name: string;
+  category: string;
+  github_repo: string | null;
+}
+
 export function ProjectSwitcher({ className }: ProjectSwitcherProps) {
-  const [selectedProject] = useState(PROJECTS[0]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    void fetch("/api/projects", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : { projects: [] }))
+      .then((d: { projects: Project[] }) => {
+        setProjects(d.projects);
+        if (d.projects.length > 0) setSelectedId(d.projects[0].id);
+      })
+      .catch(() => undefined);
+  }, []);
+
+  const selected = projects.find((p) => p.id === selectedId) ?? null;
 
   return (
     <DropdownMenu>
@@ -29,12 +48,14 @@ export function ProjectSwitcher({ className }: ProjectSwitcherProps) {
             "bg-vf-bg-1 border border-vf-border",
             "hover:bg-vf-bg-2 transition-colors duration-150",
             "min-h-[36px]",
-            className
+            className,
           )}
         >
-          <ProjectFavicon project={selectedProject} size="sm" />
-          <span className="text-sm text-vf-fg hidden sm:inline max-w-[100px] truncate">
-            {selectedProject.name}
+          <span className="font-mono text-[11px] text-vf-fg-2 px-1.5 py-0.5 rounded bg-vf-bg-2 border border-vf-border-1">
+            {selected ? selected.id.slice(0, 2).toUpperCase() : "—"}
+          </span>
+          <span className="text-sm text-vf-fg hidden sm:inline max-w-[120px] truncate">
+            {selected?.name ?? "Sin proyectos"}
           </span>
           <ChevronDown className="w-3 h-3 text-vf-fg-2" />
         </button>
@@ -43,22 +64,51 @@ export function ProjectSwitcher({ className }: ProjectSwitcherProps) {
         align="end"
         className="w-64 bg-vf-bg-1 border-vf-border"
       >
-        {PROJECTS.map((project) => (
-          <DropdownMenuItem key={project.id} asChild>
+        {projects.length === 0 ? (
+          <DropdownMenuItem asChild>
             <Link
-              href={`/projects/${project.slug}`}
+              href="/projects"
               className="flex items-center gap-3 px-3 py-2 cursor-pointer"
             >
-              <ProjectFavicon project={project} size="sm" />
-              <div className="flex-1 min-w-0">
-                <div className="text-sm text-vf-fg truncate">{project.name}</div>
-                <div className="text-xs text-vf-fg-2 font-mono truncate">
-                  {project.repo}
-                </div>
-              </div>
+              <FolderPlus className="w-4 h-4 text-vf-green" />
+              <div className="text-sm text-vf-fg">Dar de alta el primero</div>
             </Link>
           </DropdownMenuItem>
-        ))}
+        ) : (
+          <>
+            {projects.map((project) => (
+              <DropdownMenuItem key={project.id} asChild>
+                <Link
+                  href={`/projects/${project.id}`}
+                  onClick={() => setSelectedId(project.id)}
+                  className="flex items-center gap-3 px-3 py-2 cursor-pointer"
+                >
+                  <span className="font-mono text-[10px] text-vf-fg-2 px-1.5 py-0.5 rounded bg-vf-bg-2 flex-shrink-0">
+                    {project.id.slice(0, 2).toUpperCase()}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-vf-fg truncate">
+                      {project.name}
+                    </div>
+                    <div className="text-xs text-vf-fg-2 font-mono truncate">
+                      {project.github_repo ?? "(sin repo)"}
+                    </div>
+                  </div>
+                </Link>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link
+                href="/projects"
+                className="flex items-center gap-3 px-3 py-2 cursor-pointer text-vf-green-quiet"
+              >
+                <FolderPlus className="w-4 h-4" />
+                <span className="text-sm">Dar de alta otro</span>
+              </Link>
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,3 +1,17 @@
+/**
+ * Type definitions only — no mock data.
+ *
+ * The dashboard now reads everything from the live database via
+ * /api/projects, /api/forge/conversations, etc. Empty arrays are
+ * preserved as named exports for backward compatibility with
+ * components that may still reference them during the transition.
+ *
+ * Anything that previously lived as a hardcoded array (PROJECTS,
+ * VAULT_SECRETS, ACTIVITY, MODULES, RECENT_VISION, RECENT_HUNTER,
+ * RECENT_SCOUT, HUB_STATS) is now empty by design — operator gives
+ * each project an alta manually through the UI.
+ */
+
 export interface Project {
   id: string;
   name: string;
@@ -40,7 +54,17 @@ export interface ActivityItem {
   actor: string;
   verb: string;
   target: string;
-  kind: "deploy" | "vault" | "error" | "vision" | "warning" | "create" | "scout" | "settings" | "backup" | "refactor";
+  kind:
+    | "deploy"
+    | "vault"
+    | "error"
+    | "vision"
+    | "warning"
+    | "create"
+    | "scout"
+    | "settings"
+    | "backup"
+    | "refactor";
   project: string | null;
 }
 
@@ -63,184 +87,21 @@ export interface RecentScout {
   time: string;
 }
 
-export const PROJECTS: Project[] = [
-  {
-    id: "castores",
-    name: "Castores Control",
-    slug: "castores",
-    repo: "turbillon50/FINAL-CASTORES",
-    domain: "castores.info",
-    stack: "Next 14",
-    status: "live",
-    lastDeploy: "3h",
-    favicon: { gradient: "from-green-900 to-black", initials: "CC", color: "#7CFF3C" },
-    description: "Construction management web app",
-    secrets: 8,
-    deploysToday: 3,
-  },
-  {
-    id: "vandefi",
-    name: "VanDeFi",
-    slug: "vandefi",
-    repo: "turbillon50/vandefi",
-    domain: "vandefi.bandefi.org",
-    stack: "Next 14",
-    status: "building",
-    lastDeploy: "1h",
-    favicon: { gradient: "from-blue-900 to-black", initials: "VD", color: "#6699FF" },
-    description: "Non-custodial DeFi neobank",
-    secrets: 12,
-    deploysToday: 2,
-  },
-  {
-    id: "urmah",
-    name: "URMAH",
-    slug: "urmah",
-    repo: "turbillon50/urmah",
-    domain: "urmah.live",
-    stack: "PWA",
-    status: "live",
-    lastDeploy: "2d",
-    favicon: { gradient: "from-red-900 to-black", initials: "UR", color: "#FF8866" },
-    description: "Cinematic ticketing PWA",
-    secrets: 6,
-    deploysToday: 0,
-  },
-  {
-    id: "movee",
-    name: "Movee",
-    slug: "movee",
-    repo: "turbillon50/movee",
-    domain: "movee.mx",
-    stack: "React",
-    status: "live",
-    lastDeploy: "5d",
-    favicon: { gradient: "from-cyan-900 to-black", initials: "MV", color: "#66DDDD" },
-    description: "Ride-sharing for Mexico",
-    secrets: 5,
-    deploysToday: 1,
-  },
-  {
-    id: "rivones",
-    name: "Rivones / Autospot",
-    slug: "rivones",
-    repo: "turbillon50/rivones",
-    domain: "autospot.mx",
-    stack: "Vite",
-    status: "error",
-    lastDeploy: "1d",
-    favicon: { gradient: "from-orange-900 to-black", initials: "RV", color: "#FFAA66" },
-    description: "Car rental marketplace · build failed",
-    secrets: 4,
-    deploysToday: 0,
-  },
-  {
-    id: "jobber",
-    name: "Jobber Logística",
-    slug: "jobber",
-    repo: "turbillon50/jobber-",
-    domain: "jobber.allglobal.ec",
-    stack: "Next 14",
-    status: "live",
-    lastDeploy: "6h",
-    favicon: { gradient: "from-purple-900 to-black", initials: "JL", color: "#BB99FF" },
-    description: "Parcel logistics PWA",
-    secrets: 7,
-    deploysToday: 1,
-  },
-  {
-    id: "sure",
-    name: "Sure & Sure",
-    slug: "sure",
-    repo: "turbillon50/sure-and-sure",
-    domain: null,
-    stack: "Planning",
-    status: "idle",
-    lastDeploy: null,
-    favicon: { gradient: "from-blue-900 to-slate-900", initials: "SS", color: "#88BBFF" },
-    description: "Life insurance premium financing fund",
-    secrets: 0,
-    deploysToday: 0,
-  },
-  {
-    id: "vmomentum",
-    name: "V-Momentum HQ",
-    slug: "vmomentum",
-    repo: "turbillon50/v-momentum",
-    domain: "momentum.allglobal.ec",
-    stack: "Next 14",
-    status: "live",
-    lastDeploy: "12h",
-    favicon: { gradient: "from-pink-900 to-black", initials: "VM", color: "#FF99DD" },
-    description: "App factory for client projects",
-    secrets: 5,
-    deploysToday: 7,
-  },
-];
+// ─────────────────────────────────────────────────────────────────
+// Empty exports — kept so legacy imports don't crash. Pantallas que
+// dependan de estos están siendo migradas a leer de /api/* directo.
+// ─────────────────────────────────────────────────────────────────
 
-export const VAULT_SECRETS: VaultSecret[] = [
-  { name: "STRIPE_SECRET_KEY", project: "castores", lastUsed: "2h", scope: "client", injectedTo: ["vercel", "railway"] },
-  { name: "DATABASE_URL", project: "castores", lastUsed: "1m", scope: "platform", injectedTo: ["vercel"] },
-  { name: "CLERK_SECRET_KEY", project: "castores", lastUsed: "3h", scope: "platform", injectedTo: ["vercel"] },
-  { name: "RESEND_API_KEY", project: "castores", lastUsed: null, scope: "platform", injectedTo: [] },
-  { name: "VERCEL_TOKEN", project: null, lastUsed: "1m", scope: "platform-global", injectedTo: [] },
-  { name: "ANTHROPIC_API_KEY", project: null, lastUsed: "30s", scope: "platform-global", injectedTo: [] },
-  { name: "GITHUB_TOKEN", project: null, lastUsed: "5m", scope: "platform-global", injectedTo: [] },
-  { name: "CLOUDFLARE_API_TOKEN", project: null, lastUsed: "1h", scope: "platform-global", injectedTo: [] },
-];
-
-export const MODULES: Module[] = [
-  { id: "repo-vision", name: "Repo Vision", description: "Diagrama + mockup visual de cualquier repositorio en 2 min.", state: "installed", tags: ["CLAUDE", "MERMAID"], icon: "Eye" },
-  { id: "repo-hunter", name: "Repo Hunter", description: "Búsqueda semántica de repositorios en GitHub, NPM y awesome lists.", state: "installed", tags: ["GITHUB", "NPM"], icon: "Search" },
-  { id: "stack-scout", name: "Stack Scout", description: "Recomendaciones técnicas: qué proveedor usar y cómo conectarlo.", state: "installed", tags: ["RESEARCH"], icon: "Compass" },
-  { id: "health-monitor", name: "Health Monitor", description: "Vigilancia 24/7 de uptime, deploys y errores en producción.", state: "installed", tags: ["SENTRY", "UPTIME"], icon: "Activity" },
-  { id: "contracts", name: "Contracts", description: "NDA, prestación, asociación · firma digital · plantillas MIRMAR.", state: "available", tags: ["DOCX", "PDF", "SIGN"], icon: "FileText" },
-  { id: "billing-sat", name: "Billing SAT 4.0", description: "Facturación electrónica MX automática vía Facturapi.", state: "available", tags: ["SAT", "FACTURAPI"], icon: "DollarSign" },
-  { id: "whatsapp-bot", name: "WhatsApp Bot", description: "Comunicación con clientes vía Twilio · plantillas + auto-reply.", state: "available", tags: ["TWILIO"], icon: "MessageSquare" },
-  { id: "analytics-cross", name: "Analytics Cross", description: "Métricas cruzadas de Stripe, MercadoPago, Ticket Tailor.", state: "beta", tags: ["STRIPE", "MP"], icon: "BarChart" },
-  { id: "backups-vault", name: "Backups Vault", description: "Backups nocturnos cifrados a Cloudflare R2 · retención 30+12.", state: "available", tags: ["R2", "AES256"], icon: "Database" },
-  { id: "client-portal", name: "Client Portal", description: "Portal externo para que clientes vean sus proyectos en vivo.", state: "available", tags: ["AUTH", "CLERK"], icon: "Users" },
-  { id: "legal-monitor", name: "Legal Monitor", description: "Monitoreo semanal de menciones públicas con alertas.", state: "available", tags: ["WEB", "ALERTS"], icon: "Shield" },
-  { id: "tax-tracker", name: "Tax Tracker", description: "Tracker fiscal MIRMAR con OCR de tickets y conciliación bancaria.", state: "beta", tags: ["OCR", "SAT"], icon: "Calculator" },
-];
-
-export const ACTIVITY: ActivityItem[] = [
-  { id: 1, time: "3 min", actor: "Forge", verb: "desplegó", target: "castores.info → producción", kind: "deploy", project: "castores" },
-  { id: 2, time: "12 min", actor: "Luis", verb: "agregó secreto", target: "STRIPE_SECRET_KEY a Castores", kind: "vault", project: "castores" },
-  { id: 3, time: "34 min", actor: "Forge", verb: "falló build en", target: "rivones / autospot.mx", kind: "error", project: "rivones" },
-  { id: 4, time: "1 h", actor: "Forge", verb: "escaneó repo", target: "vandefi (score 9/10)", kind: "vision", project: "vandefi" },
-  { id: 5, time: "2 h", actor: "Health Monitor", verb: "alertó latencia alta en", target: "jobber.allglobal.ec", kind: "warning", project: "jobber" },
-  { id: 6, time: "3 h", actor: "Luis", verb: "creó proyecto", target: "Sure & Sure", kind: "create", project: "sure" },
-  { id: 7, time: "5 h", actor: "Forge", verb: "propuso stack para", target: "V-Momentum HQ", kind: "scout", project: "vmomentum" },
-  { id: 8, time: "6 h", actor: "Forge", verb: "desplegó", target: "jobber.allglobal.ec → producción", kind: "deploy", project: "jobber" },
-  { id: 9, time: "8 h", actor: "Luis", verb: "actualizó dominio de", target: "Movee", kind: "settings", project: "movee" },
-  { id: 10, time: "12 h", actor: "Forge", verb: "desplegó", target: "momentum.allglobal.ec", kind: "deploy", project: "vmomentum" },
-  { id: 11, time: "1 d", actor: "Backups Vault", verb: "completó snapshot de", target: "8 proyectos a R2", kind: "backup", project: null },
-  { id: 12, time: "2 d", actor: "Forge", verb: "refactorizó schema en", target: "URMAH", kind: "refactor", project: "urmah" },
-];
-
-export const RECENT_VISION: RecentVision[] = [
-  { repo: "turbillon50/vandefi", score: "9/10", duration: "1m 47s", time: "1 h" },
-  { repo: "shadcn/ui", score: "10/10", duration: "2m 03s", time: "yesterday" },
-  { repo: "vercel/next.js", score: "10/10", duration: "4m 12s", time: "3 d" },
-];
-
-export const RECENT_HUNTER: RecentHunter[] = [
-  { query: "PWA ticketing offline-first", results: 14, time: "30 min" },
-  { query: "DeFi self-custody wallet React", results: 22, time: "4 h" },
-  { query: "OCR receipt extraction node", results: 9, time: "2 d" },
-];
-
-export const RECENT_SCOUT: RecentScout[] = [
-  { question: "¿Qué proveedor para video chat WebRTC con grabación?", answer: "LiveKit Cloud", time: "1 h" },
-  { question: "¿Cómo cobrar SPEI con conciliación automática?", answer: "Conekta vs MercadoPago", time: "1 d" },
-  { question: "¿Mejor stack para PWA cinematográfica iOS-grade?", answer: "Next 14 + Capacitor + Framer", time: "3 d" },
-];
-
-// Stats for Hub
+export const PROJECTS: Project[] = [];
+export const VAULT_SECRETS: VaultSecret[] = [];
+export const MODULES: Module[] = [];
+export const ACTIVITY: ActivityItem[] = [];
+export const RECENT_VISION: RecentVision[] = [];
+export const RECENT_HUNTER: RecentHunter[] = [];
+export const RECENT_SCOUT: RecentScout[] = [];
 export const HUB_STATS = {
-  activeProjects: { value: 8, delta: "+1 esta semana", tone: "positive" as const },
-  deploysToday: { value: 14, delta: "12 ok · 2 fallidos", tone: "warning" as const },
-  forgeRuns: { value: 47, delta: "avg 1.4 min", tone: "neutral" as const },
-  uptime: { value: "99.84%", delta: "últimos 30 días", tone: "positive" as const },
+  activeProjects: { value: 0, delta: "—" },
+  deploysToday: { value: 0, delta: "—" },
+  forgeRuns: { value: 0, delta: "—" },
+  uptime: { value: "—", delta: "—" },
 };


### PR DESCRIPTION
## Resumen

Luis pidió "tablero en ceros" — vacía la lib/mock-data + TRUNCATE projects en DB. Las pantallas leen de la DB en vivo y muestran empty states con CTA "Dar de alta".

## Pendientes (esperando confirmación de Luis)

- **Conversations**: ¿borro las conversaciones previas con V o conservo?
- **Vault**: ¿migro las 11 env keys a operator_secrets cifrados con UI de copiar?

## Test plan

- [x] `npm run build` verde, 13 rutas prerenderizan
- [x] `tsc --noEmit` 0 errores
- [x] TRUNCATE projects, repo_audits aplicado en producción
- [x] knowledge_base intacto (33 entradas) — V mantiene memoria

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_