### PR TITLE
feat(forge): full kit — Vercel + Name.com + senior-engineer + protocolos

### DIFF
--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -39,6 +39,36 @@ function toolDisplayName(name: string): string {
       return "Leyendo archivo del repo";
     case "vault_list_secrets":
       return "Listando secrets del Vault";
+    case "memory_save":
+      return "Guardando en memoria";
+    case "vercel_list_projects":
+      return "Listando proyectos de Vercel";
+    case "vercel_get_project":
+      return "Cargando proyecto de Vercel";
+    case "vercel_create_project":
+      return "Creando proyecto en Vercel";
+    case "vercel_list_deployments":
+      return "Listando deployments";
+    case "vercel_get_deployment":
+      return "Cargando deployment";
+    case "vercel_trigger_deployment":
+      return "Disparando deployment";
+    case "vercel_set_env_var":
+      return "Configurando env var";
+    case "vercel_add_domain":
+      return "Agregando dominio a Vercel";
+    case "vercel_get_domain_config":
+      return "Pidiendo config DNS a Vercel";
+    case "namecom_list_domains":
+      return "Listando dominios de Name.com";
+    case "namecom_get_domain":
+      return "Cargando dominio";
+    case "namecom_list_records":
+      return "Listando registros DNS";
+    case "namecom_upsert_record":
+      return "Configurando registro DNS";
+    case "namecom_delete_record":
+      return "Borrando registro DNS";
     default:
       return `Ejecutando ${name}`;
   }

