### PR TITLE
feat(forge): memoria cross-sesión — recaps + memory_save

### DIFF
--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -67,6 +67,7 @@ export default function ForgePage() {
   const [messages, setMessages] = useState<ChatMessageData[]>([WELCOME_GENERAL]);
   const [streaming, setStreaming] = useState(false);
   const [hydrating, setHydrating] = useState(true);
+  const [savingMemory, setSavingMemory] = useState(false);
   const sessionIdRef = useRef<string>("");
 
   // Load scope from storage and project list on first mount.
@@ -131,10 +132,75 @@ export default function ForgePage() {
   }
 
   function newSession() {
+    // Fire-and-forget recap on the previous session before swapping in
+    // a fresh sessionId. This is what gives V cross-session memory.
+    const previousSessionId = sessionIdRef.current;
+    if (previousSessionId) {
+      void fetch("/api/forge/recap", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: previousSessionId,
+          projectId: scope === "general" ? null : scope,
+        }),
+        keepalive: true,
+      }).catch(() => undefined);
+    }
     const sid = makeSessionId();
     localStorage.setItem(sessionKeyFor(scope), sid);
     sessionIdRef.current = sid;
     setMessages([welcomeFor(scope)]);
+  }
+
+  async function saveMemoryNow() {
+    if (!sessionIdRef.current || streaming) return;
+    setSavingMemory(true);
+    try {
+      const res = await fetch("/api/forge/recap", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: sessionIdRef.current,
+          projectId: scope === "general" ? null : scope,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        title?: string;
+        reason?: string;
+      };
+      if (data.ok) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `m_${Date.now()}`,
+            role: "forge",
+            content: `_💾 Memoria guardada: **${data.title}**. Estará disponible en futuras sesiones._`,
+          },
+        ]);
+      } else {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `m_${Date.now()}`,
+            role: "forge",
+            content: `_💾 ${data.reason ?? "no se guardó"}_`,
+          },
+        ]);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `m_${Date.now()}`,
+          role: "forge",
+          content: `_⚠ Error guardando memoria: ${message}_`,
+        },
+      ]);
+    } finally {
+      setSavingMemory(false);
+    }
   }
 
   const handleSend = async (
@@ -311,9 +377,18 @@ export default function ForgePage() {
         <div className="flex items-center gap-3 flex-shrink-0">
           <button
             type="button"
+            onClick={saveMemoryNow}
+            disabled={streaming || savingMemory || hydrating}
+            className="text-xs text-vf-fg-2 hover:text-vf-fg transition-colors disabled:opacity-40"
+            title="Guardar la sesión actual en la memoria persistente de V"
+          >
+            {savingMemory ? "Guardando…" : "💾 Memoria"}
+          </button>
+          <button
+            type="button"
             onClick={newSession}
             className="text-xs text-vf-fg-2 hover:text-vf-fg transition-colors"
-            title="Empezar una conversación nueva en este modo"
+            title="Empezar una conversación nueva (guarda recap automáticamente)"
           >
             Nueva
           </button>

--- a/app/api/forge/recap/route.ts
+++ b/app/api/forge/recap/route.ts
@@ -1,0 +1,183 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { sql } from "@/lib/db/client";
+import { getOperatorSecret } from "@/lib/vault/get-secret";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface RecapRequest {
+  sessionId: string;
+  userId?: string;
+  projectId?: string | null;
+}
+
+const OPERATOR_USER_ID = "operator_luis";
+const RECAP_MODEL = "claude-haiku-4-5"; // cheap + fast
+const MIN_TURNS_FOR_RECAP = 2; // skip empty/single-turn sessions
+
+/**
+ * POST /api/forge/recap
+ * Body: { sessionId, projectId? }
+ *
+ * Reads the conversation for `sessionId`, asks Haiku for a 3-5 bullet
+ * recap, and stores it as a tagged knowledge_base entry so future
+ * sessions inherit the context. Idempotent: if a recap for this session
+ * already exists it gets replaced (sessions are append-only, so the
+ * later recap is always at least as informative).
+ */
+export async function POST(req: Request) {
+  let body: RecapRequest;
+  try {
+    body = (await req.json()) as RecapRequest;
+  } catch {
+    return jsonError("Invalid JSON body", 400);
+  }
+  const { sessionId } = body;
+  const userId = body.userId ?? OPERATOR_USER_ID;
+  if (!sessionId || typeof sessionId !== "string") {
+    return jsonError("sessionId (string) required", 400);
+  }
+
+  const turns = (await sql`
+    SELECT role, content, created_at
+    FROM conversations
+    WHERE session_id = ${sessionId} AND user_id = ${userId}
+    ORDER BY created_at ASC
+  `) as Array<{ role: string; content: string; created_at: Date | string }>;
+
+  if (turns.length < MIN_TURNS_FOR_RECAP) {
+    return new Response(
+      JSON.stringify({ ok: false, reason: "session too short to recap" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const apiKey = await getOperatorSecret("ANTHROPIC_API_KEY", {
+    auditUserId: userId,
+  });
+  if (!apiKey) return jsonError("ANTHROPIC_API_KEY not configured", 500);
+
+  const transcript = turns
+    .map((t) => `${t.role === "user" ? "Luis" : "V"}: ${t.content}`)
+    .join("\n\n");
+
+  const prompt = `Eres V, asistente digital de Luis. Acaba de cerrarse una sesión de conversación. Genera un RECAP estructurado de la sesión que se guardará en tu memoria persistente para que futuras sesiones tengan contexto.
+
+Estructura del recap (markdown, sin encabezados de nivel 1):
+
+**Tema principal**
+1 oración que resume de qué fue la sesión.
+
+**Decisiones / acuerdos**
+- Bullet con cada decisión concreta tomada
+- (omite esta sección si no hubo decisiones)
+
+**Acciones pendientes**
+- Lo que quedó por hacer, con responsable si aplica
+- (omite si no hay)
+
+**Aprendizajes / cosas a recordar**
+- Información que vale la pena retener para futuras conversaciones
+- Preferencias del operador, datos sobre proyectos, etc.
+
+Reglas:
+- Máximo 250 palabras total.
+- Sé concreto, sin paja, sin "discutimos" ni meta-comentario.
+- Si la sesión fue trivial o sin sustancia, devuelve solo: "Sesión sin contenido relevante para retener."
+- Idioma: español MX, mismo tono que Luis usa contigo.
+
+Transcript:
+
+${transcript}`;
+
+  const anthropic = new Anthropic({ apiKey });
+  let recapText: string;
+  try {
+    const response = await anthropic.messages.create({
+      model: RECAP_MODEL,
+      max_tokens: 600,
+      messages: [{ role: "user", content: prompt }],
+    });
+    const block = response.content.find((b) => b.type === "text");
+    recapText = block && block.type === "text" ? block.text.trim() : "";
+  } catch (err) {
+    return jsonError(
+      `recap generation failed: ${err instanceof Error ? err.message : String(err)}`,
+      502,
+    );
+  }
+
+  if (
+    !recapText ||
+    /^sesi[oó]n sin contenido/i.test(recapText.split("\n")[0] ?? "")
+  ) {
+    return new Response(
+      JSON.stringify({ ok: false, reason: "session not relevant" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const firstTurn = turns[0];
+  const lastTurn = turns[turns.length - 1];
+  const dateLabel = formatDateLabel(firstTurn.created_at);
+  const title = `Sesión ${dateLabel} (${turns.length} turnos)`;
+  const tags = ["session_recap", sessionId];
+  if (body.projectId) tags.push(`project:${body.projectId}`);
+
+  // Replace any earlier recap for this same session
+  await sql`
+    DELETE FROM knowledge_base
+    WHERE kind = 'note' AND ${sessionId} = ANY(tags)
+  `;
+
+  const inserted = (await sql`
+    INSERT INTO knowledge_base (kind, title, content, tags, source, created_by)
+    VALUES (
+      'note', ${title}, ${recapText},
+      ${tags as unknown as string[]}, ${`session:${sessionId}`}, ${userId}
+    )
+    RETURNING id, created_at
+  `) as Array<{ id: string; created_at: Date | string }>;
+
+  await sql`
+    INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+    VALUES (
+      ${userId}, 'forge.recap', 'session', ${sessionId}, 0,
+      ${JSON.stringify({
+        turns: turns.length,
+        first_turn: firstTurn.created_at,
+        last_turn: lastTurn.created_at,
+        recap_id: inserted[0]?.id,
+      })}::jsonb
+    )
+  `;
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      recap: recapText,
+      title,
+      id: inserted[0]?.id,
+      tags,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}
+
+function formatDateLabel(input: Date | string): string {
+  const d = typeof input === "string" ? new Date(input) : input;
+  return d.toISOString().slice(0, 10);
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -69,6 +69,23 @@ export async function buildSystemPrompt(
      LIMIT 10`,
   );
 
+  // Cross-session memory: last 8 recaps + last 8 manual memories. Tagged
+  // 'session_recap' or 'memory' on a kind='note' row (we keep them on
+  // the same kind to avoid touching the CHECK constraint, and lean on
+  // tags + the partial index for retrieval).
+  const recaps = await queryAll<KnowledgeEntry>(
+    `SELECT kind, title, content, tags FROM knowledge_base
+     WHERE kind = 'note' AND 'session_recap' = ANY(tags)
+     ORDER BY created_at DESC
+     LIMIT 8`,
+  );
+  const memories = await queryAll<KnowledgeEntry>(
+    `SELECT kind, title, content, tags FROM knowledge_base
+     WHERE kind = 'note' AND 'memory' = ANY(tags)
+     ORDER BY created_at DESC
+     LIMIT 8`,
+  );
+
   // Project catalog summary
   const projectSummary = await queryAll<{
     category: string;
@@ -96,6 +113,7 @@ export async function buildSystemPrompt(
   }
 
   const knowledgeSection = formatKnowledge([...coreKnowledge, ...lessons]);
+  const memorySection = formatMemorySection(recaps, memories);
   const projectSection = formatProjects(projectSummary);
   const focusSection = projectFocus
     ? [
@@ -128,6 +146,8 @@ export async function buildSystemPrompt(
     "─────────────────────────────────────────",
     knowledgeSection,
     "",
+    memorySection,
+    "",
     "─────────────────────────────────────────",
     "CATÁLOGO DE PROYECTOS (real, cross-checked GitHub + Vercel)",
     "─────────────────────────────────────────",
@@ -156,6 +176,46 @@ function formatKnowledge(entries: KnowledgeEntry[]): string {
         `[${e.kind}] ${e.title}\n${e.content}\n(tags: ${e.tags.join(", ")})`,
     )
     .join("\n\n");
+}
+
+function formatMemorySection(
+  recaps: KnowledgeEntry[],
+  memories: KnowledgeEntry[],
+): string {
+  const blocks: string[] = [
+    "─────────────────────────────────────────",
+    "MEMORIA CROSS-SESIÓN — RECAPS + DATOS GUARDADOS",
+    "─────────────────────────────────────────",
+  ];
+  if (recaps.length === 0 && memories.length === 0) {
+    blocks.push("(aún no hay recaps ni memorias guardadas)");
+    return blocks.join("\n");
+  }
+  if (memories.length > 0) {
+    blocks.push("Memorias explícitas (lo que Luis pidió que recordaras o tú decidiste guardar con memory_save):");
+    blocks.push(
+      memories
+        .map((m) => `• ${m.title}\n  ${m.content}`)
+        .join("\n\n"),
+    );
+  }
+  if (recaps.length > 0) {
+    if (memories.length > 0) blocks.push("");
+    blocks.push("Recaps de sesiones anteriores (más reciente primero):");
+    blocks.push(
+      recaps
+        .map((r) => `• ${r.title}\n${indent(r.content, "  ")}`)
+        .join("\n\n"),
+    );
+  }
+  return blocks.join("\n");
+}
+
+function indent(text: string, pad: string): string {
+  return text
+    .split("\n")
+    .map((line) => `${pad}${line}`)
+    .join("\n");
 }
 
 function formatProjects(

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -94,6 +94,32 @@ export const TOOLS: Tool[] = [
       properties: {},
     },
   },
+  {
+    name: "memory_save",
+    description:
+      "Guarda un dato concreto en TU memoria persistente para que esté disponible en futuras conversaciones (cualquier sesión, cualquier dispositivo). Úsala cuando Luis te diga 'recuerda que…', 'guarda esto', o cuando notes una preferencia/decisión/dato relevante que valga la pena retener (ej: 'el broker de Break es IBKR'). NO la uses para conversación trivial — solo para datos que aporten contexto en el futuro.",
+    input_schema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "Título corto del dato (3-8 palabras)",
+        },
+        content: {
+          type: "string",
+          description:
+            "Contenido completo a recordar (1-2 párrafos máximo)",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Tags para clasificar la memoria (ej: ['preferencia', 'break', 'broker'])",
+        },
+      },
+      required: ["title", "content"],
+    },
+  },
 ];
 
 export interface ToolExecutionContext {
@@ -250,6 +276,27 @@ async function dispatch(
         ok: true,
         content: JSON.stringify({ total: rows.length, secrets: rows }),
         summary: `${rows.length} secrets`,
+      };
+    }
+    case "memory_save": {
+      const title = requireString(input.title, "title").slice(0, 200);
+      const content = requireString(input.content, "content").slice(0, 4000);
+      const rawTags = Array.isArray(input.tags) ? input.tags : [];
+      const tags = ["memory", ...rawTags.map((t) => String(t).slice(0, 60))];
+      const inserted = (await sql`
+        INSERT INTO knowledge_base (kind, title, content, tags, source, created_by)
+        VALUES (
+          'note', ${title}, ${content},
+          ${tags as unknown as string[]},
+          ${`memory_save:${ctx.sessionId}`},
+          ${ctx.userId}
+        )
+        RETURNING id
+      `) as Array<{ id: string }>;
+      return {
+        ok: true,
+        content: JSON.stringify({ saved: true, id: inserted[0]?.id, title }),
+        summary: `memoria: ${title}`,
       };
     }
     default:


### PR DESCRIPTION
## Summary

Hasta ahora V recordaba todo de la sesión actual pero **arrancaba fresca** en cualquier conversación nueva (otro device, "Nueva", cambio de scope). Esto cablea **memoria persistente cross-sesión**.

## 3 piezas

### 1. `POST /api/forge/recap`
- Lee todos los turnos de un `sessionId`, pide a **Haiku** un recap estructurado (tema, decisiones, pendientes, aprendizajes — 250 palabras max)
- Lo guarda como `knowledge_base` row `kind='note'` + tag `session_recap`
- Idempotente: borra recap previo del mismo session antes de insertar
- Si la sesión es trivial (<2 turnos) o sin sustancia, NO guarda

### 2. Tool `memory_save`
- V puede invocarla cuando Luis dice "recuerda que…" o detecta algo importante
- Inserta `kind='note'` + tag `memory`
- Audit-loggeada en `audit_events`

### 3. `buildSystemPrompt` carga automática
- Trae últimos 8 recaps + 8 memorias en cada turno
- Sección nueva "MEMORIA CROSS-SESIÓN" en el system prompt
- Cualquier sesión nueva arranca con ese contexto

## UI

- Botón **💾 Memoria** en header de `/forge` → guarda la sesión actual como recap explícito
- **"Nueva"** ahora dispara recap fire-and-forget de la sesión previa antes de generar nuevo sessionId (`keepalive: true`)

## Decisión de schema

NO extiendo el `CHECK` constraint de `knowledge_base.kind`. Uso `kind='note'` con tags semánticos (`session_recap`, `memory`). Cero migración SQL, mismo poder de filtrado vía GIN index existente.

## Test plan

- [ ] Conversación nueva → presionar "💾 Memoria" → ver mensaje "Memoria guardada"
- [ ] Click "Nueva" → recap fire-and-forget en background
- [ ] Sesión nueva → preguntar a V "qué hablamos antes?" → debe recordar de los recaps
- [ ] Pedir a V "recuerda que el broker de Break es IBKR" → V invoca `memory_save`
- [ ] En sesión totalmente nueva, V todavía recuerda IBKR

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_