### PR TITLE
feat(vault): per-project vault + projects sync + UI tabs/buttons

### DIFF
--- a/app/(dashboard)/forge/page.tsx
+++ b/app/(dashboard)/forge/page.tsx
@@ -69,6 +69,14 @@ function toolDisplayName(name: string): string {
       return "Configurando registro DNS";
     case "namecom_delete_record":
       return "Borrando registro DNS";
+    case "project_secret_save":
+      return "Guardando secret del proyecto";
+    case "project_secret_list":
+      return "Listando secrets del proyecto";
+    case "project_secret_delete":
+      return "Borrando secret del proyecto";
+    case "projects_sync":
+      return "Sincronizando proyectos (Vercel + GitHub)";
     default:
       return `Ejecutando ${name}`;
   }

--- a/app/(dashboard)/projects/page.tsx
+++ b/app/(dashboard)/projects/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Plus, ExternalLink, GitBranch, Lock } from "lucide-react";
+import { Plus, ExternalLink, GitBranch, Lock, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface Project {
@@ -37,11 +37,20 @@ const CATEGORIES: { id: CategoryFilter; label: string; emoji: string }[] = [
   { id: "pendiente_borrado", label: "Pendiente borrado", emoji: "🗑️" },
 ];
 
+const OPERATOR_TOKEN_KEY = "vforge_operator_token";
+
+function getOperatorToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(OPERATOR_TOKEN_KEY);
+}
+
 export default function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [active, setActive] = useState<CategoryFilter>("all");
   const [showAddModal, setShowAddModal] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
 
   async function load() {
     setLoading(true);
@@ -54,6 +63,45 @@ export default function ProjectsPage() {
       setProjects([]);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function sync() {
+    const token = getOperatorToken();
+    if (!token) {
+      setSyncMsg("Necesitas desbloquear el Vault primero (operator token)");
+      setTimeout(() => setSyncMsg(null), 6000);
+      return;
+    }
+    setSyncing(true);
+    setSyncMsg(null);
+    try {
+      const res = await fetch("/api/projects/sync", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as {
+        inserted?: number;
+        updated?: number;
+        total?: number;
+        error?: string;
+        errors?: Array<{ id: string; message: string }>;
+      };
+      if (data.error) {
+        setSyncMsg(`error: ${data.error}`);
+      } else {
+        setSyncMsg(
+          `+${data.inserted ?? 0} nuevos · ${data.updated ?? 0} actualizados · ${data.total ?? 0} total`,
+        );
+        await load();
+      }
+    } catch (err) {
+      setSyncMsg(
+        `error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSyncing(false);
+      setTimeout(() => setSyncMsg(null), 8000);
     }
   }
 
@@ -80,18 +128,35 @@ export default function ProjectsPage() {
                 ? "Sin proyectos"
                 : `${projects.length} proyecto${projects.length === 1 ? "" : "s"}`}
           </h1>
-          <button
-            type="button"
-            onClick={() => setShowAddModal(true)}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-vf-green text-black text-sm font-medium flex-shrink-0"
-          >
-            <Plus className="w-4 h-4" />
-            Dar de alta
-          </button>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <button
+              type="button"
+              onClick={sync}
+              disabled={syncing}
+              title="Cruzar Vercel + GitHub e insertar/actualizar la tabla projects"
+              className="inline-flex items-center gap-1.5 px-2.5 py-2 rounded-md bg-vf-bg-2 border border-vf-border-1 text-vf-fg-1 text-xs disabled:opacity-50"
+            >
+              <RefreshCw className={cn("w-3.5 h-3.5", syncing && "animate-spin")} />
+              {syncing ? "Sincronizando…" : "Sincronizar"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAddModal(true)}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-vf-green text-black text-sm font-medium"
+            >
+              <Plus className="w-4 h-4" />
+              Dar de alta
+            </button>
+          </div>
         </div>
         <p className="text-sm text-vf-fg-2">
-          Filtra por categoría · da de alta los nuevos manualmente
+          Filtra por categoría · sincroniza para traer Vercel + GitHub
         </p>
+        {syncMsg && (
+          <div className="text-xs font-mono text-vf-fg-1 bg-vf-bg-2 border border-vf-border-1 rounded-md px-2 py-1.5 mt-1">
+            {syncMsg}
+          </div>
+        )}
       </header>
 
       {/* Category chips */}

--- a/app/(dashboard)/vault/page.tsx
+++ b/app/(dashboard)/vault/page.tsx
@@ -13,6 +13,9 @@ import {
   ShieldAlert,
   KeyRound,
   LogIn,
+  Wrench,
+  Folder,
+  Globe,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -54,12 +57,24 @@ interface VaultHealth {
   error?: string;
 }
 
+interface ProjectOption {
+  id: string;
+  name: string;
+  category?: string;
+}
+
 export default function VaultPage() {
+  const [tab, setTab] = useState<"general" | "project">("general");
   const [secrets, setSecrets] = useState<SecretMetadata[]>([]);
+  const [projectSecrets, setProjectSecrets] = useState<SecretMetadata[]>([]);
   const [health, setHealth] = useState<VaultHealth | null>(null);
   const [loading, setLoading] = useState(true);
   const [authState, setAuthState] = useState<"checking" | "missing" | "ok" | "invalid">("checking");
   const [showAdd, setShowAdd] = useState(false);
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
+  const [migrating, setMigrating] = useState(false);
+  const [migrateMsg, setMigrateMsg] = useState<string | null>(null);
 
   async function load() {
     setLoading(true);
@@ -91,41 +106,191 @@ export default function VaultPage() {
     }
   }
 
+  async function loadProjects() {
+    try {
+      const res = await fetch("/api/projects", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = (await res.json()) as { projects: ProjectOption[] };
+      setProjects(data.projects ?? []);
+      if (data.projects?.length && !selectedProjectId) {
+        setSelectedProjectId(data.projects[0].id);
+      }
+    } catch {
+      /* noop */
+    }
+  }
+
+  async function loadProjectSecrets(projectId: string) {
+    if (!projectId) {
+      setProjectSecrets([]);
+      return;
+    }
+    try {
+      const res = await authedFetch(
+        `/api/vault/project-secrets?projectId=${encodeURIComponent(projectId)}`,
+      );
+      if (!res.ok) {
+        setProjectSecrets([]);
+        return;
+      }
+      const data = (await res.json()) as { secrets: SecretMetadata[] };
+      setProjectSecrets(data.secrets ?? []);
+    } catch {
+      setProjectSecrets([]);
+    }
+  }
+
+  async function applyMigrations() {
+    setMigrating(true);
+    setMigrateMsg(null);
+    try {
+      const res = await authedFetch("/api/admin/migrate", { method: "POST" });
+      const data = (await res.json()) as {
+        results?: Array<{ file: string; status: string; message?: string }>;
+        error?: string;
+      };
+      if (data.error) {
+        setMigrateMsg(`error: ${data.error}`);
+      } else {
+        const applied = (data.results ?? []).filter(
+          (r) => r.status === "applied",
+        );
+        const errors = (data.results ?? []).filter(
+          (r) => r.status === "error",
+        );
+        setMigrateMsg(
+          errors.length > 0
+            ? `error en ${errors.map((e) => e.file).join(", ")}: ${errors[0].message ?? ""}`
+            : applied.length > 0
+              ? `aplicadas ${applied.length}: ${applied.map((a) => a.file).join(", ")}`
+              : "todo al día — nada que aplicar",
+        );
+      }
+    } catch (err) {
+      setMigrateMsg(
+        `error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setMigrating(false);
+      setTimeout(() => setMigrateMsg(null), 8000);
+    }
+  }
+
   useEffect(() => {
     void load();
+    void loadProjects();
   }, []);
+
+  useEffect(() => {
+    if (tab === "project" && selectedProjectId) {
+      void loadProjectSecrets(selectedProjectId);
+    }
+  }, [tab, selectedProjectId]);
 
   // Show auth setup screen if no token / invalid token
   if (authState === "missing" || authState === "invalid") {
     return <OperatorAuthGate state={authState} onUnlock={() => void load()} />;
   }
 
+  const visibleSecrets = tab === "general" ? secrets : projectSecrets;
+
   return (
     <div className="space-y-6">
-      <header className="space-y-1">
+      <header className="space-y-2">
         <p className="font-mono text-[11px] uppercase tracking-wide text-vf-fg-2">
           Bóveda · server-side encrypted
         </p>
         <div className="flex items-baseline justify-between gap-3">
           <h1 className="text-2xl md:text-3xl font-semibold tracking-tight-vf text-vf-fg">
-            {loading ? "Cargando…" : `${secrets.length} secreto${secrets.length === 1 ? "" : "s"}`}
+            {loading ? "Cargando…" : `${visibleSecrets.length} secreto${visibleSecrets.length === 1 ? "" : "s"}`}
           </h1>
-          <button
-            type="button"
-            onClick={() => setShowAdd(true)}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-vf-green text-black text-sm font-medium flex-shrink-0"
-          >
-            <Plus className="w-4 h-4" />
-            Agregar
-          </button>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <button
+              type="button"
+              onClick={applyMigrations}
+              disabled={migrating}
+              title="Aplicar migraciones SQL pendientes"
+              className="inline-flex items-center gap-1.5 px-2.5 py-2 rounded-md bg-vf-bg-2 border border-vf-border-1 text-vf-fg-1 text-xs disabled:opacity-50"
+            >
+              <Wrench className="w-3.5 h-3.5" />
+              {migrating ? "Migrando…" : "Migrar"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAdd(true)}
+              disabled={tab === "project" && !selectedProjectId}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-md bg-vf-green text-black text-sm font-medium disabled:opacity-50"
+            >
+              <Plus className="w-4 h-4" />
+              Agregar
+            </button>
+          </div>
         </div>
         <p className="text-sm text-vf-fg-2">
           Cifradas AES-256-GCM con master pepper · V las invoca automáticamente cuando las necesita
         </p>
+        {migrateMsg && (
+          <div className="text-xs font-mono text-vf-fg-1 bg-vf-bg-2 border border-vf-border-1 rounded-md px-2 py-1.5">
+            {migrateMsg}
+          </div>
+        )}
       </header>
 
+      {/* Tabs */}
+      <div className="flex items-center gap-1 border-b border-vf-border-1">
+        <button
+          type="button"
+          onClick={() => setTab("general")}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-2 text-sm border-b-2 -mb-[1px] transition-colors",
+            tab === "general"
+              ? "border-vf-green text-vf-fg"
+              : "border-transparent text-vf-fg-2 hover:text-vf-fg-1",
+          )}
+        >
+          <Globe className="w-3.5 h-3.5" />
+          General
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("project")}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-2 text-sm border-b-2 -mb-[1px] transition-colors",
+            tab === "project"
+              ? "border-vf-green text-vf-fg"
+              : "border-transparent text-vf-fg-2 hover:text-vf-fg-1",
+          )}
+        >
+          <Folder className="w-3.5 h-3.5" />
+          Por proyecto
+        </button>
+      </div>
+
+      {tab === "project" && (
+        <div className="flex items-center gap-2">
+          <label className="text-xs font-mono uppercase tracking-wide text-vf-fg-2">
+            Proyecto
+          </label>
+          <select
+            value={selectedProjectId}
+            onChange={(e) => setSelectedProjectId(e.target.value)}
+            className="bg-vf-bg-2 border border-vf-border-1 rounded-md px-2 py-1.5 text-sm text-vf-fg max-w-[260px]"
+          >
+            {projects.length === 0 ? (
+              <option value="">(sin proyectos — sincroniza primero)</option>
+            ) : (
+              projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))
+            )}
+          </select>
+        </div>
+      )}
+
       {/* Vault health */}
