### PR TITLE
feat(forge): tools tier 1 — V puede usar GitHub + Vault

### DIFF
--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -27,6 +27,23 @@ function makeSessionId() {
   return `s_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function toolDisplayName(name: string): string {
+  switch (name) {
+    case "github_list_repos":
+      return "Listando repos de GitHub";
+    case "github_get_repo":
+      return "Cargando detalle del repo";
+    case "github_list_commits":
+      return "Cargando commits";
+    case "github_read_file":
+      return "Leyendo archivo del repo";
+    case "vault_list_secrets":
+      return "Listando secrets del Vault";
+    default:
+      return `Ejecutando ${name}`;
+  }
+}
+
 function sessionKeyFor(scope: string) {
   return SESSION_PREFIX + scope;
 }
@@ -186,6 +203,8 @@ export default function ForgePage() {
           try {
             const evt = JSON.parse(line.slice(6)) as
               | { type: "text"; value: string }
+              | { type: "tool_use_start"; id: string; name: string }
+              | { type: "tool_use_result"; id: string; ok: boolean; summary: string }
               | { type: "done"; tokensIn: number; tokensOut: number; model: string }
               | { type: "error"; message: string };
             if (evt.type === "text") {
@@ -193,6 +212,25 @@ export default function ForgePage() {
                 prev.map((m) =>
                   m.id === assistantId
                     ? { ...m, content: m.content + evt.value }
+                    : m,
+                ),
+              );
+            } else if (evt.type === "tool_use_start") {
+              const marker = `\n\n_🔧 ${toolDisplayName(evt.name)}…_\n\n`;
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + marker }
+                    : m,
+                ),
+              );
+            } else if (evt.type === "tool_use_result") {
+              const icon = evt.ok ? "✓" : "⚠";
+              const marker = `_${icon} ${evt.summary}_\n\n`;
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + marker }
                     : m,
                 ),
               );

--- a/app/api/forge/run/route.ts
+++ b/app/api/forge/run/route.ts
@@ -1,6 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
+import type {
+  MessageParam,
+  ToolResultBlockParam,
+} from "@anthropic-ai/sdk/resources/messages";
 import { sql } from "@/lib/db/client";
 import { buildSystemPrompt } from "@/lib/forge/system-prompt";
+import { TOOLS, executeTool } from "@/lib/forge/tools";
 import { getOperatorSecret } from "@/lib/vault/get-secret";
 
 export const runtime = "nodejs";
@@ -15,10 +20,11 @@ interface RunRequest {
   messages: ChatTurn[];
   sessionId: string;
   userId?: string; // defaults to operator_luis until Clerk lands
-  projectId?: string | null; // optional project focus
+  projectId?: string | null;
 }
 
 const OPERATOR_USER_ID = "operator_luis";
+const MAX_TOOL_ROUNDS = 5;
 
 export async function POST(req: Request) {
   let body: RunRequest;
@@ -38,9 +44,6 @@ export async function POST(req: Request) {
     return jsonError("sessionId (string) required", 400);
   }
 
-  // Pull from Vault first, fall back to env. This is V invoking her own
-  // operator secret to call Claude — every read is audited and cached
-  // for 60s in-process.
   const apiKey = await getOperatorSecret("ANTHROPIC_API_KEY", {
     auditUserId: userId,
   });
@@ -53,7 +56,6 @@ export async function POST(req: Request) {
   });
   const lastUserTurn = messages[messages.length - 1];
 
-  // Persist the user turn first
   if (lastUserTurn.role === "user") {
     await sql`
       INSERT INTO conversations (user_id, session_id, role, content)
@@ -63,86 +65,152 @@ export async function POST(req: Request) {
 
   const anthropic = new Anthropic({ apiKey });
 
-  // Convert chat history into Anthropic message shape
-  const anthropicMessages = messages.map((m) => ({
+  // Working copy of the conversation that grows with assistant turns
+  // and tool_result user turns across rounds.
+  const conversationMessages: MessageParam[] = messages.map((m) => ({
     role: m.role,
     content: m.content,
   }));
 
   const encoder = new TextEncoder();
-  let assistantBuffer = "";
-  let usageTokensIn = 0;
-  let usageTokensOut = 0;
 
   const stream = new ReadableStream({
     async start(controller) {
+      const send = (event: Record<string, unknown>) => {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(event)}\n\n`),
+        );
+      };
+
+      let assistantTextBuffer = "";
+      let totalTokensIn = 0;
+      let totalTokensOut = 0;
+      let lastStopReason: string | null = null;
+
       try {
-        const response = await anthropic.messages.stream({
-          model: config.default_model,
-          max_tokens: 2048,
-          system: systemPrompt,
-          messages: anthropicMessages,
-        });
+        for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+          const response = anthropic.messages.stream({
+            model: config.default_model,
+            max_tokens: 2048,
+            system: systemPrompt,
+            tools: TOOLS,
+            messages: conversationMessages,
+          });
 
-        for await (const event of response) {
-          if (event.type === "content_block_delta") {
-            const delta = event.delta;
-            if (delta.type === "text_delta") {
-              assistantBuffer += delta.text;
-              controller.enqueue(
-                encoder.encode(
-                  `data: ${JSON.stringify({ type: "text", value: delta.text })}\n\n`,
-                ),
-              );
+          let roundTokensIn = 0;
+          let roundTokensOut = 0;
+
+          for await (const event of response) {
+            if (event.type === "message_start") {
+              roundTokensIn = event.message.usage?.input_tokens ?? 0;
+            } else if (event.type === "content_block_start") {
+              const block = event.content_block;
+              if (block.type === "tool_use") {
+                send({
+                  type: "tool_use_start",
+                  id: block.id,
+                  name: block.name,
+                });
+              }
+            } else if (event.type === "content_block_delta") {
+              const delta = event.delta;
+              if (delta.type === "text_delta") {
+                assistantTextBuffer += delta.text;
+                send({ type: "text", value: delta.text });
+              }
+            } else if (event.type === "message_delta") {
+              roundTokensOut =
+                event.usage?.output_tokens ?? roundTokensOut;
             }
-          } else if (event.type === "message_start") {
-            usageTokensIn = event.message.usage?.input_tokens ?? 0;
-          } else if (event.type === "message_delta") {
-            usageTokensOut = event.usage?.output_tokens ?? usageTokensOut;
-          } else if (event.type === "message_stop") {
-            // Persist the assistant turn
-            await sql`
-              INSERT INTO conversations (
-                user_id, session_id, role, content, model,
-                tokens_in, tokens_out, cost_usd
-              )
-              VALUES (
-                ${userId}, ${sessionId}, 'assistant', ${assistantBuffer},
-                ${config.default_model},
-                ${usageTokensIn}, ${usageTokensOut},
-                ${estimateCost(config.default_model, usageTokensIn, usageTokensOut)}
-              )
-            `;
-
-            // Audit event
-            await sql`
-              INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
-              VALUES (
-                ${userId}, 'forge.chat.turn', 'conversation', ${sessionId}, 0,
-                ${JSON.stringify({ tokens_in: usageTokensIn, tokens_out: usageTokensOut, model: config.default_model })}::jsonb
-              )
-            `;
-
-            controller.enqueue(
-              encoder.encode(
-                `data: ${JSON.stringify({
-                  type: "done",
-                  tokensIn: usageTokensIn,
-                  tokensOut: usageTokensOut,
-                  model: config.default_model,
-                })}\n\n`,
-              ),
-            );
-            controller.close();
           }
+
+          const finalMessage = await response.finalMessage();
+          totalTokensIn += roundTokensIn;
+          totalTokensOut += roundTokensOut;
+          lastStopReason = finalMessage.stop_reason;
+
+          // Append the assistant turn (with all its blocks) so the next
+          // round sees the tool_use blocks alongside the tool_results.
+          conversationMessages.push({
+            role: "assistant",
+            content: finalMessage.content,
+          });
+
+          if (finalMessage.stop_reason !== "tool_use") {
+            break;
+          }
+
+          // Execute every tool_use block in parallel and collect results.
+          const toolBlocks = finalMessage.content.filter(
+            (b): b is Extract<typeof b, { type: "tool_use" }> =>
+              b.type === "tool_use",
+          );
+          const toolResults: ToolResultBlockParam[] = await Promise.all(
+            toolBlocks.map(async (block) => {
+              const result = await executeTool(
+                block.name,
+                (block.input ?? {}) as Record<string, unknown>,
+                { userId, sessionId },
+              );
+              send({
+                type: "tool_use_result",
+                id: block.id,
+                ok: result.ok,
+                summary: result.summary,
+              });
+              return {
+                type: "tool_result",
+                tool_use_id: block.id,
+                content: result.content,
+                is_error: !result.ok,
+              };
+            }),
+          );
+
+          conversationMessages.push({
+            role: "user",
+            content: toolResults,
+          });
         }
+
+        // Persist the final assistant text (tool intermediate steps are
+        // not replayed on rehydrate; only the visible answer is stored).
+        await sql`
+          INSERT INTO conversations (
+            user_id, session_id, role, content, model,
+            tokens_in, tokens_out, cost_usd
+          )
+          VALUES (
+            ${userId}, ${sessionId}, 'assistant', ${assistantTextBuffer},
+            ${config.default_model},
+            ${totalTokensIn}, ${totalTokensOut},
+            ${estimateCost(config.default_model, totalTokensIn, totalTokensOut)}
+          )
+        `;
+
+        await sql`
+          INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+          VALUES (
+            ${userId}, 'forge.chat.turn', 'conversation', ${sessionId}, 0,
+            ${JSON.stringify({
+              tokens_in: totalTokensIn,
+              tokens_out: totalTokensOut,
+              model: config.default_model,
+              stop_reason: lastStopReason,
+            })}::jsonb
+          )
+        `;
+
+        send({
+          type: "done",
+          tokensIn: totalTokensIn,
+          tokensOut: totalTokensOut,
+          model: config.default_model,
+        });
+        controller.close();
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        controller.enqueue(
-          encoder.encode(
-            `data: ${JSON.stringify({ type: "error", message })}\n\n`,
-          ),
-        );
+        send({ type: "error", message });
         controller.close();
       }
     },
@@ -152,7 +220,7 @@ export async function POST(req: Request) {
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache, no-transform",
-      "Connection": "keep-alive",
+      Connection: "keep-alive",
       "X-Accel-Buffering": "no",
     },
   });
@@ -165,15 +233,19 @@ function jsonError(message: string, status: number): Response {
   });
 }
 
-// Pricing as of April 2026 (USD per 1M tokens). Approximate.
 const PRICING: Record<string, { input: number; output: number }> = {
   "claude-opus-4-7": { input: 15, output: 75 },
   "claude-sonnet-4-6": { input: 3, output: 15 },
   "claude-haiku-4-5": { input: 0.8, output: 4 },
 };
 
-function estimateCost(model: string, tokensIn: number, tokensOut: number): number {
+function estimateCost(
+  model: string,
+  tokensIn: number,
+  tokensOut: number,
+): number {
   const p = PRICING[model] ?? { input: 3, output: 15 };
-  const cost = (tokensIn / 1_000_000) * p.input + (tokensOut / 1_000_000) * p.output;
+  const cost =
+    (tokensIn / 1_000_000) * p.input + (tokensOut / 1_000_000) * p.output;
   return Number(cost.toFixed(6));
 }

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -1,0 +1,299 @@
+/**
+ * Tool registry for V (forge brain).
+ *
+ * Each tool is a small read-only adapter over an existing capability
+ * (GitHub via Octokit, Vault metadata via SQL). All tools require an
+ * authenticated operator user id passed through the execution context;
+ * each call audits a `forge.tool.invoke` event so we can trace what V
+ * did during a turn.
+ */
+import type { Tool } from "@anthropic-ai/sdk/resources/messages";
+import { sql } from "@/lib/db/client";
+import {
+  listAllUserRepos,
+  getRepo,
+  listRecentCommits,
+  getFileContent,
+} from "@/lib/github/client";
+
+export const TOOLS: Tool[] = [
+  {
+    name: "github_list_repos",
+    description:
+      "Lista los repositorios de GitHub visibles para el PAT del operador (públicos y privados). Devuelve full_name, descripción, lenguaje, último push, archived, fork, stars, html_url. Úsala cuando Luis pregunte qué repos tiene, qué proyectos hay en su GitHub, o quiera ver actividad reciente del catálogo.",
+    input_schema: {
+      type: "object",
+      properties: {
+        max: {
+          type: "number",
+          description: "Cuántos repos devolver (1-200, default 50)",
+        },
+      },
+    },
+  },
+  {
+    name: "github_get_repo",
+    description:
+      "Detalle de un repo específico: descripción, lenguaje, license, default_branch, stars, forks, open_issues, archived, etc. Úsala cuando Luis pregunte por un repo concreto por nombre.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: {
+          type: "string",
+          description: "Owner del repo (user u organización)",
+        },
+        repo: { type: "string", description: "Nombre del repo" },
+      },
+      required: ["owner", "repo"],
+    },
+  },
+  {
+    name: "github_list_commits",
+    description:
+      "Últimos commits de un repo (sha, mensaje, autor, fecha). Úsala cuando Luis pregunte qué hizo recientemente, qué actividad hay, qué cambios se hicieron en un repo.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        limit: {
+          type: "number",
+          description: "Máximo de commits a devolver (1-50, default 20)",
+        },
+      },
+      required: ["owner", "repo"],
+    },
+  },
+  {
+    name: "github_read_file",
+    description:
+      "Lee el contenido de un archivo de un repo (README, package.json, configs, etc.). El contenido se trunca a 5KB para no inflar el contexto.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        path: {
+          type: "string",
+          description: "Ruta relativa del archivo en el repo (ej. 'README.md')",
+        },
+        branch: {
+          type: "string",
+          description: "Branch a leer (default: el default branch del repo)",
+        },
+      },
+      required: ["owner", "repo", "path"],
+    },
+  },
+  {
+    name: "vault_list_secrets",
+    description:
+      "Lista los METADATOS de los secrets del vault del operador: nombre, provider, descripción, fecha de creación, último uso. NUNCA devuelve los valores plaintext — solo la lista. Úsala cuando Luis pregunte qué keys tiene guardadas, qué providers están configurados, qué hay en su Vault.",
+    input_schema: {
+      type: "object",
+      properties: {},
+    },
+  },
+];
+
+export interface ToolExecutionContext {
+  userId: string;
+  sessionId: string;
+}
+
+export interface ToolExecutionResult {
+  ok: boolean;
+  /** JSON string body returned to Claude as tool_result content */
+  content: string;
+  /** Short human-readable summary surfaced to the chat UI */
+  summary: string;
+}
+
+export async function executeTool(
+  name: string,
+  input: Record<string, unknown>,
+  ctx: ToolExecutionContext,
+): Promise<ToolExecutionResult> {
+  const startedAt = Date.now();
+  let result: ToolExecutionResult;
+  try {
+    result = await dispatch(name, input, ctx);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    result = {
+      ok: false,
+      content: JSON.stringify({ error: message }),
+      summary: `error: ${message.slice(0, 80)}`,
+    };
+  }
+  const durationMs = Date.now() - startedAt;
+
+  // Best-effort audit; never block the tool result on a failed insert.
+  try {
+    await sql`
+      INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+      VALUES (
+        ${ctx.userId}, 'forge.tool.invoke', 'tool', ${name}, 0,
+        ${JSON.stringify({
+          tool: name,
+          input: redactInput(input),
+          ok: result.ok,
+          summary: result.summary,
+          duration_ms: durationMs,
+          session_id: ctx.sessionId,
+        })}::jsonb
+      )
+    `;
+  } catch {
+    /* audit failures must not break the chat turn */
+  }
+  return result;
+}
+
+async function dispatch(
+  name: string,
+  input: Record<string, unknown>,
+  ctx: ToolExecutionContext,
+): Promise<ToolExecutionResult> {
+  switch (name) {
+    case "github_list_repos": {
+      const max = clampNumber(input.max, 1, 200, 50);
+      const repos = await listAllUserRepos({
+        max,
+        auditUserId: ctx.userId,
+      });
+      const slim = repos.map((r) => ({
+        full_name: r.full_name,
+        private: r.private,
+        archived: r.archived,
+        fork: r.fork,
+        description: r.description,
+        language: r.language,
+        default_branch: r.default_branch,
+        pushed_at: r.pushed_at,
+        stargazers_count: r.stargazers_count,
+        open_issues_count: r.open_issues_count,
+        html_url: r.html_url,
+      }));
+      return {
+        ok: true,
+        content: JSON.stringify({ total: slim.length, repos: slim }),
+        summary: `${slim.length} repos`,
+      };
+    }
+    case "github_get_repo": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const detail = await getRepo(owner, repo, {
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify(detail),
+        summary: `${owner}/${repo}`,
+      };
+    }
+    case "github_list_commits": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const limit = clampNumber(input.limit, 1, 50, 20);
+      const commits = await listRecentCommits(owner, repo, {
+        limit,
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify({ total: commits.length, commits }),
+        summary: `${commits.length} commits de ${owner}/${repo}`,
+      };
+    }
+    case "github_read_file": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const path = requireString(input.path, "path");
+      const branch =
+        typeof input.branch === "string" && input.branch.length > 0
+          ? input.branch
+          : undefined;
+      const file = await getFileContent(owner, repo, path, {
+        branch,
+        auditUserId: ctx.userId,
+      });
+      const MAX_BYTES = 5000;
+      const truncated = file.content.length > MAX_BYTES;
+      const slice = truncated ? file.content.slice(0, MAX_BYTES) : file.content;
+      return {
+        ok: true,
+        content: JSON.stringify({
+          path,
+          size: file.size,
+          sha: file.sha,
+          truncated,
+          content: slice,
+        }),
+        summary: `${path} (${file.size} B${truncated ? ", truncado a 5KB" : ""})`,
+      };
+    }
+    case "vault_list_secrets": {
+      const rows = (await sql`
+        SELECT name, provider, description, created_at, last_used_at
+        FROM operator_secrets
+        ORDER BY name
+      `) as Array<{
+        name: string;
+        provider: string | null;
+        description: string | null;
+        created_at: Date | string;
+        last_used_at: Date | string | null;
+      }>;
+      return {
+        ok: true,
+        content: JSON.stringify({ total: rows.length, secrets: rows }),
+        summary: `${rows.length} secrets`,
+      };
+    }
+    default:
+      return {
+        ok: false,
+        content: JSON.stringify({ error: `Unknown tool: ${name}` }),
+        summary: `unknown tool: ${name}`,
+      };
+  }
+}
+
+function clampNumber(
+  v: unknown,
+  min: number,
+  max: number,
+  def: number,
+): number {
+  const n = typeof v === "number" ? v : parseInt(String(v ?? ""), 10);
+  if (Number.isNaN(n)) return def;
+  return Math.min(Math.max(n, min), max);
+}
+
+function requireString(v: unknown, name: string): string {
+  if (typeof v !== "string" || v.length === 0) {
+    throw new Error(`'${name}' must be a non-empty string`);
+  }
+  return v;
+}
+
+/**
+ * Strip values that might leak secrets if logged. Tool inputs for the
+ * Tier-1 read-only set are safe (owner/repo/path), but we keep this
+ * defensive.
+ */
+function redactInput(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const safe: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (typeof v === "string" && v.length > 200) {
+      safe[k] = `${v.slice(0, 80)}…(truncated)`;
+    } else {
+      safe[k] = v;
+    }
+  }
+  return safe;
+}


### PR DESCRIPTION
## Summary

V ahora puede **ejecutar** 5 tools read-only (ring 0) durante una conversación, no solo describirlas. Resuelve el bug que Luis vio en el screenshot donde V dijo "no tengo tools activas cableadas".

| Tool | Qué hace |
|---|---|
| `github_list_repos` | Lista los repos del PAT (full_name, lang, archived, fork, pushed_at, stars) |
| `github_get_repo` | Detalle de 1 repo (license, forks, open_issues, etc.) |
| `github_list_commits` | Últimos commits de un repo |
| `github_read_file` | Lee un archivo (truncado a 5KB) |
| `vault_list_secrets` | **Metadatos** del vault — NUNCA plaintext |

## Cómo funciona

- Loop de tool-use con `MAX_TOOL_ROUNDS=5` por turno; ejecutamos los `tool_use` blocks en paralelo (`Promise.all`) y mandamos `tool_result` de vuelta a Claude.
- La UI recibe eventos `tool_use_start` / `tool_use_result` y los renderiza inline como italic markdown markers (`🔧 Listando repos…` / `✓ 34 repos`).
- Cada ejecución audita `forge.tool.invoke` con duration_ms, ok, summary y session_id.
- Solo se persiste el texto final del assistant — los bloques `tool_use` intermedios no se replayan en rehidrate (Claude los regenera).

## Seguridad

- Tools son **read-only**, ring 0. Sin escritura.
- `vault_list_secrets` devuelve solo metadatos. Ningún plaintext de secret pasa por el modelo.
- `github_read_file` trunca a 5KB para no inflar contexto ni leakear archivos enormes.
- `GITHUB_TOKEN` se sigue sacando del vault vía `requireOperatorSecret` que audita la lectura.

## Test plan

- [ ] `/forge` → "qué repos tengo?" → V llama `github_list_repos` y resume el catálogo
- [ ] `/forge` → "qué hice ayer en VanDeFi?" → V llama `github_list_commits`
- [ ] `/forge` → "qué keys tengo en el vault?" → V llama `vault_list_secrets`
- [ ] Eventos tool_use_start/result se ven inline en la respuesta
- [ ] Audit logs en audit_events con `forge.tool.invoke`

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_