--- a/app/api/admin/migrate/route.ts
+++ b/app/api/admin/migrate/route.ts
@@ -1,0 +1,153 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { sql } from "@/lib/db/client";
+import {
+  requireOperatorAuth,
+  authFailureResponse,
+} from "@/lib/auth/operator-token";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/migrate
+ *
+ * One-shot admin endpoint to apply any pending SQL migrations from
+ * the `migrations/` directory. Idempotent: each migration is keyed
+ * on its filename in the schema_migrations table; if it's already
+ * applied, it's skipped.
+ *
+ * Bearer-token protected (operator only). Useful for one-off seeds
+ * or schema changes between deploys without having to manually open
+ * a Neon SQL editor.
+ *
+ * Splits SQL on `;` but respects DO $$…$$ blocks.
+ */
+export async function POST(req: Request) {
+  const auth = requireOperatorAuth(req);
+  if (!auth.ok) return authFailureResponse(auth);
+
+  const migrationsDir = path.resolve(process.cwd(), "migrations");
+  let entries: string[];
+  try {
+    entries = readdirSync(migrationsDir)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+  } catch (err) {
+    return jsonError(
+      `Cannot read migrations dir: ${err instanceof Error ? err.message : err}`,
+      500,
+    );
+  }
+
+  const applied = (await sql`SELECT version FROM schema_migrations`) as Array<{
+    version: string;
+  }>;
+  const appliedSet = new Set(applied.map((r) => r.version));
+
+  const results: Array<{
+    file: string;
+    version: string;
+    status: "skipped" | "applied" | "error";
+    message?: string;
+    statements?: number;
+  }> = [];
+
+  for (const file of entries) {
+    const version = file.replace(/\.sql$/, "");
+    if (appliedSet.has(version)) {
+      results.push({ file, version, status: "skipped" });
+      continue;
+    }
+    const filePath = path.join(migrationsDir, file);
+    let body: string;
+    try {
+      body = readFileSync(filePath, "utf8");
+    } catch (err) {
+      results.push({
+        file,
+        version,
+        status: "error",
+        message: `read failed: ${err instanceof Error ? err.message : err}`,
+      });
+      continue;
+    }
+
+    const statements = splitSql(body);
+    try {
+      for (const stmt of statements) {
+        await sql.query(stmt);
+      }
+      results.push({
+        file,
+        version,
+        status: "applied",
+        statements: statements.length,
+      });
+    } catch (err) {
+      results.push({
+        file,
+        version,
+        status: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+      // Stop on first error so we don't apply later migrations on top
+      // of a broken state.
+      break;
+    }
+  }
+
+  await sql`
+    INSERT INTO audit_events (user_id, action, resource_type, ring, payload)
+    VALUES (${auth.userId}, 'admin.migrate', 'database', 2,
+      ${JSON.stringify({ results })}::jsonb)
+  `;
+
+  return new Response(JSON.stringify({ results }, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+/**
+ * Split SQL on `;` while respecting `DO $$ ... $$;` and quoted strings.
+ * Naive but handles our migration style.
+ */
+function splitSql(input: string): string[] {
+  const out: string[] = [];
+  let buf = "";
+  let inDollar = false;
+  let inSingle = false;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    const next2 = input.slice(i, i + 2);
+    if (!inSingle && next2 === "$$") {
+      inDollar = !inDollar;
+      buf += "$$";
+      i += 1;
+      continue;
+    }
+    if (!inDollar && ch === "'") {
+      inSingle = !inSingle;
+    }
+    buf += ch;
+    if (!inDollar && !inSingle && ch === ";") {
+      const trimmed = buf.trim();
+      if (trimmed && !trimmed.startsWith("--")) out.push(trimmed);
+      buf = "";
+    }
+  }
+  const tail = buf.trim();
+  if (tail && !tail.startsWith("--")) out.push(tail);
+  return out;
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -141,6 +141,8 @@ export async function buildSystemPrompt(
   const systemPrompt = [
     config.ai_personality,
     "",
+    SENIOR_ENGINEER_DOCTRINE,
+    "",
     "─────────────────────────────────────────",
     "MEMORIA — CONOCIMIENTO PERSISTENTE",
     "─────────────────────────────────────────",
@@ -167,6 +169,72 @@ export async function buildSystemPrompt(
 
   return { systemPrompt, config };
 }
+
+/**
+ * Doctrina de senior engineer / mejor programador del mundo.
+ * Inyectada al inicio del system prompt para que V opere con
+ * mentalidad de ejecución, no de orientación.
+ */
+const SENIOR_ENGINEER_DOCTRINE = `─────────────────────────────────────────
+DOCTRINA — CÓMO OPERAS (mejor programador del mundo)
+─────────────────────────────────────────
+
+EJECUTA, NO ORIENTES
+- Tienes tools reales: GitHub, Vercel, Name.com, Vault, memoria. Úsalas.
+- Cuando Luis pregunte "qué repos tengo" → llama github_list_repos, no le digas "ve a github.com".
+- Cuando pida desplegar algo → vercel_create_project + vercel_trigger_deployment.
+- Cuando pida apuntar dominio → vercel_add_domain + vercel_get_domain_config + namecom_upsert_record.
+- Si una tool puede contestar la pregunta, llámala antes de opinar.
+
+LEE ANTES DE OPINAR
+- Antes de diagnosticar un repo: github_get_repo + github_read_file (README, package.json, vite.config).
+- Antes de tocar Vercel: vercel_get_project para ver framework + rootDirectory + outputDirectory reales.
+- Antes de cambiar DNS: namecom_list_records para ver el estado actual + vercel_get_domain_config para saber qué necesita.
+- No inventes paths, env vars o configs — léelos.
+
+CITA ARCHIVOS COMO path:line
+- "El bug está en artifacts/autospot/vite.config.ts:42 (outDir = 'dist/public' pero Vercel buscaba 'dist')"
+- Esto vale más que un párrafo abstracto.
+
+PARCHE MÍNIMO > REWRITE
+- Si rescate de un repo: prefiere editar 3 líneas a regenerar todo.
+- Solo rewrite si el stack está irrecuperable.
+- Trade-offs explícitos: "patch toma 10 min y mantiene historial; rewrite toma 4 horas y limpia tech debt".
+
+NO BACKWARDS-COMPAT INNECESARIA
+- Si un cambio no requiere migración, no la metas.
+- Si una variable no se usa, bórrala (no la renombres con _).
+- Si un comentario explica el QUÉ, bórralo. Solo deja comentarios cuando expliquen el PORQUÉ no obvio.
+
+ERRORES → ROOT CAUSE
+- No tapes con try/catch genérico. Diagnostica.
+- No agregues fallbacks para casos imposibles.
+- Si un build falla: lee el log, identifica la línea, propón el fix exacto.
+
+CONFIRMACIONES SOLO PARA RING 2+
+- Ring 0 (read): ejecuta directo.
+- Ring 1 (write en recursos del operador): ejecuta y reporta.
+- Ring 2 (destructivo, costoso, afecta a terceros): pregunta antes.
+- No pidas permiso para listar repos, leer archivos, crear deploys nuevos.
+
+RECUERDA
+- Cuando Luis te diga "recuerda que…" → llama memory_save.
+- Cuando termine una sesión importante → recap automático ya cablea, pero si hay un dato clave, memory_save adicional.
+- Cuando notes un patrón ("siempre prefiere X") → memory_save como preferencia.
+
+TONO
+- Cálido y camarada, en español MX.
+- Sin jerga corporativa. Sin "discutimos" ni meta-comentario.
+- Concreto: "lo hago" > "podríamos considerar hacer".
+- Si Luis está hyped, eleva la energía. Si está cansado, sé breve.
+- No le des 5 opciones cuando pide la más simple. Dale UNA recomendación con su trade-off.
+
+MÉTODO vForge (recordatorio rápido)
+- 3-Layer Development Model: descriptive prompt → JSX literal → direct code.
+- Protocolos: NUEVO (proyecto desde cero), RESCATE (repo roto existente), HUNTER (búsqueda externa).
+- Day-1 reset: nuevos proyectos arrancan con DB limpia.
+- Method docs en docs/method.md.
+- Cuando Luis pida "modo X", ese es el protocolo.`;
 
 function formatKnowledge(entries: KnowledgeEntry[]): string {
   if (entries.length === 0) return "(sin entradas)";

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -1,11 +1,17 @@
 /**
  * Tool registry for V (forge brain).
  *
- * Each tool is a small read-only adapter over an existing capability
- * (GitHub via Octokit, Vault metadata via SQL). All tools require an
- * authenticated operator user id passed through the execution context;
- * each call audits a `forge.tool.invoke` event so we can trace what V
- * did during a turn.
+ * Each tool is a small adapter over an existing capability (GitHub
+ * via Octokit, Vault metadata via SQL, Vercel REST API, Name.com REST
+ * API, knowledge_base SQL). All tools require an authenticated
+ * operator user id passed through the execution context; each call
+ * audits a `forge.tool.invoke` event so we can trace what V did
+ * during a turn.
+ *
+ * Privilege rings:
+ *   ring 0  read-only, auto-allowed
+ *   ring 1  write side-effects in operator's own resources, allowed
+ *   ring 2  destructive or expensive — would need confirmation (none yet)
  */
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import { sql } from "@/lib/db/client";
@@ -15,6 +21,24 @@ import {
   listRecentCommits,
   getFileContent,
 } from "@/lib/github/client";
+import {
+  listProjects as vercelListProjects,
+  getProject as vercelGetProject,
+  createProject as vercelCreateProject,
+  listDeployments as vercelListDeployments,
+  getDeployment as vercelGetDeployment,
+  triggerDeployment as vercelTriggerDeployment,
+  setEnvVar as vercelSetEnvVar,
+  addDomain as vercelAddDomain,
+  getDomainConfig as vercelGetDomainConfig,
+} from "@/lib/vercel/client";
+import {
+  listDomains as nameListDomains,
+  getDomain as nameGetDomain,
+  listRecords as nameListRecords,
+  upsertRecord as nameUpsertRecord,
+  deleteRecord as nameDeleteRecord,
+} from "@/lib/namecom/client";
 
 export const TOOLS: Tool[] = [
   {
@@ -118,6 +142,230 @@ export const TOOLS: Tool[] = [
         },
       },
       required: ["title", "content"],
+    },
+  },
+
+  // ─── Vercel ──────────────────────────────────────────────────────
+  {
+    name: "vercel_list_projects",
+    description:
+      "Lista todos los proyectos de Vercel del equipo del operador. Devuelve id, name, framework, rootDirectory, link al repo de GitHub. Úsala cuando Luis pregunte qué hay en Vercel, qué proyectos están desplegados, o quiera ver el inventario.",
+    input_schema: {
+      type: "object",
+      properties: {
+        max: { type: "number", description: "1-200, default 50" },
+      },
+    },
+  },
+  {
+    name: "vercel_get_project",
+    description:
+      "Detalle completo de un proyecto de Vercel (id, framework, root, build/install/output commands, dominio, link a repo). Acepta id (prj_…) o slug.",
+    input_schema: {
+      type: "object",
+      properties: {
+        idOrSlug: { type: "string", description: "Project id (prj_…) o slug" },
+      },
+      required: ["idOrSlug"],
+    },
+  },
+  {
+    name: "vercel_create_project",
+    description:
+      "Crea un proyecto nuevo en Vercel, opcionalmente linkeado a un repo de GitHub. Útil cuando Luis quiere desplegar un repo nuevo (ej. 'V despliega turbillon50/break a Vercel'). El primer deploy se dispara automáticamente cuando hay gitRepository.",
+    input_schema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Nombre del proyecto en Vercel" },
+        framework: {
+          type: ["string", "null"],
+          description: "Framework preset: 'vite', 'nextjs', 'remix', 'astro', etc. null para auto-detect.",
+        },
+        rootDirectory: {
+          type: ["string", "null"],
+          description: "Subdirectorio del repo donde está el proyecto (ej. 'apps/web')",
+        },
+        buildCommand: { type: ["string", "null"] },
+        outputDirectory: { type: ["string", "null"] },
+        installCommand: { type: ["string", "null"] },
+        ghRepoFullName: {
+          type: "string",
+          description: "GitHub owner/repo (ej. 'turbillon50/rivones'). Si lo das, se linkea.",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "vercel_list_deployments",
+    description:
+      "Lista los últimos deployments de un proyecto. Útil para diagnosticar fallos, ver qué deploy está vivo, o checar historial.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string", description: "prj_…" },
+        limit: { type: "number", description: "1-50, default 10" },
+      },
+      required: ["projectId"],
+    },
+  },
+  {
+    name: "vercel_get_deployment",
+    description:
+      "Detalle completo de un deployment (URL, estado, errores, build logs link). Acepta id (dpl_…) o URL del deploy.",
+    input_schema: {
+      type: "object",
+      properties: {
+        idOrUrl: { type: "string" },
+      },
+      required: ["idOrUrl"],
+    },
+  },
+  {
+    name: "vercel_trigger_deployment",
+    description:
+      "Dispara un deploy nuevo desde una branch específica de GitHub. Úsala para hacer 'redeploy' o promover una branch a producción.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string" },
+        name: { type: "string", description: "Nombre del proyecto Vercel" },
+        ghRepoFullName: { type: "string", description: "owner/repo de GitHub" },
+        branch: { type: "string", description: "branch a desplegar (ej. 'main')" },
+        target: {
+          type: "string",
+          enum: ["production", "preview", "staging"],
+          description: "Default: production",
+        },
+      },
+      required: ["projectId", "name", "ghRepoFullName", "branch"],
+    },
+  },
+  {
+    name: "vercel_set_env_var",
+    description:
+      "Crea o actualiza una variable de entorno en un proyecto Vercel. Útil para meter VITE_CLERK_PUBLISHABLE_KEY, DATABASE_URL, etc. después de crear un proyecto. SIEMPRE encrypted por default.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string" },
+        key: { type: "string", description: "Nombre de la env var (ej. VITE_CLERK_PUBLISHABLE_KEY)" },
+        value: { type: "string", description: "Valor (se cifra al guardar)" },
+        target: {
+          type: "array",
+          items: { type: "string", enum: ["production", "preview", "development"] },
+          description: "Entornos donde aplica. Default: ['production', 'preview']",
+        },
+      },
+      required: ["projectId", "key", "value"],
+    },
+  },
+  {
+    name: "vercel_add_domain",
+    description:
+      "Agrega un dominio (apex o subdominio) a un proyecto Vercel. Úsala antes de configurar DNS — devuelve si Vercel ya lo verifica. Para www → apex usa redirect=apexDomain.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string" },
+        domain: { type: "string", description: "ej. 'rivones.site' o 'www.rivones.site'" },
+        redirect: {
+          type: "string",
+          description: "Si es subdominio que debe redirigir (ej. www→apex), pon el destino aquí",
+        },
+        redirectStatusCode: {
+          type: "number",
+          description: "301, 302, 307, 308. Default 308",
+        },
+      },
+      required: ["projectId", "domain"],
+    },
+  },
+  {
+    name: "vercel_get_domain_config",
+    description:
+      "Pregunta a Vercel qué registros DNS espera ver para un dominio dado (A target, CNAME target, recommendedIPv4, recommendedCNAME, misconfigured flag). Úsala ANTES de crear records en Name.com.",
+    input_schema: {
+      type: "object",
+      properties: {
+        domain: { type: "string" },
+      },
+      required: ["domain"],
+    },
+  },
+
+  // ─── Name.com ────────────────────────────────────────────────────
+  {
+    name: "namecom_list_domains",
+    description:
+      "Lista los dominios del operador en Name.com (con expireDate, nameservers, etc.). Útil para ver qué dominios hay disponibles para apuntar a deploys.",
+    input_schema: {
+      type: "object",
+      properties: {
+        max: { type: "number", description: "1-500, default 200" },
+      },
+    },
+  },
+  {
+    name: "namecom_get_domain",
+    description:
+      "Detalle de un dominio en Name.com: nameservers, contactos, expiración, autorenew, locked. Devuelve dato sensible (contactos) — solo úsala cuando Luis necesite el dato.",
+    input_schema: {
+      type: "object",
+      properties: { domain: { type: "string" } },
+      required: ["domain"],
+    },
+  },
+  {
+    name: "namecom_list_records",
+    description:
+      "Lista los registros DNS de un dominio en Name.com (id, host, type, answer, ttl). Úsala para auditar DNS o decidir qué upsertear.",
+    input_schema: {
+      type: "object",
+      properties: { domain: { type: "string" } },
+      required: ["domain"],
+    },
+  },
+  {
+    name: "namecom_upsert_record",
+    description:
+      "Crea o reemplaza un registro DNS en Name.com (idempotente: borra cualquier match previo de mismo host+type, luego crea el nuevo). Úsala para apuntar dominios a Vercel: A apex → 216.150.1.1, CNAME www → cname.vercel-dns.com.",
+    input_schema: {
+      type: "object",
+      properties: {
+        domain: { type: "string" },
+        host: {
+          type: "string",
+          description: "subdominio (ej. 'www', 'api'). Vacío o ausente = apex.",
+        },
+        type: {
+          type: "string",
+          enum: ["A", "AAAA", "CNAME", "TXT", "MX", "NS"],
+        },
+        answer: {
+          type: "string",
+          description: "El valor (IP, hostname, texto). CNAMEs aceptan con o sin punto final.",
+        },
+        ttl: { type: "number", description: "Default 300" },
+        priority: {
+          type: "number",
+          description: "Solo para tipo MX",
+        },
+      },
+      required: ["domain", "type", "answer"],
+    },
+  },
+  {
+    name: "namecom_delete_record",
+    description:
+      "Borra un registro DNS por id. Idempotente (no falla si ya no existe).",
+    input_schema: {
+      type: "object",
+      properties: {
+        domain: { type: "string" },
+        recordId: { type: "number" },
+      },
+      required: ["domain", "recordId"],
     },
   },
 ];