-      {health && (
+      {health && tab === "general" && (
         <div
           className={cn(
             "flex items-center gap-2 px-3 py-2 rounded-md text-xs font-mono",
@@ -149,16 +314,29 @@ export default function VaultPage() {
       )}
 
       {/* List or empty state */}
-      {!loading && secrets.length === 0 ? (
-        <EmptyState onAdd={() => setShowAdd(true)} />
+      {!loading && visibleSecrets.length === 0 ? (
+        tab === "general" ? (
+          <EmptyState onAdd={() => setShowAdd(true)} />
+        ) : (
+          <ProjectEmptyState
+            hasProject={!!selectedProjectId}
+            onAdd={() => setShowAdd(true)}
+          />
+        )
       ) : (
         <div className="border border-vf-border rounded-xl overflow-hidden bg-vf-bg-1">
-          {secrets.map((s, i) => (
+          {visibleSecrets.map((s, i) => (
             <SecretRow
               key={s.id}
               secret={s}
               isFirst={i === 0}
-              onDelete={load}
+              scope={tab}
+              projectId={tab === "project" ? selectedProjectId : null}
+              onDelete={() =>
+                tab === "general"
+                  ? load()
+                  : loadProjectSecrets(selectedProjectId)
+              }
             />
           ))}
         </div>
@@ -166,12 +344,50 @@ export default function VaultPage() {
 
       {showAdd && (
         <AddSecretModal
+          scope={tab}
+          projectId={tab === "project" ? selectedProjectId : null}
           onClose={() => setShowAdd(false)}
           onAdded={() => {
             setShowAdd(false);
-            void load();
+            if (tab === "general") void load();
+            else void loadProjectSecrets(selectedProjectId);
           }}
         />
+      )}
+    </div>
+  );
+}
+
+function ProjectEmptyState({
+  hasProject,
+  onAdd,
+}: {
+  hasProject: boolean;
+  onAdd: () => void;
+}) {
+  return (
+    <div className="border border-dashed border-vf-border-1 rounded-xl px-6 py-12 text-center space-y-3">
+      <Folder className="w-8 h-8 text-vf-fg-3 mx-auto" />
+      {hasProject ? (
+        <>
+          <p className="text-vf-fg-2 text-sm">
+            Este proyecto aún no tiene secrets propios. Las llaves generales
+            (Anthropic, Stripe, etc.) las hereda del vault General.
+          </p>
+          <button
+            type="button"
+            onClick={onAdd}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-vf-green text-black text-sm font-medium"
+          >
+            <Plus className="w-4 h-4" />
+            Agregar secret al proyecto
+          </button>
+        </>
+      ) : (
+        <p className="text-vf-fg-2 text-sm">
+          No hay proyectos en el catálogo de vForge. Ve a /projects y dale
+          “Sincronizar” para traer tus repos de GitHub + Vercel.
+        </p>
       )}
     </div>
   );
@@ -203,9 +419,13 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
 function SecretRow({
   secret,
   isFirst,
+  scope,
+  projectId,
   onDelete,
 }: {
   secret: SecretMetadata;
+  scope?: "general" | "project";
+  projectId?: string | null;
   isFirst: boolean;
   onDelete: () => void;
 }) {
@@ -215,6 +435,11 @@ function SecretRow({
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
+  const apiBase =
+    scope === "project"
+      ? "/api/vault/project-secrets"
+      : "/api/vault/operator-secrets";
+
   async function reveal() {
     if (revealed) {
       setRevealed(null);
@@ -222,7 +447,7 @@ function SecretRow({
     }
     setRevealing(true);
     try {
-      const res = await authedFetch(`/api/vault/operator-secrets/${secret.id}/value`);
+      const res = await authedFetch(`${apiBase}/${secret.id}/value`);
       if (!res.ok) throw new Error("fail");
       const data = (await res.json()) as { value: string };
       setRevealed(data.value);
@@ -236,7 +461,7 @@ function SecretRow({
   async function copy() {
     setRevealing(true);
     try {
-      const res = await authedFetch(`/api/vault/operator-secrets/${secret.id}/value`);
+      const res = await authedFetch(`${apiBase}/${secret.id}/value`);
       if (!res.ok) throw new Error("fail");
       const data = (await res.json()) as { value: string };
       await navigator.clipboard.writeText(data.value);
@@ -252,7 +477,7 @@ function SecretRow({
   async function doDelete() {
     setDeleting(true);
     try {
-      const res = await authedFetch(`/api/vault/operator-secrets/${secret.id}`, {
+      const res = await authedFetch(`${apiBase}/${secret.id}`, {
         method: "DELETE",
       });
       if (res.ok) onDelete();
@@ -261,6 +486,9 @@ function SecretRow({
       setConfirmingDelete(false);
     }
   }
+
+  // projectId is captured by the closure for cache invalidation context.
+  void projectId;
 
   const meta: string[] = [];
   if (secret.provider) meta.push(secret.provider);
@@ -352,9 +580,13 @@ function SecretRow({
 function AddSecretModal({
   onClose,
   onAdded,
+  scope: targetScope,
+  projectId,
 }: {
   onClose: () => void;
   onAdded: () => void;
+  scope?: "general" | "project";
+  projectId?: string | null;
 }) {
   const [form, setForm] = useState({
     name: "",
@@ -424,16 +656,29 @@ function AddSecretModal({
     }
     setSubmitting(true);
     try {
-      const res = await authedFetch("/api/vault/operator-secrets", {
+      const isProject = targetScope === "project";
+      const endpoint = isProject
+        ? "/api/vault/project-secrets"
+        : "/api/vault/operator-secrets";
+      const body = isProject
+        ? {
+            projectId,
+            name: form.name,
+            value: form.value,
+            description: form.description || null,
+            provider: form.provider || null,
+          }
+        : {
+            name: form.name,
+            value: form.value,
+            description: form.description || null,
+            provider: form.provider || null,
+            scope: form.scope || null,
+          };
+      const res = await authedFetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: form.name,
-          value: form.value,
-          description: form.description || null,
-          provider: form.provider || null,
-          scope: form.scope || null,
-        }),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));

--- a/app/api/projects/sync/route.ts
+++ b/app/api/projects/sync/route.ts
@@ -1,0 +1,194 @@
+import { sql } from "@/lib/db/client";
+import { listAllUserRepos } from "@/lib/github/client";
+import { listProjects as vercelListProjects } from "@/lib/vercel/client";
+import {
+  requireOperatorAuth,
+  authFailureResponse,
+} from "@/lib/auth/operator-token";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/projects/sync
+ *
+ * Cross-references the Vercel project list and the GitHub repo list
+ * to upsert rows in `projects`. Each row gets:
+ *   - id: slug derived from the project's name (or repo when no project)
+ *   - name, description
+ *   - github_* fields when a matching repo exists
+ *   - vercel_project_id, vercel_url when a matching deploy exists
+ *
+ * Idempotent: existing rows get updated; nothing is deleted.
+ *
+ * Bearer-token protected, audit-logged.
+ */
+export async function POST(req: Request) {
+  const auth = requireOperatorAuth(req);
+  if (!auth.ok) return authFailureResponse(auth);
+
+  const [vercelProjects, ghRepos] = await Promise.all([
+    vercelListProjects({ auditUserId: auth.userId, max: 200 }).catch(
+      (err) => {
+        return { error: err instanceof Error ? err.message : String(err), data: [] as const };
+      },
+    ),
+    listAllUserRepos({ auditUserId: auth.userId, max: 200 }).catch(
+      (err) => {
+        return { error: err instanceof Error ? err.message : String(err), data: [] as const };
+      },
+    ),
+  ]);
+
+  const vp = Array.isArray(vercelProjects) ? vercelProjects : [];
+  const gr = Array.isArray(ghRepos) ? ghRepos : [];
+
+  // Build a unified set keyed on the GitHub repo full_name when known,
+  // or the Vercel project name otherwise.
+  type Aggregated = {
+    id: string;
+    name: string;
+    description: string | null;
+    github_repo: string | null;
+    github_private: boolean | null;
+    github_default_branch: string | null;
+    github_language: string | null;
+    github_url: string | null;
+    vercel_project_id: string | null;
+    vercel_url: string | null;
+  };
+  const byKey = new Map<string, Aggregated>();
+
+  for (const repo of gr) {
+    const id = slugify(repo.name);
+    byKey.set(repo.full_name.toLowerCase(), {
+      id,
+      name: repo.name,
+      description: repo.description,
+      github_repo: repo.full_name,
+      github_private: repo.private,
+      github_default_branch: repo.default_branch,
+      github_language: repo.language,
+      github_url: repo.html_url,
+      vercel_project_id: null,
+      vercel_url: null,
+    });
+  }
+
+  for (const project of vp) {
+    const repoFullName = (project.link as { repo?: string; org?: string } | null | undefined)
+      ?.repo
+      ? `${(project.link as { repo: string; org: string }).org ?? ""}/${(project.link as { repo: string; org: string }).repo}`
+      : null;
+    const key = repoFullName ? repoFullName.toLowerCase() : `vercel:${project.name}`;
+    const prevAgg = byKey.get(key);
+    const merged: Aggregated = prevAgg
+      ? {
+          ...prevAgg,
+          vercel_project_id: project.id,
+          vercel_url: prevAgg.vercel_url ?? guessVercelUrl(project.name),
+        }
+      : {
+          id: slugify(project.name),
+          name: project.name,
+          description: null,
+          github_repo: null,
+          github_private: null,
+          github_default_branch: null,
+          github_language: null,
+          github_url: null,
+          vercel_project_id: project.id,
+          vercel_url: guessVercelUrl(project.name),
+        };
+    byKey.set(key, merged);
+  }
+
+  let inserted = 0;
+  let updated = 0;
+  let errors: Array<{ id: string; message: string }> = [];
+
+  for (const agg of byKey.values()) {
+    try {
+      const existing = (await sql`SELECT id FROM projects WHERE id = ${agg.id}`) as Array<{ id: string }>;
+      if (existing.length > 0) {
+        await sql`
+          UPDATE projects SET
+            name = COALESCE(${agg.name}, name),
+            description = COALESCE(${agg.description}, description),
+            github_repo = COALESCE(${agg.github_repo}, github_repo),
+            github_private = COALESCE(${agg.github_private}, github_private),
+            github_default_branch = COALESCE(${agg.github_default_branch}, github_default_branch),
+            github_language = COALESCE(${agg.github_language}, github_language),
+            github_url = COALESCE(${agg.github_url}, github_url),
+            vercel_project_id = COALESCE(${agg.vercel_project_id}, vercel_project_id),
+            vercel_url = COALESCE(${agg.vercel_url}, vercel_url)
+          WHERE id = ${agg.id}
+        `;
+        updated += 1;
+      } else {
+        await sql`
+          INSERT INTO projects (
+            id, name, description,
+            github_repo, github_private, github_default_branch,
+            github_language, github_url,
+            vercel_project_id, vercel_url
+          ) VALUES (
+            ${agg.id}, ${agg.name}, ${agg.description},
+            ${agg.github_repo}, ${agg.github_private}, ${agg.github_default_branch},
+            ${agg.github_language}, ${agg.github_url},
+            ${agg.vercel_project_id}, ${agg.vercel_url}
+          )
+        `;
+        inserted += 1;
+      }
+    } catch (err) {
+      errors.push({
+        id: agg.id,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  await sql`
+    INSERT INTO audit_events (user_id, action, resource_type, ring, payload)
+    VALUES (
+      ${auth.userId}, 'projects.sync', 'projects', 1,
+      ${JSON.stringify({
+        inserted,
+        updated,
+        total_aggregated: byKey.size,
+        vercel_count: vp.length,
+        github_count: gr.length,
+        errors,
+      })}::jsonb
+    )
+  `;
+
+  return new Response(
+    JSON.stringify({
+      ok: errors.length === 0,
+      inserted,
+      updated,
+      total: byKey.size,
+      vercel_count: vp.length,
+      github_count: gr.length,
+      errors,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+    },
+  );
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function guessVercelUrl(projectName: string): string {
+  return `https://${projectName}.vercel.app`;
+}

--- a/app/api/vault/project-secrets/[id]/route.ts
+++ b/app/api/vault/project-secrets/[id]/route.ts
@@ -1,0 +1,52 @@
+import { sql } from "@/lib/db/client";
+import {
+  requireOperatorAuth,
+  authFailureResponse,
+} from "@/lib/auth/operator-token";
+import { invalidateSecretCache } from "@/lib/vault/get-secret";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * DELETE /api/vault/project-secrets/{id}
+ *
+ * Deletes a project-scoped secret by row id. Audit-logged at ring 3
+ * (destructive). Bearer-token protected.
+ */
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = requireOperatorAuth(req);
+  if (!auth.ok) return authFailureResponse(auth);
+
+  const { id } = await params;
+
+  const rows = (await sql`
+    DELETE FROM project_secrets WHERE id = ${id}
+    RETURNING id, project_id, name
+  `) as Array<{ id: string; project_id: string; name: string }>;
+
+  if (rows.length === 0) {
+    return new Response(JSON.stringify({ error: "secret not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  invalidateSecretCache(rows[0].name, rows[0].project_id);
+
+  await sql`
+    INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+    VALUES (
+      ${auth.userId}, 'vault.project.delete', 'project_secret', ${rows[0].id}, 3,
+      ${JSON.stringify({ name: rows[0].name, project_id: rows[0].project_id })}::jsonb
+    )
+  `;
+
+  return new Response(JSON.stringify({ ok: true, deleted: rows[0] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/api/vault/project-secrets/[id]/value/route.ts
+++ b/app/api/vault/project-secrets/[id]/value/route.ts
@@ -1,0 +1,89 @@
+import { sql } from "@/lib/db/client";
+import { decryptOperatorSecret } from "@/lib/vault/operator-crypto";
+import {
+  requireOperatorAuth,
+  authFailureResponse,
+} from "@/lib/auth/operator-token";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/vault/project-secrets/{id}/value
+ *
+ * Decrypts and returns the plaintext for a single project secret.
+ * Bearer-token protected; audit-logged at ring 1.
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = requireOperatorAuth(req);
+  if (!auth.ok) return authFailureResponse(auth);
+
+  const { id } = await params;
+
+  const rows = (await sql`
+    SELECT id, project_id, name, ciphertext, iv, auth_tag
+      FROM project_secrets
+     WHERE id = ${id}
+  `) as Array<{
+    id: string;
+    project_id: string;
+    name: string;
+    ciphertext: Buffer;
+    iv: Buffer;
+    auth_tag: Buffer;
+  }>;
+
+  if (rows.length === 0) {
+    return new Response(JSON.stringify({ error: "secret not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const row = rows[0];
+
+  let plaintext: string;
+  try {
+    plaintext = decryptOperatorSecret({
+      ciphertext: Buffer.from(row.ciphertext),
+      iv: Buffer.from(row.iv),
+      authTag: Buffer.from(row.auth_tag),
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        error: `decrypt failed: ${err instanceof Error ? err.message : String(err)}`,
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  await Promise.all([
+    sql`UPDATE project_secrets SET last_used_at = now(), last_used_by = ${auth.userId} WHERE id = ${row.id}`,
+    sql`
+      INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+      VALUES (
+        ${auth.userId}, 'vault.project.read', 'project_secret', ${row.id}, 1,
+        ${JSON.stringify({ name: row.name, project_id: row.project_id, scope: "project", via: "ui" })}::jsonb
+      )
+    `,
+  ]);
+
+  return new Response(
+    JSON.stringify({
+      id: row.id,
+      project_id: row.project_id,
+      name: row.name,
+      value: plaintext,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/app/api/vault/project-secrets/route.ts
+++ b/app/api/vault/project-secrets/route.ts
@@ -1,0 +1,159 @@
+import { sql } from "@/lib/db/client";
+import {
+  encryptOperatorSecret,
+  vaultSelfTest,
+} from "@/lib/vault/operator-crypto";
+import { invalidateSecretCache } from "@/lib/vault/get-secret";
+import {
+  requireOperatorAuth,
+  authFailureResponse,
+} from "@/lib/auth/operator-token";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface ProjectSecretRow {
+  id: string;
+  project_id: string;
+  name: string;
+  description: string | null;
+  provider: string | null;
+  created_at: string;
+  rotated_at: string | null;
+  last_used_at: string | null;
+}
+
+/**
+ * GET  /api/vault/project-secrets?projectId=...
+ * POST /api/vault/project-secrets
+ *
+ * Per-project sibling of /api/vault/operator-secrets. Same crypto,
+ * scoped by project_id. GET returns metadata only (never plaintext).
+ * POST upserts (project_id, name) — encrypts value with the same
+ * AES-256-GCM master pepper used for operator_secrets.
+ */
+export async function GET(req: Request) {
+  const auth = requireOperatorAuth(req);
+  if (!auth.ok) return authFailureResponse(auth);
+
+  const { searchParams } = new URL(req.url);
+  const projectId = searchParams.get("projectId");
+  if (!projectId) return jsonError("projectId query param required", 400);
+
+  const rows = (await sql`
+    SELECT id, project_id, name, description, provider,
+           created_at, rotated_at, last_used_at
+      FROM project_secrets
+     WHERE project_id = ${projectId}
+     ORDER BY name
+  `) as ProjectSecretRow[];
+
+  const vault_health = vaultSelfTest();
+
+  return new Response(
+    JSON.stringify({
+      project_id: projectId,
+      secrets: rows,
+      vault_health,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+    },
+  );
+}
+
+export async function POST(req: Request) {
+  const auth = requireOperatorAuth(req);
+  if (!auth.ok) return authFailureResponse(auth);
+
+  let body: {
+    projectId?: string;
+    name?: string;
+    value?: string;
+    description?: string | null;
+    provider?: string | null;
+  };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return jsonError("Invalid JSON body", 400);
+  }
+
+  const projectId = body.projectId?.trim();
+  const name = body.name?.trim();
+  const value = body.value;
+  if (!projectId) return jsonError("projectId is required", 400);
+  if (!name || !/^[A-Z][A-Z0-9_]{0,63}$/.test(name)) {
+    return jsonError(
+      "name must be UPPER_SNAKE_CASE (max 64 chars, [A-Z][A-Z0-9_]*)",
+      400,
+    );
+  }
+  if (typeof value !== "string" || value.length === 0) {
+    return jsonError("value must be a non-empty string", 400);
+  }
+  if (value.length > 8192) {
+    return jsonError("value too large (max 8192 chars)", 413);
+  }
+
+  const projExists = (await sql`SELECT id FROM projects WHERE id = ${projectId}`) as Array<{ id: string }>;
+  if (projExists.length === 0) {
+    return jsonError(`project '${projectId}' not found`, 404);
+  }
+
+  const enc = encryptOperatorSecret(value);
+
+  const ciphertextHex = enc.ciphertext.toString("hex");
+  const ivHex = enc.iv.toString("hex");
+  const authTagHex = enc.authTag.toString("hex");
+
+  const upsert = (await sql`
+    INSERT INTO project_secrets (
+      project_id, name, description, provider,
+      ciphertext, iv, auth_tag
+    ) VALUES (
+      ${projectId}, ${name},
+      ${body.description ?? null}, ${body.provider ?? null},
+      decode(${ciphertextHex}, 'hex'),
+      decode(${ivHex}, 'hex'),
+      decode(${authTagHex}, 'hex')
+    )
+    ON CONFLICT (project_id, name) DO UPDATE SET
+      description = COALESCE(EXCLUDED.description, project_secrets.description),
+      provider = COALESCE(EXCLUDED.provider, project_secrets.provider),
+      ciphertext = EXCLUDED.ciphertext,
+      iv = EXCLUDED.iv,
+      auth_tag = EXCLUDED.auth_tag,
+      rotated_at = now()
+    RETURNING id, project_id, name, created_at, rotated_at
+  `) as Array<{
+    id: string;
+    project_id: string;
+    name: string;
+    created_at: string;
+    rotated_at: string | null;
+  }>;
+
+  invalidateSecretCache(name, projectId);
+
+  await sql`
+    INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+    VALUES (
+      ${auth.userId}, 'vault.project.write', 'project_secret', ${upsert[0].id}, 2,
+      ${JSON.stringify({ name, project_id: projectId, rotated: !!upsert[0].rotated_at })}::jsonb
+    )
+  `;
+
+  return new Response(JSON.stringify({ secret: upsert[0] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -39,6 +39,8 @@ import {
   upsertRecord as nameUpsertRecord,
   deleteRecord as nameDeleteRecord,
 } from "@/lib/namecom/client";
+import { encryptOperatorSecret } from "@/lib/vault/operator-crypto";
+import { invalidateSecretCache } from "@/lib/vault/get-secret";
 
 export const TOOLS: Tool[] = [
   {
@@ -367,6 +369,59 @@ export const TOOLS: Tool[] = [
       },
       required: ["domain", "recordId"],
     },
+  },
+
+  // ─── Per-project vault ────────────────────────────────────────────
+  {
+    name: "project_secret_save",
+    description:
+      "Guarda un secret cifrado en el vault del proyecto especificado. Úsala cuando Luis te diga 'pa rivones la VITE_CLERK_PUBLISHABLE_KEY es pk_live_…' o cuando le agregues una key específica de un proyecto. NO la uses para keys generales que aplican a todos los proyectos (esas van al vault general como ANTHROPIC_API_KEY, STRIPE_SECRET_KEY, etc.). Si Luis no te dice explícitamente que es de un proyecto, pregunta el scope.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: {
+          type: "string",
+          description: "Slug del proyecto (ej. 'rivones', 'vforge'). Debe existir en la tabla projects.",
+        },
+        name: {
+          type: "string",
+          description: "Nombre UPPER_SNAKE_CASE (ej. VITE_CLERK_PUBLISHABLE_KEY)",
+        },
+        value: { type: "string", description: "Valor en plaintext (se cifra al guardar)" },
+        description: { type: "string" },
+        provider: { type: "string", description: "Proveedor (ej. clerk, stripe, google-maps)" },
+      },
+      required: ["projectId", "name", "value"],
+    },
+  },
+  {
+    name: "project_secret_list",
+    description:
+      "Lista los METADATOS de los secrets de un proyecto (nombre, provider, descripción, fecha de creación). NUNCA devuelve plaintext. Úsala para auditar qué keys tiene un proyecto.",
+    input_schema: {
+      type: "object",
+      properties: { projectId: { type: "string" } },
+      required: ["projectId"],
+    },
+  },
+  {
+    name: "project_secret_delete",
+    description:
+      "Borra un secret específico del vault de un proyecto. Ring 3 (destructivo) — confirma con Luis antes.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: { type: "string" },
+        name: { type: "string" },
+      },
+      required: ["projectId", "name"],
+    },
+  },
+  {
+    name: "projects_sync",
+    description:
+      "Cruza la lista de proyectos de Vercel con los repos de GitHub y los sincroniza a la tabla `projects` de vForge. Usa esta tool cuando Luis pregunte 'qué proyectos tengo' y la tabla esté vacía/desactualizada, o cuando agregue un proyecto nuevo. Idempotente: actualiza existentes, inserta los nuevos, no borra nada.",
+    input_schema: { type: "object", properties: {} },
   },
 ];
 
@@ -797,6 +852,222 @@ async function dispatch(
       };
     }
 
+    // ─── Per-project vault ─────────────────────────────────────────
+    case "project_secret_save": {
+      const projectId = requireString(input.projectId, "projectId");
+      const name = requireString(input.name, "name");
+      const value = requireString(input.value, "value");
+      if (!/^[A-Z][A-Z0-9_]{0,63}$/.test(name)) {
+        throw new Error(
+          "name must be UPPER_SNAKE_CASE ([A-Z][A-Z0-9_]*, max 64)",
+        );
+      }
+      const projExists = (await sql`SELECT id FROM projects WHERE id = ${projectId}`) as Array<{ id: string }>;
+      if (projExists.length === 0) {
+        throw new Error(`project '${projectId}' not in vForge catalog (run projects_sync first?)`);
+      }
+      const enc = encryptOperatorSecret(value);
+      const ciphertextHex = enc.ciphertext.toString("hex");
+      const ivHex = enc.iv.toString("hex");
+      const authTagHex = enc.authTag.toString("hex");
+      const description =
+        typeof input.description === "string" ? input.description : null;
+      const provider =
+        typeof input.provider === "string" ? input.provider : null;
+      const upsert = (await sql`
+        INSERT INTO project_secrets (
+          project_id, name, description, provider,
+          ciphertext, iv, auth_tag
+        ) VALUES (
+          ${projectId}, ${name}, ${description}, ${provider},
+          decode(${ciphertextHex}, 'hex'),
+          decode(${ivHex}, 'hex'),
+          decode(${authTagHex}, 'hex')
+        )
+        ON CONFLICT (project_id, name) DO UPDATE SET
+          description = COALESCE(EXCLUDED.description, project_secrets.description),
+          provider = COALESCE(EXCLUDED.provider, project_secrets.provider),
+          ciphertext = EXCLUDED.ciphertext,
+          iv = EXCLUDED.iv,
+          auth_tag = EXCLUDED.auth_tag,
+          rotated_at = now()
+        RETURNING id, rotated_at
+      `) as Array<{ id: string; rotated_at: string | null }>;
+      invalidateSecretCache(name, projectId);
+      return {
+        ok: true,
+        content: JSON.stringify({
+          id: upsert[0].id,
+          project_id: projectId,
+          name,
+          rotated: !!upsert[0].rotated_at,
+        }),
+        summary: `secret ${name} guardado en ${projectId}`,
+      };
+    }
+    case "project_secret_list": {
+      const projectId = requireString(input.projectId, "projectId");
+      const rows = (await sql`
+        SELECT name, description, provider,
+               created_at, rotated_at, last_used_at
+          FROM project_secrets
+         WHERE project_id = ${projectId}
+         ORDER BY name
+      `) as Array<{
+        name: string;
+        description: string | null;
+        provider: string | null;
+        created_at: Date | string;
+        rotated_at: Date | string | null;
+        last_used_at: Date | string | null;
+      }>;
+      return {
+        ok: true,
+        content: JSON.stringify({
+          project_id: projectId,
+          total: rows.length,
+          secrets: rows,
+        }),
+        summary: `${rows.length} secrets en ${projectId}`,
+      };
+    }
+    case "project_secret_delete": {
+      const projectId = requireString(input.projectId, "projectId");
+      const name = requireString(input.name, "name");
+      const rows = (await sql`
+        DELETE FROM project_secrets
+         WHERE project_id = ${projectId} AND name = ${name}
+        RETURNING id, name
+      `) as Array<{ id: string; name: string }>;
+      if (rows.length === 0) {
+        return {
+          ok: false,
+          content: JSON.stringify({ error: "not found" }),
+          summary: `${name} no existía en ${projectId}`,
+        };
+      }
+      invalidateSecretCache(name, projectId);
+      return {
+        ok: true,
+        content: JSON.stringify({
+          deleted: rows[0],
+          project_id: projectId,
+        }),
+        summary: `${name} borrado de ${projectId}`,
+      };
+    }
+    case "projects_sync": {
+      const [vps, ghs] = await Promise.all([
+        vercelListProjects({ auditUserId: ctx.userId, max: 200 }).catch(
+          () => [] as ReturnType<typeof vercelListProjects> extends Promise<infer R> ? R : never,
+        ),
+        listAllUserRepos({ auditUserId: ctx.userId, max: 200 }).catch(
+          () => [],
+        ),
+      ]);
+
+      type Aggregated = {
+        id: string;
+        name: string;
+        description: string | null;
+        github_repo: string | null;
+        github_private: boolean | null;
+        github_default_branch: string | null;
+        github_language: string | null;
+        github_url: string | null;
+        vercel_project_id: string | null;
+        vercel_url: string | null;
+      };
+      const byKey = new Map<string, Aggregated>();
+      for (const repo of (Array.isArray(ghs) ? ghs : [])) {
+        byKey.set(repo.full_name.toLowerCase(), {
+          id: slugify(repo.name),
+          name: repo.name,
+          description: repo.description,
+          github_repo: repo.full_name,
+          github_private: repo.private,
+          github_default_branch: repo.default_branch,
+          github_language: repo.language,
+          github_url: repo.html_url,
+          vercel_project_id: null,
+          vercel_url: null,
+        });
+      }
+      for (const project of (Array.isArray(vps) ? vps : [])) {
+        const link = project.link as
+          | { type?: string; org?: string; repo?: string }
+          | null
+          | undefined;
+        const fullName = link?.org && link?.repo ? `${link.org}/${link.repo}` : null;
+        const key = fullName ? fullName.toLowerCase() : `vercel:${project.name}`;
+        const prev = byKey.get(key);
+        const merged: Aggregated = prev
+          ? {
+              ...prev,
+              vercel_project_id: project.id,
+              vercel_url: prev.vercel_url ?? `https://${project.name}.vercel.app`,
+            }
+          : {
+              id: slugify(project.name),
+              name: project.name,
+              description: null,
+              github_repo: null,
+              github_private: null,
+              github_default_branch: null,
+              github_language: null,
+              github_url: null,
+              vercel_project_id: project.id,
+              vercel_url: `https://${project.name}.vercel.app`,
+            };
+        byKey.set(key, merged);
+      }
+      let inserted = 0;
+      let updated = 0;
+      for (const agg of byKey.values()) {
+        const existing = (await sql`SELECT id FROM projects WHERE id = ${agg.id}`) as Array<{ id: string }>;
+        if (existing.length > 0) {
+          await sql`
+            UPDATE projects SET
+              name = COALESCE(${agg.name}, name),
+              description = COALESCE(${agg.description}, description),
+              github_repo = COALESCE(${agg.github_repo}, github_repo),
+              github_private = COALESCE(${agg.github_private}, github_private),
+              github_default_branch = COALESCE(${agg.github_default_branch}, github_default_branch),
+              github_language = COALESCE(${agg.github_language}, github_language),
+              github_url = COALESCE(${agg.github_url}, github_url),
+              vercel_project_id = COALESCE(${agg.vercel_project_id}, vercel_project_id),
+              vercel_url = COALESCE(${agg.vercel_url}, vercel_url)
+            WHERE id = ${agg.id}
+          `;
+          updated += 1;
+        } else {
+          await sql`
+            INSERT INTO projects (
+              id, name, description,
+              github_repo, github_private, github_default_branch,
+              github_language, github_url,
+              vercel_project_id, vercel_url
+            ) VALUES (
+              ${agg.id}, ${agg.name}, ${agg.description},
+              ${agg.github_repo}, ${agg.github_private}, ${agg.github_default_branch},
+              ${agg.github_language}, ${agg.github_url},
+              ${agg.vercel_project_id}, ${agg.vercel_url}
+            )
+          `;
+          inserted += 1;
+        }
+      }
+      return {
+        ok: true,
+        content: JSON.stringify({
+          inserted,
+          updated,
+          total: byKey.size,
+        }),
+        summary: `proyectos sync: +${inserted} nuevos, ${updated} actualizados`,
+      };
+    }
+
     default:
       return {
         ok: false,
@@ -809,6 +1080,14 @@ async function dispatch(
 function nullableString(v: unknown): string | null {
   if (typeof v !== "string") return null;
   return v.length === 0 ? null : v;
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
 }
 
 function clampNumber(

--- a/lib/vault/get-secret.ts
+++ b/lib/vault/get-secret.ts
@@ -1,13 +1,14 @@
 /**
- * Server-side helper for V (and any backend code) to invoke an
- * operator secret by name. Reads from operator_secrets table,
- * decrypts on the fly with the AES key derived from
- * VFORGE_MASTER_PEPPER, updates last_used_at, and returns the
- * plaintext.
+ * Server-side helper for V (and any backend code) to invoke a
+ * vault secret by name, with cascade resolution:
  *
- * Falls back to process.env when the secret hasn't been migrated
- * yet — keeps the brain endpoint working during the transition
- * from "all keys in Vercel env" to "all keys in DB cifradas".
+ *    project_secrets (if scope.projectId)
+ *      → operator_secrets (always)
+ *      → process.env (transition fallback)
+ *
+ * Reads from the relevant table, decrypts on the fly with the AES
+ * key derived from VFORGE_MASTER_PEPPER, updates last_used_at, and
+ * returns the plaintext. Each successful read writes an audit event.
  */
 import { queryOne, sql } from "@/lib/db/client";
 import { decryptOperatorSecret } from "./operator-crypto";
@@ -22,21 +23,55 @@ interface SecretRow {
 const VAULT_HIT_CACHE = new Map<string, { value: string; expiresAt: number }>();
 const CACHE_TTL_MS = 60 * 1000; // 60 s in-process cache (per Lambda invocation)
 
+function cacheKey(name: string, projectId: string | null | undefined): string {
+  return projectId ? `p:${projectId}:${name}` : `g:${name}`;
+}
+
+interface GetSecretOptions {
+  auditUserId?: string;
+  /**
+   * If set, look in project_secrets WHERE project_id=projectId AND name=name
+   * BEFORE falling through to operator_secrets. If the value isn't found at
+   * the project scope, the resolution continues with the global vault — so
+   * a project can override a key (e.g. its own VITE_CLERK_PUBLISHABLE_KEY)
+   * without invalidating the shared default.
+   */
+  projectId?: string | null;
+}
+
 /**
- * Returns the plaintext value of an operator secret, looking it up
- * by name. Cached for 60 seconds in-memory per process.
- *
- * Falls back to process.env[name] if no DB row exists.
+ * Returns the plaintext value of a vault secret, with project →
+ * operator → env cascade. Cached for 60 seconds in-memory per process,
+ * keyed on (scope, name) so different projects don't poison each
+ * other's cache.
  */
 export async function getOperatorSecret(
   name: string,
-  options: { auditUserId?: string } = {},
+  options: GetSecretOptions = {},
 ): Promise<string | null> {
-  const cached = VAULT_HIT_CACHE.get(name);
+  const cKey = cacheKey(name, options.projectId);
+  const cached = VAULT_HIT_CACHE.get(cKey);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.value;
   }
 
+  // 1) Project-scoped lookup (if requested)
+  if (options.projectId) {
+    const projectRow = await tryReadProjectSecret(
+      options.projectId,
+      name,
+      options.auditUserId,
+    );
+    if (projectRow) {
+      VAULT_HIT_CACHE.set(cKey, {
+        value: projectRow,
+        expiresAt: Date.now() + CACHE_TTL_MS,
+      });
+      return projectRow;
+    }
+  }
+
+  // 2) Global operator vault
   let row: SecretRow | null = null;
   try {
     row = await queryOne<SecretRow>(
@@ -45,14 +80,14 @@ export async function getOperatorSecret(
       [name],
     );
   } catch {
-    // DB unreachable → degrade to env var
     row = null;
   }
 
   if (!row) {
+    // 3) Env fallback
     const envVal = process.env[name];
     if (envVal) {
-      VAULT_HIT_CACHE.set(name, {
+      VAULT_HIT_CACHE.set(cKey, {
         value: envVal,
         expiresAt: Date.now() + CACHE_TTL_MS,
       });
@@ -69,28 +104,66 @@ export async function getOperatorSecret(
       authTag: Buffer.from(row.auth_tag),
     });
   } catch (err) {
-    // If decryption fails, fall back to env var so the system keeps
-    // working while we diagnose. Log loudly so it's visible.
     console.error("[vault] decrypt failed for", name, err);
     return process.env[name] ?? null;
   }
 
-  // Update last_used_at + audit log (fire-and-forget, don't block the call)
   void Promise.all([
     sql`UPDATE operator_secrets SET last_used_at = now(), last_used_by = ${options.auditUserId ?? null} WHERE id = ${row.id}`,
     sql`
       INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
       VALUES (
         ${options.auditUserId ?? "system"}, 'vault.operator.read', 'operator_secret', ${row.id}, 1,
-        ${JSON.stringify({ name })}::jsonb
+        ${JSON.stringify({ name, scope: "global" })}::jsonb
       )
     `,
   ]).catch(() => undefined);
 
-  VAULT_HIT_CACHE.set(name, {
+  VAULT_HIT_CACHE.set(cKey, {
     value: plaintext,
     expiresAt: Date.now() + CACHE_TTL_MS,
   });
+  return plaintext;
+}
+
+async function tryReadProjectSecret(
+  projectId: string,
+  name: string,
+  auditUserId?: string,
+): Promise<string | null> {
+  let row: SecretRow | null = null;
+  try {
+    row = await queryOne<SecretRow>(
+      `SELECT id::text, ciphertext, iv, auth_tag
+         FROM project_secrets
+        WHERE project_id = $1 AND name = $2`,
+      [projectId, name],
+    );
+  } catch {
+    return null;
+  }
+  if (!row) return null;
+  let plaintext: string;
+  try {
+    plaintext = decryptOperatorSecret({
+      ciphertext: Buffer.from(row.ciphertext),
+      iv: Buffer.from(row.iv),
+      authTag: Buffer.from(row.auth_tag),
+    });
+  } catch (err) {
+    console.error("[vault] decrypt failed for project secret", projectId, name, err);
+    return null;
+  }
+  void Promise.all([
+    sql`UPDATE project_secrets SET last_used_at = now(), last_used_by = ${auditUserId ?? null} WHERE id = ${row.id}`,
+    sql`
+      INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+      VALUES (
+        ${auditUserId ?? "system"}, 'vault.project.read', 'project_secret', ${row.id}, 1,
+        ${JSON.stringify({ name, project_id: projectId, scope: "project" })}::jsonb
+      )
+    `,
+  ]).catch(() => undefined);
   return plaintext;
 }
 
@@ -99,7 +172,7 @@ export async function getOperatorSecret(
  */
 export async function requireOperatorSecret(
   name: string,
-  options: { auditUserId?: string } = {},
+  options: GetSecretOptions = {},
 ): Promise<string> {
   const value = await getOperatorSecret(name, options);
   if (!value) {
@@ -113,7 +186,13 @@ export async function requireOperatorSecret(
 /**
  * Drop the in-process cache. Useful after rotating a key.
  */
-export function invalidateSecretCache(name?: string): void {
-  if (name) VAULT_HIT_CACHE.delete(name);
-  else VAULT_HIT_CACHE.clear();
+export function invalidateSecretCache(
+  name?: string,
+  projectId?: string | null,
+): void {
+  if (name) {
+    VAULT_HIT_CACHE.delete(cacheKey(name, projectId));
+  } else {
+    VAULT_HIT_CACHE.clear();
+  }
 }

--- a/migrations/004_project_secrets.sql
+++ b/migrations/004_project_secrets.sql
@@ -1,0 +1,33 @@
+-- -----------------------------------------------------------
+-- Migration 004 — Per-project vault
+--
+-- Adds a project-scoped sibling to operator_secrets. Same AES-256-GCM
+-- crypto with VFORGE_MASTER_PEPPER, but rows are tied to a project_id.
+-- Resolution cascade in app code: project_secrets → operator_secrets
+-- → process.env. UNIQUE on (project_id, name) so each project can
+-- have its own VITE_CLERK_PUBLISHABLE_KEY, STRIPE_SECRET_KEY, etc.
+-- -----------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS project_secrets (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id        text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name              text NOT NULL,
+  description       text,
+  ciphertext        bytea NOT NULL,
+  iv                bytea NOT NULL,
+  auth_tag          bytea NOT NULL,
+  provider          text,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  rotated_at        timestamptz,
+  last_used_at      timestamptz,
+  last_used_by      text REFERENCES users(id) ON DELETE SET NULL,
+  UNIQUE (project_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_secrets_project
+  ON project_secrets (project_id);
+CREATE INDEX IF NOT EXISTS idx_project_secrets_provider
+  ON project_secrets (provider);
+
+INSERT INTO schema_migrations (version) VALUES ('004_project_secrets')
+  ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Summary

Tres cosas que Luis pidió mientras arrancaba a usar V con tools:

1. **Claves por proyecto** — Stripe global (general vault), pero Clerk de Rivones solo aplica a Rivones (project vault).
2. **Reconocer proyectos existentes** — Break ya estaba en Vercel pero la tabla `projects` estaba vacía.
3. **No pegar tokens en curl** — botón "Migrar" en `/vault` que usa el bearer del localStorage.

## Piezas

### Schema 004 — `project_secrets`
- Mismo crypto que `operator_secrets` (AES-256-GCM, mismo pepper)
- `project_id` FK → `projects(id) ON DELETE CASCADE`
- `UNIQUE(project_id, name)` → cada proyecto tiene su namespace
- Índices por `project_id` y por `provider`

### Cascade resolver
`getOperatorSecret(name, { projectId? })` busca en orden:
```
project_secrets[projectId] → operator_secrets → process.env
```
Cache keyed por `(scope, name)`. Audit events distintos por scope.

### CRUD endpoints `/api/vault/project-secrets`
| Endpoint | Qué hace |
|---|---|
| `GET ?projectId=X` | Metadata (no plaintext) |
| `POST` | Encrypt + upsert |
| `GET /:id/value` | Reveal plaintext con audit |
| `DELETE /:id` | Borrar + invalidar cache |

### Endpoint `/api/projects/sync`
Cruza `vercel_list_projects` + `github_list_repos`, dedupa por GitHub repo (o nombre Vercel), idempotente (UPDATE si existe, COALESCE para no pisar). Bearer-protected, audit ring 1.

### Tools nuevas para V (4)
- `project_secret_save` (ring 2)
- `project_secret_list` (ring 0)
- `project_secret_delete` (ring 3)
- `projects_sync` (ring 1)

### UI `/vault`
- Tabs **General | Por proyecto** + selector de proyecto
- Mismo flow Ver/Copiar/Borrar/Agregar (`SecretRow` + modal reusados)
- Botón **🔧 Migrar** en header — POST a `/api/admin/migrate` con bearer del localStorage. **No más curl.**
- `ProjectEmptyState` que invita a sync si no hay proyectos

### UI `/projects`
- Botón **↻ Sincronizar** arriba (spinner mientras corre)
- Estado inline `+N nuevos · M actualizados`
- Lee operator token de localStorage

## Después del deploy

Tap **🔧 Migrar** en `/vault` → corre migración 004 idempotente.

## Test plan

- [ ] Tap **Migrar** en `/vault` → ve "aplicadas 1: 004_project_secrets.sql"
- [ ] Ir a `/projects` → tap **Sincronizar** → ve `+N nuevos · M actualizados`
- [ ] Break y todos los Vercel projects aparecen en la lista
- [ ] En `/vault` → tab **Por proyecto** → seleccionar `rivones` → agregar `VITE_CLERK_PUBLISHABLE_KEY` con valor → ✓ guardado
- [ ] V en `/forge`: "guarda en Rivones la VITE_GOOGLE_MAPS_API_KEY = AIza…" → invoca `project_secret_save` → ✓
- [ ] V: "qué keys tiene rivones?" → invoca `project_secret_list`

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_