### PR TITLE
fix(admin/migrate): no descartar primera sentencia con bloque de comentarios

### DIFF
--- a/app/api/admin/migrate/route.ts
+++ b/app/api/admin/migrate/route.ts
@@ -115,6 +115,11 @@ export async function POST(req: Request) {
 /**
  * Split SQL on `;` while respecting `DO $$ ... $$;` and quoted strings.
  * Naive but handles our migration style.
+ *
+ * Strips leading comment-only lines from each chunk before evaluating
+ * whether it's "empty" — earlier the first statement was being dropped
+ * whenever the file started with a block comment, since the trimmed
+ * buffer began with "--".
  */
 function splitSql(input: string): string[] {
   const out: string[] = [];
@@ -135,14 +140,26 @@ function splitSql(input: string): string[] {
     }
     buf += ch;
     if (!inDollar && !inSingle && ch === ";") {
-      const trimmed = buf.trim();
-      if (trimmed && !trimmed.startsWith("--")) out.push(trimmed);
+      const meaningful = stripCommentLines(buf);
+      if (meaningful) out.push(buf.trim());
       buf = "";
     }
   }
-  const tail = buf.trim();
-  if (tail && !tail.startsWith("--")) out.push(tail);
+  const meaningfulTail = stripCommentLines(buf);
+  if (meaningfulTail) out.push(buf.trim());
   return out;
+}
+
+/** Remove lines that are pure SQL comments. Returns the remaining content. */
+function stripCommentLines(s: string): string {
+  return s
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed.length > 0 && !trimmed.startsWith("--");
+    })
+    .join("\n")
+    .trim();
 }
 
 function jsonError(message: string, status: number): Response {


### PR DESCRIPTION
## Summary

Hotfix: el splitter de SQL en `/api/admin/migrate` descartaba la primera sentencia de cualquier migración que arrancara con un bloque de comentarios `--`. Como casi todas nuestras migraciones empiezan con un header explicativo, esto rompía silenciosamente.

## Síntoma

Al aplicar `004_project_secrets.sql` en producción:
```
status: error
message: relation "project_secrets" does not exist
```

El CREATE TABLE inicial venía pegado al header de comentarios. Como el chunk completo (comentarios + CREATE TABLE) empezaba con `--`, mi check `trimmed.startsWith("--")` lo descartaba. Las siguientes sentencias (CREATE INDEX) sí se ejecutaban — y explotaban porque la tabla nunca se creó.

## Fix

`stripCommentLines()` filtra líneas de comentario antes de evaluar si el chunk está "vacío". Si hay SQL real ahí, se ejecuta el chunk completo (preservando comentarios para que el log sea legible).

## Test plan

- [ ] Mergear → tap "🔧 Migrar" en `/vault`
- [ ] Status debería mostrar "aplicadas 1: 004_project_secrets.sql"
- [ ] `/projects` → tap "Sincronizar" → ve los proyectos del catálogo
- [ ] `/vault` → tab "Por proyecto" → debería listar proyectos y permitir agregar secrets

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_