@@ -299,6 +547,256 @@ async function dispatch(
         summary: `memoria: ${title}`,
       };
     }
+
+    // ─── Vercel ────────────────────────────────────────────────────
+    case "vercel_list_projects": {
+      const max = clampNumber(input.max, 1, 200, 50);
+      const projects = await vercelListProjects({
+        max,
+        auditUserId: ctx.userId,
+      });
+      const slim = projects.map((p) => ({
+        id: p.id,
+        name: p.name,
+        framework: p.framework,
+        rootDirectory: p.rootDirectory,
+        link: p.link,
+        createdAt: p.createdAt,
+      }));
+      return {
+        ok: true,
+        content: JSON.stringify({ total: slim.length, projects: slim }),
+        summary: `${slim.length} proyectos vercel`,
+      };
+    }
+    case "vercel_get_project": {
+      const idOrSlug = requireString(input.idOrSlug, "idOrSlug");
+      const project = await vercelGetProject(idOrSlug, {
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify(project),
+        summary: `proyecto vercel: ${project.name}`,
+      };
+    }
+    case "vercel_create_project": {
+      const name = requireString(input.name, "name");
+      const ghRepoFullName =
+        typeof input.ghRepoFullName === "string"
+          ? input.ghRepoFullName
+          : undefined;
+      const project = await vercelCreateProject(
+        {
+          name,
+          framework: nullableString(input.framework),
+          rootDirectory: nullableString(input.rootDirectory),
+          buildCommand: nullableString(input.buildCommand),
+          outputDirectory: nullableString(input.outputDirectory),
+          installCommand: nullableString(input.installCommand),
+          gitRepository: ghRepoFullName
+            ? { type: "github", repo: ghRepoFullName }
+            : undefined,
+        },
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify({
+          id: project.id,
+          name: project.name,
+          framework: project.framework,
+          rootDirectory: project.rootDirectory,
+        }),
+        summary: `proyecto vercel creado: ${project.name}`,
+      };
+    }
+    case "vercel_list_deployments": {
+      const projectId = requireString(input.projectId, "projectId");
+      const limit = clampNumber(input.limit, 1, 50, 10);
+      const deployments = await vercelListDeployments(projectId, {
+        limit,
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify({ total: deployments.length, deployments }),
+        summary: `${deployments.length} deploys`,
+      };
+    }
+    case "vercel_get_deployment": {
+      const idOrUrl = requireString(input.idOrUrl, "idOrUrl");
+      const deployment = await vercelGetDeployment(idOrUrl, {
+        auditUserId: ctx.userId,
+      });
+      const slim = {
+        id: deployment.id ?? deployment.uid,
+        url: deployment.url,
+        readyState: deployment.readyState,
+        target: deployment.target,
+        meta: deployment.meta,
+        errorMessage: deployment.errorMessage,
+      };
+      return {
+        ok: true,
+        content: JSON.stringify(slim),
+        summary: `deploy ${slim.readyState ?? "?"}: ${slim.url ?? slim.id}`,
+      };
+    }
+    case "vercel_trigger_deployment": {
+      const result = await vercelTriggerDeployment(
+        {
+          projectId: requireString(input.projectId, "projectId"),
+          name: requireString(input.name, "name"),
+          ghRepoFullName: requireString(input.ghRepoFullName, "ghRepoFullName"),
+          branch: requireString(input.branch, "branch"),
+          target:
+            typeof input.target === "string"
+              ? (input.target as "production" | "preview" | "staging")
+              : "production",
+        },
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `deploy disparado: ${result.url}`,
+      };
+    }
+    case "vercel_set_env_var": {
+      const target = Array.isArray(input.target)
+        ? (input.target as string[])
+        : ["production", "preview"];
+      const result = await vercelSetEnvVar(
+        requireString(input.projectId, "projectId"),
+        {
+          key: requireString(input.key, "key"),
+          value: requireString(input.value, "value"),
+          target: target.filter((t) =>
+            ["production", "preview", "development"].includes(t),
+          ) as Array<"production" | "preview" | "development">,
+        },
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `env ${input.key} → ${target.join("+")}`,
+      };
+    }
+    case "vercel_add_domain": {
+      const result = await vercelAddDomain(
+        requireString(input.projectId, "projectId"),
+        requireString(input.domain, "domain"),
+        {
+          redirect:
+            typeof input.redirect === "string" ? input.redirect : undefined,
+          redirectStatusCode:
+            typeof input.redirectStatusCode === "number"
+              ? input.redirectStatusCode
+              : undefined,
+          auditUserId: ctx.userId,
+        },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `dominio agregado: ${result.name}${result.verified ? " ✓" : " (pending)"}`,
+      };
+    }
+    case "vercel_get_domain_config": {
+      const config = await vercelGetDomainConfig(
+        requireString(input.domain, "domain"),
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(config),
+        summary: `DNS config ${input.domain}: misconfig=${config.misconfigured}`,
+      };
+    }
+
+    // ─── Name.com ──────────────────────────────────────────────────
+    case "namecom_list_domains": {
+      const max = clampNumber(input.max, 1, 500, 200);
+      const domains = await nameListDomains({
+        max,
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify({
+          total: domains.length,
+          domains: domains.map((d) => ({
+            domainName: d.domainName,
+            expireDate: d.expireDate,
+            autorenewEnabled: d.autorenewEnabled,
+            locked: d.locked,
+          })),
+        }),
+        summary: `${domains.length} dominios name.com`,
+      };
+    }
+    case "namecom_get_domain": {
+      const domain = await nameGetDomain(
+        requireString(input.domain, "domain"),
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(domain),
+        summary: `domain ${domain.domainName}`,
+      };
+    }
+    case "namecom_list_records": {
+      const records = await nameListRecords(
+        requireString(input.domain, "domain"),
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify({ total: records.length, records }),
+        summary: `${records.length} DNS records`,
+      };
+    }
+    case "namecom_upsert_record": {
+      const created = await nameUpsertRecord(
+        requireString(input.domain, "domain"),
+        {
+          host: typeof input.host === "string" ? input.host : "",
+          type: requireString(input.type, "type") as
+            | "A"
+            | "AAAA"
+            | "CNAME"
+            | "TXT"
+            | "MX"
+            | "NS",
+          answer: requireString(input.answer, "answer"),
+          ttl: typeof input.ttl === "number" ? input.ttl : undefined,
+          priority:
+            typeof input.priority === "number" ? input.priority : undefined,
+        },
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(created),
+        summary: `${created.type} ${created.fqdn} → ${created.answer}`,
+      };
+    }
+    case "namecom_delete_record": {
+      const result = await nameDeleteRecord(
+        requireString(input.domain, "domain"),
+        Number(input.recordId),
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `record ${input.recordId} borrado`,
+      };
+    }
+
     default:
       return {
         ok: false,
@@ -306,6 +804,11 @@ async function dispatch(
         summary: `unknown tool: ${name}`,
       };
   }
+}
+
+function nullableString(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  return v.length === 0 ? null : v;
 }
 
 function clampNumber(

--- a/lib/namecom/client.ts
+++ b/lib/namecom/client.ts
@@ -1,0 +1,199 @@
+/**
+ * Name.com REST API client.
+ *
+ * Auth: HTTP basic with NAME_USERNAME (typically the registrant email)
+ * + NAME_TOKEN. Both are pulled from the operator vault on demand.
+ */
+import { requireOperatorSecret } from "@/lib/vault/get-secret";
+
+const NAMECOM_API = "https://api.name.com";
+
+async function getCreds(options: { auditUserId?: string } = {}): Promise<{
+  username: string;
+  token: string;
+}> {
+  const [username, token] = await Promise.all([
+    requireOperatorSecret("NAME_USERNAME", options),
+    requireOperatorSecret("NAME_TOKEN", options),
+  ]);
+  return { username, token };
+}
+
+function basicAuthHeader(username: string, token: string): string {
+  return `Basic ${Buffer.from(`${username}:${token}`).toString("base64")}`;
+}
+
+async function nameFetch(
+  path: string,
+  init: RequestInit & { auth: string },
+): Promise<Response> {
+  const res = await fetch(`${NAMECOM_API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: init.auth,
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  return res;
+}
+
+async function nameJson<T>(
+  path: string,
+  init: RequestInit & { auth: string },
+): Promise<T> {
+  const res = await nameFetch(path, init);
+  const text = await res.text();
+  let body: T & { message?: string } = {} as T & { message?: string };
+  if (text) {
+    try {
+      body = JSON.parse(text) as T & { message?: string };
+    } catch {
+      throw new Error(`name.com non-JSON response (${res.status}): ${text.slice(0, 200)}`);
+    }
+  }
+  if (!res.ok) {
+    const message = body?.message ?? `name.com ${res.status} on ${path}`;
+    throw new Error(message);
+  }
+  return body;
+}
+
+export interface NameDomain {
+  domainName: string;
+  nameservers?: string[];
+  expireDate?: string;
+  createDate?: string;
+  locked?: boolean;
+  autorenewEnabled?: boolean;
+  privacyEnabled?: boolean;
+}
+
+export async function listDomains(
+  options: { auditUserId?: string; max?: number } = {},
+): Promise<NameDomain[]> {
+  const { username, token } = await getCreds(options);
+  const auth = basicAuthHeader(username, token);
+  const out: NameDomain[] = [];
+  let page = 1;
+  const perPage = 100;
+  const max = options.max ?? 200;
+  while (out.length < max) {
+    const data = await nameJson<{
+      domains?: NameDomain[];
+      nextPage?: number;
+    }>(`/v4/domains?perPage=${perPage}&page=${page}`, {
+      method: "GET",
+      auth,
+    });
+    const batch = data.domains ?? [];
+    out.push(...batch);
+    if (!data.nextPage || batch.length === 0) break;
+    page = data.nextPage;
+  }
+  return out.slice(0, max);
+}
+
+export async function getDomain(
+  domain: string,
+  options: { auditUserId?: string } = {},
+): Promise<NameDomain & { contacts?: unknown }> {
+  const { username, token } = await getCreds(options);
+  return nameJson(
+    `/v4/domains/${encodeURIComponent(domain)}`,
+    { method: "GET", auth: basicAuthHeader(username, token) },
+  );
+}
+
+export interface NameDnsRecord {
+  id: number;
+  domainName: string;
+  host?: string;
+  fqdn: string;
+  type: string;
+  answer: string;
+  ttl: number;
+  priority?: number;
+}
+
+export async function listRecords(
+  domain: string,
+  options: { auditUserId?: string } = {},
+): Promise<NameDnsRecord[]> {
+  const { username, token } = await getCreds(options);
+  const data = await nameJson<{ records?: NameDnsRecord[] }>(
+    `/v4/domains/${encodeURIComponent(domain)}/records`,
+    { method: "GET", auth: basicAuthHeader(username, token) },
+  );
+  return data.records ?? [];
+}
+
+export interface UpsertRecordInput {
+  host?: string; // empty / omit for apex
+  type: "A" | "AAAA" | "CNAME" | "TXT" | "MX" | "NS";
+  answer: string;
+  ttl?: number;
+  priority?: number;
+}
+
+/**
+ * Upsert a record by (host, type) — deletes any existing match first
+ * then creates the new one. Idempotent for the common case of pointing
+ * a hostname at a single target.
+ */
+export async function upsertRecord(
+  domain: string,
+  input: UpsertRecordInput,
+  options: { auditUserId?: string } = {},
+): Promise<NameDnsRecord> {
+  const { username, token } = await getCreds(options);
+  const auth = basicAuthHeader(username, token);
+  const host = (input.host ?? "").trim();
+  const type = input.type;
+
+  const existing = await nameJson<{ records?: NameDnsRecord[] }>(
+    `/v4/domains/${encodeURIComponent(domain)}/records`,
+    { method: "GET", auth },
+  );
+  for (const r of existing.records ?? []) {
+    const rh = r.host ?? "";
+    if (rh === host && r.type === type) {
+      await nameFetch(
+        `/v4/domains/${encodeURIComponent(domain)}/records/${r.id}`,
+        { method: "DELETE", auth },
+      );
+    }
+  }
+
+  const created = await nameJson<NameDnsRecord>(
+    `/v4/domains/${encodeURIComponent(domain)}/records`,
+    {
+      method: "POST",
+      auth,
+      body: JSON.stringify({
+        host,
+        type,
+        answer: input.answer,
+        ttl: input.ttl ?? 300,
+        ...(typeof input.priority === "number" ? { priority: input.priority } : {}),
+      }),
+    },
+  );
+  return created;
+}
+
+export async function deleteRecord(
+  domain: string,
+  recordId: number,
+  options: { auditUserId?: string } = {},
+): Promise<{ ok: boolean }> {
+  const { username, token } = await getCreds(options);
+  const res = await nameFetch(
+    `/v4/domains/${encodeURIComponent(domain)}/records/${recordId}`,
+    { method: "DELETE", auth: basicAuthHeader(username, token) },
+  );
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`name.com ${res.status} deleting record ${recordId}`);
+  }
+  return { ok: true };
+}

--- a/lib/vercel/client.ts
+++ b/lib/vercel/client.ts
@@ -1,0 +1,294 @@
+/**
+ * Vercel REST API client.
+ *
+ * Pulls VERCEL_TOKEN from the operator vault on demand. Caches the
+ * resolved team id for 5 min in-process so we don't hit `/v2/teams`
+ * on every tool call.
+ */
+import { requireOperatorSecret } from "@/lib/vault/get-secret";
+
+const VERCEL_API = "https://api.vercel.com";
+const TEAM_CACHE_TTL_MS = 5 * 60 * 1000;
+
+let teamCache: { id: string; slug: string; expiresAt: number } | null = null;
+
+async function getCreds(
+  options: { auditUserId?: string } = {},
+): Promise<{ token: string }> {
+  const token = await requireOperatorSecret("VERCEL_TOKEN", options);
+  return { token };
+}
+
+async function vercelFetch(
+  path: string,
+  init: RequestInit & { token: string; teamId?: string },
+): Promise<Response> {
+  const url = new URL(`${VERCEL_API}${path}`);
+  if (init.teamId) url.searchParams.set("teamId", init.teamId);
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${init.token}`,
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  return res;
+}
+
+async function vercelJson<T>(
+  path: string,
+  init: RequestInit & { token: string; teamId?: string },
+): Promise<T> {
+  const res = await vercelFetch(path, init);
+  const body = (await res.json()) as T & { error?: { message?: string } };
+  if (!res.ok) {
+    const message =
+      body?.error?.message ?? `vercel ${res.status} on ${path}`;
+    throw new Error(message);
+  }
+  return body;
+}
+
+export async function getDefaultTeam(
+  options: { auditUserId?: string } = {},
+): Promise<{ id: string; slug: string }> {
+  if (teamCache && teamCache.expiresAt > Date.now()) {
+    return { id: teamCache.id, slug: teamCache.slug };
+  }
+  const { token } = await getCreds(options);
+  const data = await vercelJson<{
+    teams: Array<{ id: string; slug: string }>;
+  }>("/v2/teams", { method: "GET", token });
+  const first = data.teams[0];
+  if (!first) throw new Error("No Vercel teams visible to this token");
+  teamCache = {
+    id: first.id,
+    slug: first.slug,
+    expiresAt: Date.now() + TEAM_CACHE_TTL_MS,
+  };
+  return { id: first.id, slug: first.slug };
+}
+
+export interface VercelProject {
+  id: string;
+  name: string;
+  framework: string | null;
+  rootDirectory: string | null;
+  outputDirectory: string | null;
+  buildCommand: string | null;
+  installCommand: string | null;
+  link?: { type: string; repo?: string; org?: string } | null;
+  createdAt: number;
+  updatedAt?: number;
+  targets?: Record<string, { url?: string }>;
+}
+
+export async function listProjects(
+  options: { auditUserId?: string; max?: number } = {},
+): Promise<VercelProject[]> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  const max = options.max ?? 50;
+  const data = await vercelJson<{ projects: VercelProject[] }>(
+    `/v9/projects?limit=${max}`,
+    { method: "GET", token, teamId: team.id },
+  );
+  return data.projects;
+}
+
+export async function getProject(
+  idOrSlug: string,
+  options: { auditUserId?: string } = {},
+): Promise<VercelProject> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  return vercelJson<VercelProject>(
+    `/v9/projects/${encodeURIComponent(idOrSlug)}`,
+    { method: "GET", token, teamId: team.id },
+  );
+}
+
+export interface CreateProjectInput {
+  name: string;
+  framework?: string | null;
+  rootDirectory?: string | null;
+  buildCommand?: string | null;
+  outputDirectory?: string | null;
+  installCommand?: string | null;
+  gitRepository?: { type: "github" | "gitlab" | "bitbucket"; repo: string };
+}
+
+export async function createProject(
+  input: CreateProjectInput,
+  options: { auditUserId?: string } = {},
+): Promise<VercelProject> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  return vercelJson<VercelProject>(`/v11/projects`, {
+    method: "POST",
+    token,
+    teamId: team.id,
+    body: JSON.stringify(input),
+  });
+}
+
+export interface VercelDeployment {
+  uid: string;
+  url: string;
+  state?: string;
+  readyState?: string;
+  target?: string | null;
+  createdAt: number;
+  meta?: Record<string, string>;
+}
+
+export async function listDeployments(
+  projectId: string,
+  options: { auditUserId?: string; limit?: number } = {},
+): Promise<VercelDeployment[]> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  const limit = options.limit ?? 10;
+  const data = await vercelJson<{ deployments: VercelDeployment[] }>(
+    `/v6/deployments?projectId=${encodeURIComponent(projectId)}&limit=${limit}`,
+    { method: "GET", token, teamId: team.id },
+  );
+  return data.deployments;
+}
+
+export async function getDeployment(
+  idOrUrl: string,
+  options: { auditUserId?: string } = {},
+): Promise<Record<string, unknown>> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  return vercelJson<Record<string, unknown>>(
+    `/v13/deployments/${encodeURIComponent(idOrUrl)}`,
+    { method: "GET", token, teamId: team.id },
+  );
+}
+
+export interface TriggerDeployInput {
+  projectId: string;
+  name: string;
+  ghRepoFullName: string;
+  branch: string;
+  target?: "production" | "preview" | "staging";
+}
+
+export async function triggerDeployment(
+  input: TriggerDeployInput,
+  options: { auditUserId?: string } = {},
+): Promise<{ id: string; url: string; readyState?: string }> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+
+  // Need numeric repoId for gitSource
+  const ghRes = await fetch(
+    `https://api.github.com/repos/${input.ghRepoFullName}`,
+  );
+  if (!ghRes.ok) {
+    throw new Error(
+      `cannot read GitHub repo ${input.ghRepoFullName}: ${ghRes.status}`,
+    );
+  }
+  const ghJson = (await ghRes.json()) as { id: number };
+
+  const data = await vercelJson<{ id: string; url: string; readyState?: string }>(
+    `/v13/deployments?forceNew=1`,
+    {
+      method: "POST",
+      token,
+      teamId: team.id,
+      body: JSON.stringify({
+        name: input.name,
+        project: input.projectId,
+        target: input.target ?? "production",
+        gitSource: {
+          type: "github",
+          repoId: ghJson.id,
+          ref: input.branch,
+        },
+      }),
+    },
+  );
+  return data;
+}
+
+export type EnvTarget = "production" | "preview" | "development";
+
+export async function setEnvVar(
+  projectId: string,
+  input: {
+    key: string;
+    value: string;
+    target: EnvTarget[];
+    type?: "encrypted" | "plain";
+  },
+  options: { auditUserId?: string } = {},
+): Promise<{ created: boolean; id?: string }> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  const res = await vercelFetch(
+    `/v10/projects/${encodeURIComponent(projectId)}/env?upsert=true`,
+    {
+      method: "POST",
+      token,
+      teamId: team.id,
+      body: JSON.stringify({
+        key: input.key,
+        value: input.value,
+        target: input.target,
+        type: input.type ?? "encrypted",
+      }),
+    },
+  );
+  const body = (await res.json()) as {
+    created?: { id?: string };
+    error?: { message?: string };
+  };
+  if (!res.ok) throw new Error(body?.error?.message ?? `vercel ${res.status}`);
+  return { created: true, id: body.created?.id };
+}
+
+export async function addDomain(
+  projectId: string,
+  domain: string,
+  options: {
+    auditUserId?: string;
+    redirect?: string;
+    redirectStatusCode?: number;
+  } = {},
+): Promise<{ name: string; verified: boolean }> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  const body: Record<string, unknown> = { name: domain };
+  if (options.redirect) {
+    body.redirect = options.redirect;
+    body.redirectStatusCode = options.redirectStatusCode ?? 308;
+  }
+  return vercelJson<{ name: string; verified: boolean }>(
+    `/v10/projects/${encodeURIComponent(projectId)}/domains`,
+    { method: "POST", token, teamId: team.id, body: JSON.stringify(body) },
+  );
+}
+
+export async function getDomainConfig(
+  domain: string,
+  options: { auditUserId?: string } = {},
+): Promise<{
+  aValues: string[] | null;
+  cnames: string[] | null;
+  recommendedIPv4: Array<{ rank: number; value: string[] }>;
+  recommendedCNAME: string[];
+  misconfigured: boolean;
+}> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  return vercelJson(`/v6/domains/${encodeURIComponent(domain)}/config`, {
+    method: "GET",
+    token,
+    teamId: team.id,
+  });
+}

--- a/migrations/003_seed_protocols.sql
+++ b/migrations/003_seed_protocols.sql
@@ -1,0 +1,99 @@
+-- -----------------------------------------------------------
+-- Migration 003 — Seed protocolos vForge + lessons del día 1
+--
+-- Carga 4 entradas en knowledge_base que V leerá en CADA sesión:
+--   - protocolo NUEVO    (kind=method)
+--   - protocolo RESCATE  (kind=method)
+--   - protocolo HUNTER   (kind=method, futuro)
+--   - lesson: deploy de Rivones (Vite outDir gotcha + DNS Vercel + name.com)
+-- -----------------------------------------------------------
+
+INSERT INTO knowledge_base (kind, title, content, tags, source, created_by) VALUES
+(
+  'method',
+  'Protocolo NUEVO — proyecto desde cero',
+  'Cuando Luis dice "arrancar proyecto nuevo X" o "modo NUEVO", sigue este flujo:
+
+1. Pregunta lo mínimo: qué hace, audiencia, 3-5 features core, marca/vibe.
+2. Genera master prompt para v0.dev (formato vForge: identidad + tokens + screens + tono).
+3. Sugiere repo name (default: turbillon50/<nombre-en-kebab-case>).
+4. Cuando v0 exporte a GitHub, audita el repo con github_get_repo + github_read_file.
+5. Despliega en Vercel: vercel_create_project con framework auto-detect, gitRepository linkeado.
+6. Si Luis pide dominio: vercel_add_domain + vercel_get_domain_config + namecom_upsert_record.
+7. Memory_save lo importante (broker, audiencia, decisión de tech).
+
+Stack default heredado del método vForge: Next 16 / Vite + React 19 + Tailwind 4 + shadcn + Neon DB.
+
+NO arranques con Railway worker hasta que sepas qué broker / WebSocket persistente se necesita.',
+  ARRAY['protocol', 'nuevo', 'workflow'],
+  'docs/method.md#protocolos',
+  'operator_luis'
+),
+(
+  'method',
+  'Protocolo RESCATE — repo existente roto',
+  'Cuando Luis dice "rescate de X", "modo RESCATE", o "tengo este repo con problemas":
+
+1. github_get_repo → metadata, lenguaje, default_branch.
+2. github_list_commits → patrón de desarrollo, último activity.
+3. github_read_file en orden: README → package.json → archivos de config (vite.config, next.config, vercel.json) → 2-3 archivos de código clave.
+4. Diagnóstico estructurado:
+   - Stack actual y distancia del método vForge
+   - Qué funciona, qué está roto, qué falta
+   - Decisión: PATCH (cambios mínimos) vs REWRITE (master prompt nuevo conservando learnings)
+5. Plan numerado con estimación por paso.
+6. Si Luis aprueba PATCH: aplicar cambios concretos (file:line).
+7. Si Luis aprueba REWRITE: nuevo master prompt → v0 → audit del nuevo repo.
+
+Para deploy: vercel_create_project del repo (cuidado con monorepos pnpm — leer el vercel.json del repo PRIMERO, no asumir).
+LECCIÓN aprendida en Rivones: Vite con build.outDir personalizado se peleaba con outputDirectory por default de Vercel. Verificar antes con github_read_file de vite.config.ts.',
+  ARRAY['protocol', 'rescate', 'workflow'],
+  'docs/method.md#protocolos',
+  'operator_luis'
+),
+(
+  'method',
+  'Protocolo HUNTER — búsqueda externa (futuro)',
+  'Cuando Luis active el "modo HUNTER" (no implementado todavía):
+
+Buscar oportunidades fuera del catálogo de turbillon50: trends en GitHub, repos populares en un nicho, ideas de producto, benchmarking competitivo.
+
+Tools necesarias (M1+):
+- github_search_repos (global, no solo del operador)
+- web_search / web_fetch
+- npm_trending / producthunt_trending
+
+Estado: roadmap, no cableado todavía.',
+  ARRAY['protocol', 'hunter', 'roadmap'],
+  'docs/method.md#protocolos',
+  'operator_luis'
+),
+(
+  'lesson',
+  'Deploy Rivones (2026-05-04): Vite outDir + DNS Vercel + Name.com',
+  'Lección 1 — Vite + monorepo pnpm + outDir personalizado:
+El repo turbillon50/rivones tiene vite.config.ts con `build.outDir = "dist/public"` (custom para Replit). Vercel buscaba `dist/` por default → 404. Tres opciones de fix:
+  a) Setear outputDirectory="dist/public" en proyecto Vercel
+  b) Usar repo root como rootDirectory → el outer vercel.json toma el control con su propia config
+  c) Hardcodear en vercel.json interno
+La opción (b) ganó porque el outer vercel.json ya tenía buildCommand correcto + rewrites SPA. Antes de configurar Vercel para un repo, SIEMPRE github_read_file de vite.config.ts y vercel.json (root + cualquier subdirectorio) para ver dónde escribe Vite y qué espera Vercel.
+
+Lección 2 — Vercel SSO Protection:
+Por default los proyectos nuevos del team luis-projects-48b011f9 traen ssoProtection={"deploymentType":"all_except_custom_domains"}. Bloquea acceso público con HTTP 401. Después de crear proyecto, PATCH ssoProtection=null si es un sitio público.
+
+Lección 3 — Name.com username = email:
+La auth básica de api.name.com pide "username" pero el username NO es turbillon50 ni Tirbillon50 — es turbillon50@gmail.com (email completo del registrante). Los otros dos dan 403.
+
+Lección 4 — Vercel A target apex:
+Los Vercel A records recomendados están versionados. La rank=1 actual es 216.150.1.1 (no la legacy 76.76.21.21). Usar siempre vercel_get_domain_config recommendedIPv4[0].value[0] en vez de hardcodear.
+
+Lección 5 — TLS provisioning:
+Después de DNS válido, Vercel tarda 10-90s en aprovisionar Let''s Encrypt cert. HTTP funciona inmediato, HTTPS devuelve 503 mientras tanto.',
+  ARRAY['lesson', 'vercel', 'namecom', 'rivones', 'monorepo', 'vite'],
+  'session_2026-05-04_rivones',
+  'operator_luis'
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO schema_migrations (version) VALUES ('003_seed_protocols')
+  ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Summary

V pasa de **6 tools** (read-only GitHub + vault metadata + memory_save) a **19 tools** que cubren el ciclo completo: rescatar repos, crear proyectos en Vercel, configurar dominios punta a punta, y operar como senior engineer — **ejecuta en vez de orientar**.

## 🔧 Tools nuevas (13)

### Vercel (9)
| Tool | Qué hace |
|---|---|
| `vercel_list_projects` | Lista proyectos del team |
| `vercel_get_project` | Detalle de uno |
| `vercel_create_project` | Crea proyecto con gitRepository linkeado |
| `vercel_list_deployments` | Historial de deploys |
| `vercel_get_deployment` | Detalle de un deploy |
| `vercel_trigger_deployment` | Dispara redeploy desde branch |
| `vercel_set_env_var` | Upsert env (encrypted) |
| `vercel_add_domain` | Apex / subdominio + redirect |
| `vercel_get_domain_config` | Pregunta a Vercel qué DNS espera |

### Name.com (5)
| Tool | Qué hace |
|---|---|
| `namecom_list_domains` | Inventario de dominios |
| `namecom_get_domain` | Detalle (NS, contactos, expiración) |
| `namecom_list_records` | DNS de un dominio |
| `namecom_upsert_record` | Crea/reemplaza A/CNAME/TXT (idempotente) |
| `namecom_delete_record` | Borra por id |

## 🧠 Doctrina senior-engineer

Inyectada al inicio del system prompt:

- **Ejecuta, no orientes** — llama tools antes de opinar
- **Lee antes de opinar** — github_read_file de configs antes de diagnosticar
- **Cita archivos como `path:line`**
- **Parche mínimo > rewrite**
- Ring 0/1 ejecuta, ring 2+ pregunta
- Tono cálido camarada en español MX, sin opciones de más

## 📚 Knowledge base seed (migración 003)

- Protocolo **NUEVO** (proyecto desde cero)
- Protocolo **RESCATE** (repo roto existente)
- Protocolo **HUNTER** (futuro)
- **Lesson Rivones 2026-05-04**: 5 gotchas reales (Vite outDir, Vercel SSO, Name.com username=email, A target 216.150.1.1, TLS provisioning)

## ⚙ Endpoint admin

`POST /api/admin/migrate` aplica migraciones pendientes idempotentemente. Bearer-protected, audit-loggeado.

**Después del deploy:**
```bash
curl -X POST -H "Authorization: Bearer $VFORGE_OPERATOR_TOKEN" \
  https://vforge.site/api/admin/migrate
```

## Test plan

- [ ] PR mergea, deploy a prod
- [ ] Curl `/api/admin/migrate` → ve `applied: ['003_seed_protocols']`
- [ ] `/forge` → "qué dominios tengo?" → V invoca `namecom_list_domains`
- [ ] `/forge` → "qué proyectos tengo en Vercel?" → V invoca `vercel_list_projects`
- [ ] `/forge` → "rescate de turbillon50/X" → V ejecuta el protocolo (lee README, package.json, vercel.json antes de opinar)
- [ ] `/forge` → "despliega turbillon50/Y a Vercel" → V crea proyecto + dispara deploy

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_