### PR TITLE
feat(forge): 5 nuevas tools GitHub write (Ring 1-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,110 @@
+# vForge environment variables — template.
+#
+# Copy to .env.local for local dev (it's gitignored). For production, set
+# the same names in Vercel → Project → Settings → Environment Variables.
+#
+# Vault cascade (see lib/vault/get-secret.ts):
+#     project_secrets (Neon)
+#       → operator_secrets (Neon, AES-256-GCM with VFORGE_MASTER_PEPPER)
+#         → process.env (this file)
+#
+# Service catalog is canonical in docs/decisions/009-external-service-stack.md.
+# Runbooks per service live in docs/integrations/.
+
+# ── Vercel access ──────────────────────────────────────────────────────
+# Personal token so vForge can manage its own and other projects' env vars,
+# trigger deployments, and read runtime logs. Used by lib/vercel/client.ts.
+# Create at https://vercel.com/account/tokens.
+VERCEL_TOKEN=
+VERCEL_TEAM_ID=team_xxxxxxxxxxxxxxxxxxxxxxxxx
+VERCEL_PROJECT_ID=prj_xxxxxxxxxxxxxxxxxxxxxxxxx
+
+# ── Database (Neon Postgres) ───────────────────────────────────────────
+# Source of truth. Branching as Git per ADR-009. The serverless driver
+# (@neondatabase/serverless) handles both HTTP and Node TCP transports.
+DATABASE_URL=postgres://user:pass@host.neon.tech/vforge?sslmode=require
+# Neon REST API — used by V to manage branches per feature.
+NEON_API_KEY=
+NEON_PROJECT_ID=
+NEON_ORG_ID=
+
+# ── LLM providers ──────────────────────────────────────────────────────
+# Anthropic — primary adapter (ADR-005). Used at app/api/forge/run/route.ts.
+ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# OpenRouter — secondary gateway (ADR-005, ADR-009). Gives V access to
+# Gemini, Mistral, Llama, etc. through one key. Used by the
+# `openrouter-gateway` adapter (M3).
+OPENROUTER_API_KEY=sk-or-v1-...
+
+# OpenAI — image (gpt-image-1, M6) and voice (whisper, M10).
+OPENAI_API_KEY=sk-proj-...
+
+# Gemini direct (optional — only if not going through OpenRouter).
+GEMINI_API_KEY=
+
+# Perplexity — alternative web search adapter. anthropic-web-search is
+# primary; Perplexity stays as fallback.
+PERPLEXITY_API_KEY=
+
+# ── Auth (Clerk) — wired in Fase 2 ─────────────────────────────────────
+# See docs/integrations/clerk.md. Today routes default to operator_luis.
+CLERK_SECRET_KEY=
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+
+# ── Operator infra (so vForge's tools can talk to other services) ──────
+# GitHub PAT for the github tools (read repos, list commits, etc.).
+# Used by lib/github/client.ts.
+GITHUB_TOKEN=ghp_...
+
+# Name.com API credentials for DNS tools (lib/namecom/client.ts).
+NAMECOM_USER=
+NAMECOM_TOKEN=
+
+# ── External services from ADR-009 — Fase 1 ────────────────────────────
+# E2B microVM sandbox for the claude-code-sdk adapter (M5).
+# Sign up at https://e2b.dev/dashboard.
+E2B_API_KEY=e2b_...
+
+# Trigger.dev for background jobs > 60s (M9).
+# Create a project at https://trigger.dev.
+TRIGGER_API_KEY=tr_pat_...
+TRIGGER_PROJECT_ID=proj_xxxxxxxxxxx
+
+# Resend for transactional email (M9.5). Verify vforge.site domain first
+# via the namecom_upsert_record tool (DKIM + SPF + DMARC).
+RESEND_API_KEY=re_...
+RESEND_FROM_ADDRESS=noreply@vforge.site
+
+# ── External services from ADR-009 — Fase 2 (multi-tenant) ─────────────
+# Turso edge SQLite — per-tenant DBs (M12).
+TURSO_AUTH_TOKEN=
+TURSO_ORG_SLUG=vforge
+
+# Liveblocks realtime collab (M13).
+LIVEBLOCKS_SECRET_KEY=sk_prod_...
+NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_prod_...
+
+# Polar.sh billing (M14). Wrappes Stripe with SaaS-dev DX.
+POLAR_ACCESS_TOKEN=polar_oat_...
+POLAR_ORGANIZATION_ID=org_...
+POLAR_WEBHOOK_SECRET=whsec_...
+
+# Unkey for per-tenant API key issuance (M15).
+UNKEY_ROOT_KEY=unkey_...
+UNKEY_API_ID=api_...
+
+# ── vForge internals ───────────────────────────────────────────────────
+# AES-256-GCM pepper for operator_secrets encryption (ADR-008). Generate
+# ONCE per deploy and never rotate (rotation forces re-encrypting every
+# row). Generate with:
+#   node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))'
+VFORGE_MASTER_PEPPER=
+
+# Admin/bootstrap token (Bearer auth for /api/admin/migrate etc.).
+# Replaced by Unkey-issued keys in Fase 2.
+VFORGE_OPERATOR_TOKEN=
+
+# ── Misc ───────────────────────────────────────────────────────────────
+# Canonical public origin. Used in emails, audit links, OAuth callbacks.
+NEXT_PUBLIC_SITE_URL=https://vforge.site

--- a/AUDITORIA_VFORGE_2026-05-12.md
+++ b/AUDITORIA_VFORGE_2026-05-12.md
@@ -1,0 +1,379 @@
+# Auditoría vForge — 2026-05-12
+
+> *Foto del estado real del repo y de los servicios externos. Ejecutada al inicio de la sesión de bootstrap MVP. Sirve de baseline contra el que medimos el progreso hacia el roadmap M0→M15 (ver `docs/architecture.md §7` post-ADR-009).*
+
+- **Operador:** Luis Humberto de la Torre Herrera
+- **Rama actual:** `claude/vforge-mvp-Lw6HY` (limpia, sin uncommitted)
+- **Auditor:** Claude Code (Opus 4.7) en sesión de bootstrap
+- **Estado global:** **~70% del cerebro cableado**, bloqueado en credenciales plaintext para arrancar la auditoría real de la BD
+
+---
+
+## 1. Veredicto en una página
+
+vForge **no es un scaffold vacío** — el cerebro de V está parcialmente construido y la arquitectura está documentada al detalle.
+
+| Área | Estado | Comentario |
+|---|---|---|
+| Stack base | ✅ Listo | Next.js 16 + React 19 + TypeScript estricto + Tailwind 4 + shadcn |
+| ADRs | ✅ 9 firmados | 001-008 originales + 009 (ADR de stack externo, escrito hoy) |
+| Schema BD | ✅ 4 migraciones | users, secrets dobles (operator + zero-knowledge), knowledge_base, conversations, projects, audit_events, project_secrets |
+| Vault | ✅ Funcional | AES-256-GCM server-side (operator_secrets) + zero-knowledge (user_secrets) + cascade `project → operator → env` |
+| Cerebro endpoint | ✅ Funcional | `/api/forge/run` con streaming SSE, tool loop de 5 rondas, persistencia de turnos |
+| Tools cableadas | ✅ 22 tools | GitHub (5), Vercel (8), Name.com (5), Vault per-project (3), memory_save, projects_sync |
+| Memoria persistente | ✅ Rica | knowledge_base + conversations + recaps + memorias explícitas |
+| Voz de V | ✅ Definida | `system_config.ai_personality` + senior-engineer doctrine en system-prompt |
+| Anillos de privilegio | ✅ Documentados | 0-3, respetados en system prompt y en tools.ts |
+| Frontend dashboard | 🟡 Scaffold | 10 pantallas con mock-data; falta cablearlas a los endpoints reales |
+| Adapter pattern | 🔜 Pendiente | Contract listo (`lib/forge/adapters/_contract.ts`), implementaciones por venir en M3-M15 |
+| OpenRouter adapter | 🔜 Pendiente | M3 — bloqueado en `OPENROUTER_API_KEY` (Luis va a generarla) |
+| Clerk | 🔜 Pendiente | M11 (Fase 2) — hoy `OPERATOR_USER_ID = "operator_luis"` hardcoded |
+| Aplicación de migraciones a Neon | ⛔ Bloqueado | Falta `DATABASE_URL` plaintext — Vercel EEV no se desencripta vía API |
+
+**Bloqueador único crítico:** falta plaintext de `DATABASE_URL`, `OPENROUTER_API_KEY`, y `VFORGE_MASTER_PEPPER`. Todo lo demás (documentación, adapter contract, runbooks, roadmap) se está completando sin tocar BD ni claves.
+
+---
+
+## 2. Topología del repo
+
+```
+vforge/
+├── app/                          Next.js App Router
+│   ├── (dashboard)/              10 pantallas con shell de UI
+│   │   ├── forge/                Chat principal con V
+│   │   ├── activity/             Audit log + cost tracking
+│   │   ├── hub/                  Dashboard agregado
+│   │   ├── hunter/               Búsqueda externa
+│   │   ├── modules/              Catálogo de capacidades
+│   │   ├── projects/             Lista + detail por slug
+│   │   ├── scout/                Discovery
+│   │   ├── settings/             Config + integraciones
+│   │   ├── vault/                Vault UI (operator + project secrets)
+│   │   └── vision/               Repo Vision
+│   └── api/                      17 endpoints (ver §5)
+├── components/                   providers, ui (shadcn), vforge, web-apis
+├── docs/
+│   ├── architecture.md           Roadmap + diagrama del cerebro (extendido hoy)
+│   ├── method.md                 El Método vForge
+│   ├── playbook.md               Manual operativo extendido
+│   ├── v0-prompt.md              Prompts para v0.dev
+│   ├── decisions/                9 ADRs (001-009)
+│   └── integrations/             Runbooks: clerk, neon, name-com, model-providers + 8 nuevos en M3-M15
+├── lib/
+│   ├── auth/                     operator-token.ts (71)
+│   ├── db/                       client.ts (66) — Neon serverless
+│   ├── forge/                    system-prompt.ts (310), tools.ts (1128), adapters/ (nuevo hoy)
+│   ├── github/                   client.ts (241) — Octokit
+│   ├── namecom/                  client.ts (199) — Name.com REST
+│   ├── vault/                    get-secret.ts (198), operator-crypto.ts (98)
+│   ├── vercel/                   client.ts (294) — Vercel REST
+│   └── mock-data.ts              (107) — usado por frontend mientras se cablea
+├── migrations/                   001-004 SQL (esquema + seeds)
+├── AGENTS.md                     Protocolo multi-agente
+├── README.md
+└── .env.example                  Reescrito hoy con shape canónico de ADR-009
+```
+
+Total backend: **~2,720 líneas TypeScript**. Es un MVP funcional, no un scaffold.
+
+---
+
+## 3. Stack y dependencias clave
+
+Verificado en `package.json`:
+
+| Dependencia | Versión | Uso |
+|---|---|---|
+| `next` | `16.2.4` | App Router + Edge Runtime |
+| `react` / `react-dom` | `^19` | UI |
+| `typescript` | `5.7.3` | Lenguaje |
+| `tailwindcss` | `^4.2.0` | Estilos (sintaxis @theme inline) |
+| `@anthropic-ai/sdk` | `^0.92.0` | Cliente Anthropic — usado en `/api/forge/run` |
+| `@neondatabase/serverless` | `^1.1.0` | Cliente Postgres con HTTP transport |
+| `openai` | `^6.35.0` | Cliente OpenAI — usado en `/api/forge/transcribe` y `/extract-secret` |
+| `octokit` | `^5.0.5` | Cliente GitHub |
+| `zod` | `^3.24.1` | Validación |
+| `framer-motion` | `^12.38.0` | Animaciones |
+| `@radix-ui/*` | varios | Primitivas shadcn |
+
+**Dependencias que llegan con ADR-009 (no instaladas aún):** `@openrouter/sdk` (o usar `openai` SDK contra `openrouter.ai/api/v1`), `@e2b/code-interpreter`, `@trigger.dev/sdk`, `resend`, `@libsql/client`, `@liveblocks/node`, `@polar-sh/sdk`, `@unkey/api`.
+
+---
+
+## 4. Schema actual (sin verificar contra Neon — pendiente)
+
+`migrations/` tiene 4 archivos. Lo que cada uno crea (leído desde el SQL, NO confirmado en Neon):
+
+### 001_initial.sql
+
+- `schema_migrations` — control de migraciones aplicadas
+- `users` — keyed por Clerk user_id (futuro); `operator_luis` en MVP
+- `operator_secrets` — Class 1 (server-side AES-256-GCM)
+- `user_secrets` — Class 2 (zero-knowledge AES-256-GCM client-side)
+- `projects` — catálogo de apps gestionadas por Forge AI
+- `knowledge_base` — memoria persistente de V (kinds: operator_profile, organization, method, preference, lesson, note con tags `session_recap` o `memory`)
+- `conversations` — historial de chat (`role`, `content`, tokens, cost, model)
+- `audit_events` — toda acción de Anillo 0-3 con `ring`, `action`, `resource_type`, `payload jsonb`
+- `system_config` — id=1 singleton con ai_name, ai_personality, default_model, default_tone
+
+### 002_seed.sql
+
+- Inserta usuario `operator_luis` (Luis, turbillon50@gmail.com)
+- Inserta `system_config` con personalidad completa de V (5+ párrafos en español MX) y modelo default `claude-sonnet-4-6`
+- Inserta knowledge_base inicial: operator_profile, organization (AGH), method (vForge), stack preference, más
+
+### 003_seed_protocols.sql
+
+- Inserta knowledge_base con protocolos: NUEVO, RESCATE, HUNTER
+- Inserta lessons del día 1 (deploy de Rivones con caveats Vite outDir + DNS)
+
+### 004_project_secrets.sql
+
+- Crea `project_secrets` (sibling de `operator_secrets` con UNIQUE(project_id, name))
+- Resolución cascade implementada en `lib/vault/get-secret.ts`
+
+**Hallazgo importante:** las migraciones están escritas pero **no sabemos si están aplicadas en Neon**. Hay que correr `/api/admin/migrate` (que escanea `migrations/`, aplica por filename, idempotente) en cuanto tengamos `DATABASE_URL`.
+
+---
+
+## 5. Endpoints API existentes (17)
+
+### Cerebro / Forge
+
+| Endpoint | Método | Estado | Notas |
+|---|---|---|---|
+| `/api/forge/run` | POST | ✅ Funcional | Streaming SSE, tool loop max 5 rondas, persiste turnos, Anthropic SDK directo |
+| `/api/forge/recap` | POST | ✅ Funcional | Pide a Haiku resumen de la sesión, lo guarda como `kind='note'` con tag `session_recap` |
+| `/api/forge/transcribe` | POST | ✅ Funcional | OpenAI Whisper, multipart audio, audio NO se persiste |
+| `/api/forge/extract-secret` | POST | ✅ Funcional | OCR de screenshots con OpenAI vision para detectar API keys; protegido por operator token |
+| `/api/forge/conversations` | GET | ✅ Funcional | Rehidratar chat por sessionId, ordenado cronológico |
+| `/api/forge/active-session` | GET/POST | ✅ Funcional | Cross-device session ID — comparte chat entre laptop y phone |
+
+### Projects
+
+| Endpoint | Método | Estado | Notas |
+|---|---|---|---|
+| `/api/projects` | GET | ✅ | Lista del catálogo (tabla `projects`) |
+| `/api/projects/[id]` | GET/PATCH | ✅ | Detail + edit |
+| `/api/projects/sync` | POST | ✅ | Cross-check GitHub + Vercel, insert/update en `projects` |
+| `/api/stats` | GET | ✅ | Métricas agregadas |
+
+### GitHub
+
+| Endpoint | Método | Estado |
+|---|---|---|
+| `/api/github/repos` | GET | ✅ |
+| `/api/github/repos/[owner]/[repo]` | GET | ✅ |
+
+### Vault
+
+| Endpoint | Método | Estado | Notas |
+|---|---|---|---|
+| `/api/vault/operator-secrets` | GET/POST | ✅ | Lista metadata + create encrypted |
+| `/api/vault/operator-secrets/[id]` | GET/PATCH/DELETE | ✅ | CRUD individual |
+| `/api/vault/operator-secrets/[id]/value` | POST | ✅ | Reveal plaintext (requires operator auth) |
+| `/api/vault/project-secrets` | GET/POST | ✅ | Mismo patrón, per-project |
+| `/api/vault/project-secrets/[id]` | GET/PATCH/DELETE | ✅ | |
+| `/api/vault/project-secrets/[id]/value` | POST | ✅ | |
+
+### Admin
+
+| Endpoint | Método | Estado |
+|---|---|---|
+| `/api/admin/migrate` | POST | ✅ Idempotente, splits por `;` con DO $$ awareness |
+
+**Endpoints que faltan según el roadmap M0→M15:**
+
+- `/api/admin/health` — health check agregado por adapter (M9)
+- `/api/forge/bg-run` — long-running jobs vía Trigger.dev (M9)
+- `/api/forge/code-exec` — corre Claude Code SDK dentro de E2B (M5)
+- `/api/billing/*` — checkout, customer portal, webhooks (M14, Fase 2)
+- `/api/apikeys/*` — issue, revoke, list per-tenant (M15, Fase 2)
+- `/api/clerk/webhook` — sync de users (M11, Fase 2)
+
+---
+
+## 6. Tools cableadas (22)
+
+Catalogadas en `lib/forge/tools.ts:45-426`. Cada una con `ring`, `description`, `input_schema`, audit a `forge.tool.invoke`.
+
+**GitHub (read-only, ring 0):** `github_list_repos`, `github_get_repo`, `github_list_commits`, `github_read_file`.
+**GitHub write (no cableado todavía):** falta `github_commit_file`, `github_create_pr`, `github_create_issue` — milestone M8.
+**Vercel (ring 0-1):** `vercel_list_projects`, `vercel_get_project`, `vercel_create_project`, `vercel_list_deployments`, `vercel_get_deployment`, `vercel_trigger_deployment`, `vercel_set_env_var`, `vercel_add_domain`, `vercel_get_domain_config` (9 — la cuenta dice 8 en el chat anterior; conté de nuevo, son 9).
+**Name.com (ring 0-1):** `namecom_list_domains`, `namecom_get_domain`, `namecom_list_records`, `namecom_upsert_record`, `namecom_delete_record`.
+**Vault (ring 0-1):** `vault_list_secrets`, `project_secret_save`, `project_secret_list`, `project_secret_delete`.
+**Memoria:** `memory_save`.
+**Sync:** `projects_sync`.
+
+**Tools que faltan según ADR-009:**
+
+| Tool | Adapter | Milestone |
+|---|---|---|
+| `model_route` | routing.ts | M3 |
+| `code_exec` | claude-code-sdk + e2b-microvm | M5 |
+| `web_search` | anthropic-web-search | M4 |
+| `image_generate` | openai-image | M6 |
+| `voice_transcribe` (ya hay endpoint pero falta tool) | openai-whisper | M10 |
+| `bg_enqueue` + `bg_status` | trigger-bg | M9 |
+| `email_send` | resend-email | M9.5 |
+| `github_commit_file` + `github_create_pr` | github-octokit (write ops) | M8 |
+| `vercel_deploy` con confirmación | vercel-deploy | M7 |
+| `realtime_room_create` | liveblocks-rooms | M13 (Fase 2) |
+| `billing_checkout` | polar-billing | M14 (Fase 2) |
+| `apikey_issue` + `apikey_revoke` | unkey-keys | M15 (Fase 2) |
+| `edge_db_create` | turso-edge | M12 (Fase 2) |
+
+---
+
+## 7. System prompt y memoria persistente
+
+`lib/forge/system-prompt.ts:42` — `buildSystemPrompt(options)` carga en cada turno:
+
+1. `system_config.ai_personality` — voz de V (cálida, español MX, camarada técnica)
+2. `SENIOR_ENGINEER_DOCTRINE` — doctrina interna de Claude Code aplicada a V (ejecuta no orientes, parche mínimo, root cause)
+3. Knowledge base sagrada (siempre): `operator_profile`, `organization`, `method`, `preference`
+4. Últimas 10 lessons
+5. Últimos 8 recaps de sesiones previas
+6. Últimas 8 memorias explícitas (`memory_save`)
+7. Catálogo de proyectos agrupado por categoría
+8. Si la conversación está scoped a un projectId, foco del proyecto
+
+**Esto YA ES** el equivalente del "bootstrap rico" de Tanit, antes de ADR-009. Solo le falta el adapter pattern para que cargue contexto desde múltiples fuentes (no solo Neon).
+
+---
+
+## 8. Vault: lo que ya está y lo que falta
+
+### Lo que está
+
+- `operator_secrets` con AES-256-GCM, IV per-row, auth_tag, indexado por provider
+- `project_secrets` con resolución cascade — verificado en `tools.ts:856-908`
+- `getOperatorSecret(name, { projectId? })` con cache in-memory 60s en `lib/vault/get-secret.ts:198`
+- Crypto helpers en `lib/vault/operator-crypto.ts` (98 líneas, todo lo que necesita el server)
+
+### Lo que falta para zero-knowledge (ADR-008)
+
+- WASM Argon2id cliente — `hash-wasm` no aparece en `package.json` aún
+- UI de setup en `/vault`: modal "Crea tu Vault Master Password", generación de 3 backup codes, descarga
+- Endpoint para guardar `vault_salt` + `vault_backup_codes_hashed` por usuario
+- Endpoint para validar backup code en recovery flow
+- Encrypt-on-client → POST → server guarda blob opaco
+
+Esto se prioriza con Clerk en M11 (no antes), porque sin multi-user el feature es académico.
+
+---
+
+## 9. Frontend: estado real (sin verificar runtime, solo estructura)
+
+10 pantallas en `app/(dashboard)/`:
+
+| Pantalla | Estado probable | Comentario |
+|---|---|---|
+| `forge` | 🟡 Probablemente cableada | Llama a `/api/forge/run` (debe confirmarse en chat con `npm run dev`) |
+| `activity` | 🟡 Probable mock | Mock data si `audit_events` no tiene rows aún |
+| `hub` | 🟡 Probable mock | Dashboard agregado |
+| `hunter` | 🟡 Mock | Búsqueda externa, falta tool `web_search` |
+| `modules` | 🟡 Mock | Catálogo de capacidades — listado decorativo |
+| `projects` + `[slug]` | 🟡 Mixta | `/api/projects` está real; el detail puede tener partes mock |
+| `scout` | 🟡 Mock | Discovery |
+| `settings` | 🟡 Mixta | Integraciones probablemente leen de DB |
+| `vault` | 🟡 Mixta | Operator secrets sí están cableados; user secrets dependen de WASM Argon2id (no implementado) |
+| `vision` | 🟡 Mock | Repo Vision (M5+ probablemente) |
+
+**Sin correr `npm run dev` no se puede afirmar más.** Eso requiere `DATABASE_URL` o aceptar errores de lectura de BD; alternativa es ver el JSX y ver si fetch a `/api/*` o lee `mockProjects`.
+
+`lib/mock-data.ts` (107 líneas) existe y se está usando — significa que parte del frontend lee de mocks aún. M7-M9 cierran eso.
+
+---
+
+## 10. Servicios externos: estado
+
+### Vercel
+- **Proyecto:** `prj_EBymOJI4YNLM4AG40ZpWmMKRN66c` (`vforge`) en team `team_gK8RSuGh0CYHEjgEqFRR2iIk`
+- **Framework:** nextjs auto-detect
+- **Último deploy:** `dpl_DwJ1AzzWqeJQeaERH3fa1Ca6LMPg` (READY)
+- **Dominios:** `vforge.site`, `www.vforge.site`, `vforge-beta.vercel.app`, más previews
+- **13 env vars** en Vercel (todas encrypted EEV — no descifrables vía API REST)
+
+### Neon
+- Acceso pendiente — `DATABASE_URL` plaintext requerida.
+- `docs/integrations/neon.md` dice: project `vforge` (`morning-lab-81926607`), org `org-super-wind-01105205`, region `aws-us-east-1`, Postgres 17.8, default branch `production` (no protegido aún).
+
+### Anthropic / OpenAI / Gemini / Perplexity
+- Keys en `operator_secrets` (verificable cuando llegue `DATABASE_URL`) y en Vercel EEVs.
+- `/api/forge/run` espera leer `ANTHROPIC_API_KEY` vía `getOperatorSecret` (que cae a env si no hay row).
+- `/api/forge/transcribe` lee `process.env.OPENAI_API_KEY` directo — **inconsistencia leve**: debería pasar por el vault para consistencia. Lo dejamos como cleanup menor para M3.
+
+### OpenRouter / E2B / Trigger.dev / Resend / Turso / Liveblocks / Polar / Unkey
+- Cuentas no creadas. Cada uno tiene su runbook stub en `docs/integrations/<servicio>.md` (escritos hoy en paralelo).
+
+---
+
+## 11. Bloqueadores actuales
+
+| Bloqueador | Resuelve | Impacto |
+|---|---|---|
+| Falta `DATABASE_URL` plaintext | Luis lo pega, o corre `vercel env pull` | No puedo auditar tablas reales, ni aplicar migraciones, ni seedear |
+| Falta `OPENROUTER_API_KEY` | Luis genera nueva en openrouter.ai/keys | No puedo construir adapter `openrouter-gateway` (M3) |
+| Falta `VFORGE_MASTER_PEPPER` plaintext | Mismo plan que DATABASE_URL | No puedo descifrar rows existentes en `operator_secrets`/`project_secrets` (si los hay) |
+
+**No bloqueadores** (puedo proceder):
+- ADR-009 ✅ Escrito y firmado
+- Adapter contract ✅ Creado
+- `.env.example` ✅ Reescrito
+- Roadmap ✅ Extendido a M15
+- Runbooks ✅ En curso (subagent ejecutando 8 archivos)
+- Esta auditoría ✅ Escrita
+
+---
+
+## 12. Siguientes pasos en orden ejecutivo
+
+### Inmediato (hoy, una vez Luis pegue credenciales)
+
+1. Llenar `.env.local` con plaintext.
+2. `npm install` para confirmar deps actuales.
+3. Verificar conectividad a Neon vía HTTP (curl POST a `endpoint/sql` con un `SELECT 1`).
+4. Listar tablas: `SELECT tablename FROM pg_tables WHERE schemaname = 'public'` — confirmar si migraciones 001-004 están aplicadas.
+5. Si no están: invocar `POST /api/admin/migrate` con bearer `VFORGE_OPERATOR_TOKEN`.
+6. Confirmar seeds: `SELECT count(*) FROM knowledge_base GROUP BY kind`.
+7. Listar secrets actuales: `SELECT name, provider FROM operator_secrets`.
+
+### Esta sesión (Fase 1 — bootstrap MVP)
+
+8. **M3 — Adapter `openrouter-gateway`:** crear `lib/forge/adapters/openrouter.ts`, registrarlo en routing policy, agregar tool `model_route` opcional, smoke test contra hello-world.
+9. **M3.5 — Migrar Anthropic SDK al adapter pattern:** refactor `/api/forge/run` para usar `lib/forge/adapters/anthropic.ts` en vez del SDK inline. Cero cambio de comportamiento, solo encapsulación.
+10. Smoke test E2E: enviar mensaje al `/api/forge/run` desde curl, ver streaming de V hablando en español MX.
+
+### Después de esta sesión
+
+11. M4 → M10 según `architecture.md §7`.
+12. Fase 2 cuando Luis decida abrirlo a terceros.
+
+---
+
+## 13. Riesgos y advertencias
+
+| Riesgo | Mitigación |
+|---|---|
+| Aplicar migraciones a producción sin DB de preview | Neon branching habilitado pero NO automatizado a PR. Aplicar 001-004 a `production` branch directo en MVP es OK porque la BD está virgen; en Fase 2 esto se cabela a CI. |
+| `default_model: claude-sonnet-4-6` en `system_config` mientras Opus 4.7 ya está GA | Actualizar a `claude-sonnet-4-6` está bien para Fase 1 (cost-effective); reservar Opus 4.7 para tareas que lo justifiquen vía routing. Decisión documentada. |
+| 13 env vars en Vercel — todas en producción, sin staging separado | Aceptable hoy (1 dev, sin clientes externos). Cuando llegue Fase 2 se separa staging. |
+| `OPERATOR_USER_ID = "operator_luis"` hardcodeado en 6+ endpoints | M11 reemplaza con Clerk. Hasta entonces, vForge es single-tenant por diseño explícito. |
+| `mock-data.ts` aún consumido por frontend | Se reemplaza pantalla por pantalla en M3-M10. No bloqueante. |
+| `/api/forge/transcribe` lee `process.env.OPENAI_API_KEY` directo en vez de vault | Cleanup menor en M3 — moverlo a `getOperatorSecret("OPENAI_API_KEY")`. |
+
+---
+
+## 14. Lo que NO se tocó en esta auditoría
+
+- Tests: no hay `__tests__/` ni `vitest.config.ts`. Test coverage actual es 0%. **TODO post-MVP:** añadir tests por adapter (M3-M15) y un suite E2E mínimo de los endpoints críticos.
+- CI/CD: `.github/workflows/` no existe (revisar). Auto-deploy a Vercel está vía conexión GitHub→Vercel nativa.
+- Performance: latencia del cerebro no medida. SSE TTFB depende de Anthropic, < 500ms en buen día.
+- Security review: pendiente correr `/security-review` al final del MVP.
+
+---
+
+## 15. Resumen ejecutivo (para Luis, 5 líneas)
+
+vForge está al 70%. No es scaffold — el cerebro funciona y tiene 22 tools cableadas, vault doble, system prompt rico con memoria persistente, 4 migraciones SQL listas y 17 endpoints. Para llegar al 100% necesitamos M3 (OpenRouter), M5 (E2B + Claude Code SDK), M9 (Trigger.dev background jobs), M9.5 (Resend) y M10 (Whisper). En total son ~18 días-persona, 4-5 semanas calendario con 1 dev (yo). Fase 2 (SaaS multi-tenant con Clerk + Turso + Liveblocks + Polar + Unkey) son +12 días, +3 semanas. **Hoy solo me falta que pegues `DATABASE_URL` y `OPENROUTER_API_KEY` para arrancar M3 mismo.**

--- a/app/api/forge/run/route.ts
+++ b/app/api/forge/run/route.ts
@@ -1,8 +1,10 @@
-import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
 import type {
-  MessageParam,
-  ToolResultBlockParam,
-} from "@anthropic-ai/sdk/resources/messages";
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+  ChatCompletionContentPart,
+  ChatCompletionMessageFunctionToolCall,
+} from "openai/resources/chat/completions";
 import { sql } from "@/lib/db/client";
 import { buildSystemPrompt } from "@/lib/forge/system-prompt";
 import { TOOLS, executeTool } from "@/lib/forge/tools";
@@ -32,6 +34,15 @@ interface RunRequest {
 
 const OPERATOR_USER_ID = "operator_luis";
 const MAX_TOOL_ROUNDS = 5;
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+// Default fallback when the config's model slug is the legacy Anthropic
+// short name and we need to map it to an OpenRouter-style slug.
+const LEGACY_MODEL_MAP: Record<string, string> = {
+  "claude-opus-4-7": "anthropic/claude-opus-4.7",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+  "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
+};
 
 export async function POST(req: Request) {
   let body: RunRequest;
@@ -51,18 +62,25 @@ export async function POST(req: Request) {
     return jsonError("sessionId (string) required", 400);
   }
 
-  const apiKey = await getOperatorSecret("ANTHROPIC_API_KEY", {
+  const apiKey = await getOperatorSecret("OPENROUTER_API_KEY", {
     auditUserId: userId,
   });
   if (!apiKey) {
-    return jsonError("ANTHROPIC_API_KEY not configured (vault or env)", 500);
+    return jsonError("OPENROUTER_API_KEY not configured (vault or env)", 500);
   }
 
   const { systemPrompt, config } = await buildSystemPrompt({
     projectId: body.projectId ?? null,
   });
-  const lastUserTurn = messages[messages.length - 1];
 
+  // Resolve the model: prefer OpenRouter-format slugs, fall back via
+  // LEGACY_MODEL_MAP for rows still using the Anthropic short name.
+  const configuredModel = config.default_model;
+  const model =
+    LEGACY_MODEL_MAP[configuredModel] ??
+    (configuredModel.includes("/") ? configuredModel : "anthropic/claude-sonnet-4.6");
+
+  const lastUserTurn = messages[messages.length - 1];
   if (lastUserTurn.role === "user") {
     // Persist a textual representation of the user turn (image bytes
     // are not stored in the conversations table — only the surrounding
@@ -75,16 +93,34 @@ export async function POST(req: Request) {
     `;
   }
 
-  const anthropic = new Anthropic({ apiKey });
+  const openrouter = new OpenAI({
+    apiKey,
+    baseURL: OPENROUTER_BASE_URL,
+    defaultHeaders: {
+      "HTTP-Referer": "https://vforge.site",
+      "X-Title": "vForge",
+    },
+  });
 
-  // Working copy of the conversation that grows with assistant turns
-  // and tool_result user turns across rounds.
-  const conversationMessages: MessageParam[] = messages.map((m) => ({
-    role: m.role,
-    content: m.content as MessageParam["content"],
+  const openaiTools: ChatCompletionTool[] = TOOLS.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.input_schema as Record<string, unknown>,
+    },
   }));
 
+  // Working copy of the conversation in OpenAI format. We rebuild from
+  // ChatTurn[] (which may have Anthropic-style image blocks from the FE)
+  // and accumulate assistant + tool turns across rounds.
+  const conversationMessages: ChatCompletionMessageParam[] = [
+    { role: "system", content: systemPrompt },
+    ...messages.map(toOpenAIMessage),
+  ];
+
   const encoder = new TextEncoder();
+  let actualModel = model;
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -101,92 +137,143 @@ export async function POST(req: Request) {
 
       try {
         for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-          const response = anthropic.messages.stream({
-            model: config.default_model,
-            max_tokens: 2048,
-            system: systemPrompt,
-            tools: TOOLS,
+          const completion = await openrouter.chat.completions.create({
+            model,
             messages: conversationMessages,
+            tools: openaiTools.length > 0 ? openaiTools : undefined,
+            max_tokens: 2048,
+            stream: true,
+            stream_options: { include_usage: true },
           });
 
-          let roundTokensIn = 0;
-          let roundTokensOut = 0;
+          let roundText = "";
+          let roundFinish: string | null = null;
+          // Tool calls arrive in chunked deltas indexed by `index`; we
+          // accumulate name + arguments per index until the assistant
+          // message ends.
+          const pendingToolCalls = new Map<
+            number,
+            { id?: string; name?: string; argsBuffer: string }
+          >();
 
-          for await (const event of response) {
-            if (event.type === "message_start") {
-              roundTokensIn = event.message.usage?.input_tokens ?? 0;
-            } else if (event.type === "content_block_start") {
-              const block = event.content_block;
-              if (block.type === "tool_use") {
-                send({
-                  type: "tool_use_start",
-                  id: block.id,
-                  name: block.name,
-                });
+          for await (const chunk of completion) {
+            // OpenAI emits an extra chunk with usage info at the end.
+            if (chunk.usage) {
+              totalTokensIn += chunk.usage.prompt_tokens ?? 0;
+              totalTokensOut += chunk.usage.completion_tokens ?? 0;
+            }
+            if (chunk.model) actualModel = chunk.model;
+
+            const choice = chunk.choices?.[0];
+            if (!choice) continue;
+
+            const delta = choice.delta;
+            if (delta.content) {
+              roundText += delta.content;
+              assistantTextBuffer += delta.content;
+              send({ type: "text", value: delta.content });
+            }
+
+            if (delta.tool_calls) {
+              for (const tcDelta of delta.tool_calls) {
+                const idx = tcDelta.index;
+                let entry = pendingToolCalls.get(idx);
+                if (!entry) {
+                  entry = { argsBuffer: "" };
+                  pendingToolCalls.set(idx, entry);
+                }
+                if (tcDelta.id) entry.id = tcDelta.id;
+                if (tcDelta.function?.name) {
+                  entry.name = tcDelta.function.name;
+                  // Surface the tool name to the UI as soon as we know it
+                  // (OpenRouter sends name in the first delta of the tool
+                  // call; arguments stream in subsequent deltas).
+                  if (entry.id) {
+                    send({
+                      type: "tool_use_start",
+                      id: entry.id,
+                      name: entry.name,
+                    });
+                  }
+                }
+                if (tcDelta.function?.arguments) {
+                  entry.argsBuffer += tcDelta.function.arguments;
+                }
               }
-            } else if (event.type === "content_block_delta") {
-              const delta = event.delta;
-              if (delta.type === "text_delta") {
-                assistantTextBuffer += delta.text;
-                send({ type: "text", value: delta.text });
-              }
-            } else if (event.type === "message_delta") {
-              roundTokensOut =
-                event.usage?.output_tokens ?? roundTokensOut;
+            }
+
+            if (choice.finish_reason) {
+              roundFinish = choice.finish_reason;
             }
           }
 
-          const finalMessage = await response.finalMessage();
-          totalTokensIn += roundTokensIn;
-          totalTokensOut += roundTokensOut;
-          lastStopReason = finalMessage.stop_reason;
+          lastStopReason = roundFinish;
 
-          // Append the assistant turn (with all its blocks) so the next
-          // round sees the tool_use blocks alongside the tool_results.
+          // Materialize the assistant message we just streamed and
+          // append it to conversation history before executing tools.
+          const toolCalls: ChatCompletionMessageFunctionToolCall[] = Array.from(
+            pendingToolCalls.entries(),
+          )
+            .sort(([a], [b]) => a - b)
+            .map(([, e]) => {
+              if (!e.id || !e.name) {
+                throw new Error(
+                  `Incomplete tool_call from stream (id=${e.id} name=${e.name})`,
+                );
+              }
+              return {
+                id: e.id,
+                type: "function" as const,
+                function: { name: e.name, arguments: e.argsBuffer || "{}" },
+              };
+            });
+
           conversationMessages.push({
             role: "assistant",
-            content: finalMessage.content,
+            content: roundText || null,
+            ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
           });
 
-          if (finalMessage.stop_reason !== "tool_use") {
+          if (toolCalls.length === 0) {
             break;
           }
 
-          // Execute every tool_use block in parallel and collect results.
-          const toolBlocks = finalMessage.content.filter(
-            (b): b is Extract<typeof b, { type: "tool_use" }> =>
-              b.type === "tool_use",
-          );
-          const toolResults: ToolResultBlockParam[] = await Promise.all(
-            toolBlocks.map(async (block) => {
+          // Execute every tool call in parallel and append a `tool` role
+          // message per call. OpenAI / OpenRouter expects one tool
+          // message per tool_call_id, in the same order as the assistant
+          // tool_calls.
+          await Promise.all(
+            toolCalls.map(async (tc) => {
+              let parsedInput: Record<string, unknown> = {};
+              try {
+                parsedInput = tc.function.arguments
+                  ? (JSON.parse(tc.function.arguments) as Record<string, unknown>)
+                  : {};
+              } catch {
+                parsedInput = {};
+              }
               const result = await executeTool(
-                block.name,
-                (block.input ?? {}) as Record<string, unknown>,
+                tc.function.name,
+                parsedInput,
                 { userId, sessionId },
               );
               send({
                 type: "tool_use_result",
-                id: block.id,
+                id: tc.id,
                 ok: result.ok,
                 summary: result.summary,
               });
-              return {
-                type: "tool_result",
-                tool_use_id: block.id,
+              conversationMessages.push({
+                role: "tool",
+                tool_call_id: tc.id,
                 content: result.content,
-                is_error: !result.ok,
-              };
+              });
             }),
           );
-
-          conversationMessages.push({
-            role: "user",
-            content: toolResults,
-          });
         }
 
-        // Persist the final assistant text (tool intermediate steps are
-        // not replayed on rehydrate; only the visible answer is stored).
+        // Persist the final assistant text. Tool intermediate steps
+        // are not replayed on rehydrate; only the visible answer.
         await sql`
           INSERT INTO conversations (
             user_id, session_id, role, content, model,
@@ -194,9 +281,9 @@ export async function POST(req: Request) {
           )
           VALUES (
             ${userId}, ${sessionId}, 'assistant', ${assistantTextBuffer},
-            ${config.default_model},
+            ${actualModel},
             ${totalTokensIn}, ${totalTokensOut},
-            ${estimateCost(config.default_model, totalTokensIn, totalTokensOut)}
+            ${estimateCost(actualModel, totalTokensIn, totalTokensOut)}
           )
         `;
 
@@ -207,7 +294,8 @@ export async function POST(req: Request) {
             ${JSON.stringify({
               tokens_in: totalTokensIn,
               tokens_out: totalTokensOut,
-              model: config.default_model,
+              model: actualModel,
+              provider: "openrouter",
               stop_reason: lastStopReason,
             })}::jsonb
           )
@@ -217,7 +305,7 @@ export async function POST(req: Request) {
           type: "done",
           tokensIn: totalTokensIn,
           tokensOut: totalTokensOut,
-          model: config.default_model,
+          model: actualModel,
         });
         controller.close();
       } catch (err) {
@@ -236,6 +324,36 @@ export async function POST(req: Request) {
       "X-Accel-Buffering": "no",
     },
   });
+}
+
+/**
+ * Convert a FE-supplied ChatTurn to OpenAI's ChatCompletionMessageParam.
+ * The FE still sends Anthropic-style image blocks
+ * ({type:"image", source:{type:"base64", media_type, data}}) so we
+ * remap them to OpenAI's image_url data-URI format here.
+ */
+function toOpenAIMessage(turn: ChatTurn): ChatCompletionMessageParam {
+  if (typeof turn.content === "string") {
+    return { role: turn.role, content: turn.content };
+  }
+  const parts: ChatCompletionContentPart[] = turn.content.map((b) => {
+    if (b.type === "text") return { type: "text", text: b.text };
+    return {
+      type: "image_url",
+      image_url: { url: `data:${b.source.media_type};base64,${b.source.data}` },
+    };
+  });
+  if (turn.role === "assistant") {
+    // OpenAI assistant content doesn't support image parts; flatten to
+    // text-only. Images in assistant turns shouldn't happen in our flow
+    // (FE only attaches them to user turns) but we degrade gracefully.
+    const textOnly = parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("\n");
+    return { role: "assistant", content: textOnly };
+  }
+  return { role: "user", content: parts };
 }
 
 /**
@@ -265,10 +383,17 @@ function jsonError(message: string, status: number): Response {
   });
 }
 
+// OpenRouter pricing per 1M tokens (USD). Used only for the cost_usd
+// column in conversations; real billing happens at OpenRouter. Refresh
+// from https://openrouter.ai/models when adding a model.
 const PRICING: Record<string, { input: number; output: number }> = {
-  "claude-opus-4-7": { input: 15, output: 75 },
-  "claude-sonnet-4-6": { input: 3, output: 15 },
-  "claude-haiku-4-5": { input: 0.8, output: 4 },
+  "anthropic/claude-opus-4.7": { input: 15, output: 75 },
+  "anthropic/claude-sonnet-4.6": { input: 3, output: 15 },
+  "anthropic/claude-haiku-4.5": { input: 0.8, output: 4 },
+  "google/gemini-2.5-flash": { input: 0.075, output: 0.3 },
+  "google/gemini-2.5-pro": { input: 1.25, output: 5 },
+  "meta-llama/llama-3.3-70b-instruct": { input: 0.13, output: 0.4 },
+  "mistralai/mistral-large-2411": { input: 2, output: 6 },
 };
 
 function estimateCost(
@@ -276,7 +401,14 @@ function estimateCost(
   tokensIn: number,
   tokensOut: number,
 ): number {
-  const p = PRICING[model] ?? { input: 3, output: 15 };
+  // OpenRouter sometimes returns a versioned model name in the response
+  // (e.g. "anthropic/claude-4.6-sonnet-20260217"); strip the suffix.
+  const normalized = model.replace(/(-\d{8}|-\d{6}|-\d{4})$/, "");
+  const p =
+    PRICING[normalized] ??
+    PRICING[model] ??
+    // Fall back to Sonnet pricing if we don't know the model.
+    { input: 3, output: 15 };
   const cost =
     (tokensIn / 1_000_000) * p.input + (tokensOut / 1_000_000) * p.output;
   return Number(cost.toFixed(6));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,22 +198,61 @@ El frontend que estamos construyendo en v0 ya tiene la cara para todo el cerebro
 
 ## 7. Roadmap a Forge funcional
 
-| Hito | Qué construye | Tiempo |
-|---|---|---|
-| **M0** | Setup Vault real (cifrado AES-256, master key derivation, permission rings) | 3 días |
-| **M1** | Brain endpoint stub: `/api/forge/run` con streaming, conversa con Claude sin tools | 1 día |
-| **M2** | Model registry + routing policy heurística | 1 día |
-| **M3** | Adapter `anthropic-claude` (Sonnet + Opus + Haiku) | 1 día |
-| **M4** | Adapter `anthropic-web-search` → Forge investiga online | 1 día |
-| **M5** | Adapter `claude-code-sdk` → Forge edita el repo (Anillo 1) | 3 días |
-| **M6** | Adapter `openai-image` (gpt-image-1) → Forge propone variantes de logo | 2 días |
-| **M7** | Adapter `vercel-deploy` con confirmación humana → Forge despliega (Anillo 2) | 1 día |
-| **M8** | Adapter `github-octokit` (commits, PRs, issues) | 1 día |
-| **M9** | Audit log persistente + cost tracking, render en `/activity` | 1 día |
-| **M10** | Adapter `openai-whisper` para el botón mic del composer | 0.5 día |
-| **M11** | Routing policy v2: clasificador entrenado con historia | 2 días |
+> Extendido por **ADR-009** (2026-05-12) para incluir el stack de servicios
+> externos. Fase 1 (M0–M10) entrega vForge single-tenant funcional para Luis.
+> Fase 2 (M11–M15) lo convierte en SaaS multi-tenant. Fase 3 (M16+) optimiza.
 
-**Total: ~17 días-persona enfocados** para Forge MVP funcional. Construible en 4 semanas calendario con 1 dev.
+### Fase 1 — MVP single-tenant para Luis
+
+| Hito | Qué construye | Servicios externos | Tiempo |
+|---|---|---|---|
+| **M0** | Setup Vault real (cifrado AES-256, master key derivation, permission rings) | Neon | 3 días |
+| **M1** | Brain endpoint stub: `/api/forge/run` con streaming, conversa con Claude sin tools | — | 1 día |
+| **M2** | Model registry + routing policy heurística | — | 1 día |
+| **M3** | Adapters `anthropic-claude` (Sonnet + Opus + Haiku) + `openrouter-gateway` (Gemini, Mistral, Llama vía OpenRouter para tareas baratas) | OpenRouter | 1.5 días |
+| **M4** | Adapter `anthropic-web-search` → Forge investiga online | — | 1 día |
+| **M5** | Adapters `e2b-microvm` (sandbox) + `claude-code-sdk` (corre dentro de E2B) → Forge edita el repo (Anillo 1) | E2B | 4 días |
+| **M6** | Adapter `openai-image` (gpt-image-1) → Forge propone variantes de logo | — | 2 días |
+| **M7** | Adapter `vercel-deploy` con confirmación humana → Forge despliega (Anillo 2) | — | 1 día |
+| **M8** | Adapter `github-octokit` (commits, PRs, issues — write ops) | — | 1 día |
+| **M9** | Adapter `trigger-bg` (jobs > 60s vía Trigger.dev) + audit log persistente + cost tracking, render en `/activity` | Trigger.dev | 2 días |
+| **M9.5** | Adapter `resend-email` → confirmaciones Ring 2/3 + recaps + alerts de deploys fallidos | Resend | 0.5 día |
+| **M10** | Adapter `openai-whisper` para el botón mic del composer | — | 0.5 día |
+
+**Subtotal Fase 1: ~18 días-persona**. Construible en 4-5 semanas calendario con 1 dev.
+
+### Fase 2 — SaaS multi-tenant para terceros
+
+| Hito | Qué construye | Servicios externos | Tiempo |
+|---|---|---|---|
+| **M11** | Clerk cableado en `/api/forge/run` (reemplaza `OPERATOR_USER_ID` hardcoded). Onboarding wizard con OAuth GitHub + Vercel | Clerk | 3 días |
+| **M12** | Adapter `turso-edge` → DB SQLite per-tenant para session state, routing telemetry, app-level state que vForge genere para clientes | Turso | 2 días |
+| **M13** | Adapter `liveblocks-rooms` → presencia + cursors compartidos en `/forge` y `/projects/[id]` | Liveblocks | 2 días |
+| **M14** | Adapter `polar-billing` → subscriptions + usage-based pass-through (cumple ADR-006). Customer portal embebido | Polar.sh | 3 días |
+| **M15** | Adapter `unkey-keys` → API keys per-cliente (reemplaza `VFORGE_OPERATOR_TOKEN`). Rate limits, scopes, analytics | Unkey | 2 días |
+
+**Subtotal Fase 2: ~12 días-persona**. Construible en 3 semanas calendario con 1 dev.
+
+### Fase 3 — Optimización y madurez
+
+| Hito | Qué construye | Servicios externos | Tiempo |
+|---|---|---|---|
+| **M16** | Routing policy v2: clasificador entrenado con historia de runs exitosos vs fallidos | — | 2 días |
+| **M17** | Cliente MCP genérico → vForge consume servidores MCP de terceros (cada tenant configura los suyos) | — | 3 días |
+| **M18** | Evaluar migración Trigger.dev → Temporal **solo si** los workflows del agente crecen a horas con compensaciones complejas | Temporal (opcional) | 5 días (si aplica) |
+| **M19** | Browserbase si V necesita interactuar con UIs sin API (Squarespace, Wix, etc.) | Browserbase (opcional) | 2 días (si aplica) |
+
+**Subtotal Fase 3: 5-12 días según qué se active.**
+
+### Totales
+
+| Fase | Días-persona | Calendario |
+|---|---|---|
+| Fase 1 (MVP single-tenant) | ~18 | 4-5 semanas |
+| Fase 2 (SaaS multi-tenant) | ~12 | 3 semanas |
+| Fase 3 (madurez) | 5-12 | variable |
+
+**MVP funcional para Luis: ~5 semanas**. Vendible a terceros: **+3 semanas más**.
 
 ---
 

--- a/docs/decisions/009-external-service-stack.md
+++ b/docs/decisions/009-external-service-stack.md
@@ -1,0 +1,231 @@
+# ADR-009: External service stack — OpenRouter, E2B, Trigger.dev, Turso, Liveblocks, Polar.sh, Unkey, Resend
+
+- **Estado:** Accepted
+- **Fecha:** 2026-05-12
+- **Decisores:** Luis, Claude Code
+- **Contexto técnico:** Fase 1 (MVP single-tenant para Luis) y Fase 2 (multi-tenant SaaS para terceros)
+- **Relaciona:** enriquece ADR-002, ADR-003, ADR-005, ADR-006, ADR-008. No supersede ninguno.
+
+## Contexto
+
+vForge se construye en dos fases:
+
+1. **Fase 1 — MVP single-tenant para Luis.** El cerebro `V` opera contra Anthropic + OpenAI + las tools ya cableadas (GitHub, Vercel, Name.com, Vault). Roadmap M0→M11 en `architecture.md §7`.
+2. **Fase 2 — SaaS multi-tenant.** Terceros llegan, conectan sus propias credenciales (GitHub, Vercel, v0), reciben su API key per-tenant, y vForge orquesta la fábrica de aplicaciones para ellos con billing pass-through.
+
+A medida que crece el alcance, varias capacidades exigen servicios externos especializados en vez de implementación casera:
+
+- Ejecución segura de código (M5: adapter `claude-code-sdk`) no puede correr en el server de vForge — riesgo de RCE y de timeouts. Necesita sandbox real.
+- Runs largos del cerebro (un proyecto entero generado en 1 sola sesión) exceden los timeouts del Edge runtime de Vercel (300s en Enterprise, 60s default). Necesitan background jobs durables.
+- Multi-tenant exige API keys per-cliente con revocation, rate limiting, analytics. Reescribirlo en casa es 2-3 sprints perdidos.
+- Notificaciones (deploy listo, confirmación Ring 2/3, recap diario) no caben todas en el chat — algunas viven mejor en email.
+- Cobro por uso (pass-through del costo de Anthropic + margen) exige sistema de billing. Stripe directo es trabajo; un wrapper SaaS-developer-first es más rápido.
+- Colaboración tiempo real (Fase 3: 2 personas viendo el mismo proyecto en `/forge` al mismo tiempo) requiere infraestructura de CRDT que no vale la pena construir.
+- Edge DB per-tenant (sessions, caches, telemetría) complementa el Postgres central de Neon sin saturarlo.
+
+La pregunta no es "¿usamos servicios externos?" sino "¿cuáles, en qué orden, y con qué contrato?".
+
+## Decisión
+
+Adoptar el siguiente stack canónico de servicios externos para vForge. Cada uno tiene rol fijo, anillo de privilegio asignado, y fase de adopción declarada.
+
+| Servicio | Rol único | Anillo | Fase | ADRs relacionados |
+|---|---|---|---|---|
+| **OpenRouter** | Gateway secundario a LLMs no-Anthropic (Gemini, Mistral, Llama, etc.) — adapter de cost optimization y fallback. **No** reemplaza el adapter Anthropic directo. | 0-1 | Fase 1 (M3) | ADR-005 |
+| **E2B** | Sandbox aislado donde corre el adapter `claude-code-sdk` (M5). Cada sesión de Claude Code se levanta en un microVM de E2B, no en el server de vForge. | 1-2 | Fase 1 (M5) | ADR-002 |
+| **Trigger.dev** | Background jobs durables para runs del cerebro que excedan 60s. El endpoint `/api/forge/run` puede enqueuar un `forge.long-run` job y devolver un `run_id`; el cliente hace polling SSE o se suscribe a updates. | 1 | Fase 1 (M9) | ADR-001, ADR-004 |
+| **Neon** | Postgres central — source of truth. Ya en uso. Branching como Git para previews por feature branch. | n/a | Fase 1 (ya) | ADR-003, ADR-008 |
+| **Turso** | SQLite distribuido edge **per-tenant** para session caches, telemetría de routing, y future per-tenant local DBs cuando vForge sirva apps de clientes. **No** reemplaza Neon. | 1 | Fase 2 | — |
+| **Liveblocks** | Presencia + colab tiempo real en `/forge` (Luis y un colaborador viendo el mismo proyecto), en `/projects/[id]` (cursors compartidos), y eventualmente en el editor de prompts. | 0-1 | Fase 2-3 | — |
+| **Polar.sh** | Billing y monetización pass-through. Wrappea Stripe con DX para SaaS de developer tools (subscriptions, usage-based, customer portal). Reemplaza el "Stripe directo" mencionado en ADR-006. | 2-3 | Fase 2 | ADR-006 |
+| **Unkey** | API keys per-tenant cuando terceros usen vForge desde sus propias apps. Reemplaza el `VFORGE_OPERATOR_TOKEN` actual (token único hardcodeado) con keys gestionadas, revocables, rate-limited, con analytics. | 3 | Fase 2 | ADR-008 |
+| **Resend** | Email transaccional con dominio propio (`@vforge.site`). Confirmaciones Ring 2/3, recaps diarios, alerts de deploys fallidos, magic links si llegan. | 1 | Fase 1 (M9.5 — opcional) | — |
+
+**Servicios explícitamente descartados** (y por qué) van en *Alternativas consideradas*.
+
+## Razón
+
+Cada elección sigue un mismo principio: **no construyas lo que ya es un servicio maduro con SLA**. Y la división de fases protege el MVP de complejidad prematura.
+
+**OpenRouter como secundario, no primario**: ADR-005 ya estableció que tener una única gateway añade latencia y un single-point-of-failure. Anthropic SDK directo sigue siendo el adapter primario para Claude (lo que ya está cableado en `app/api/forge/run/route.ts:78`). OpenRouter entra como adapter paralelo cuando V necesita un modelo distinto (Gemini para tareas baratas de clasificación, Mistral para resúmenes, Llama para experimentos) o cuando hay degradación de Anthropic.
+
+**E2B sobre code execution casero**: ejecutar código que un LLM genera en el mismo proceso que sirve la app es RCE-by-design. Containers de E2B son microVMs Firecracker — aislamiento real, snapshots, persistencia opcional, SDK JS nativo. La alternativa (Docker-in-Docker propio o subprocess sandboxing con seccomp) es 1-2 semanas de operacional ininterrumpido. ADR-002 dijo "ejecución vía Claude Code SDK"; E2B es el "dónde" de esa ejecución.
+
+**Trigger.dev sobre Temporal**: ambos hacen workflows durables. Temporal es enterprise-grade (necesita worker process, statefulness explícita en código, Temporal Cloud o cluster propio). Trigger.dev v3 es JS-nativo, deploy via npm, DX más simple, suficiente para "ejecutar un sub-plan de 5 pasos con retry". Si en Fase 3 aparece un caso de uso que exige Temporal (workflows de horas con compensaciones complejas, multi-region replication de estado), se evalúa migrar entonces. El costo de migrar de Trigger→Temporal después es contenido si los workflows son cortos; el costo de empezar con Temporal hoy es alto y se paga aunque no se use su potencia.
+
+**Neon + Turso conviven**: Neon es Postgres central — schemas relacionales, joins complejos, transacciones ACID, branching como Git. Turso es SQLite distribuido edge — lectura baja latencia desde cualquier región, bases libres per-tenant. **No es uno o el otro**: Neon mantiene knowledge_base, conversations, audit_events, projects, operator_secrets. Turso entra en Fase 2 para session_state per-tenant (qué proyecto está activo, qué tool corrió por último, cache de embeddings), y eventualmente para "vForge gestiona la DB que la app del cliente usa" (un Turso DB libre por cada app que Forge AI deploye).
+
+**Polar.sh sobre Stripe directo**: Stripe es excelente pero requiere construir el customer portal, los planes, la facturación de usage-based, los webhooks, la reconciliación. Polar abstrae todo eso con primitivas pensadas para "SaaS para developers". ADR-006 dijo "pass-through en v2" — Polar es el vehículo concreto. Si Polar cambia precios drásticamente, migrar a Stripe directo es 2 semanas (todos los datos siguen siendo de Stripe under the hood).
+
+**Unkey sobre API keys caseras**: gestión de API keys (creación, revocation, rotation, rate limiting, analytics, scoping a endpoints específicos) es un producto entero. Implementarlo en casa significa 1-2 sprints + mantenimiento perpetuo. Unkey es el equivalente de Clerk pero para machine credentials.
+
+**Resend desde Fase 1**: email transaccional NO es un nice-to-have. Cuando V deployea algo a producción a las 3 AM y algo falla, mejor recibir un email que descubrirlo en el dashboard al día siguiente. Resend tiene DX de developer (TypeScript SDK, React Email para templates), dominio propio con DKIM/SPF automatizado.
+
+**Liveblocks en Fase 2-3**: hoy Luis es el único usuario. Colab tiempo real no aporta valor hasta que haya 2+ personas en el mismo workspace. Cuando ocurra, Liveblocks es la única opción razonable (Yjs casero es viable pero requiere infra de WebSocket/sync, mantenida 24/7).
+
+## Consecuencias
+
+**Fácil:**
+- Cada adapter es un archivo en `lib/forge/adapters/<servicio>.ts` que implementa el contract `ForgeAdapter<Input, Output>` definido en `architecture.md §3.1`. Onboarding de un nuevo proveedor: 1 archivo + 1 entry en model registry + 1 runbook en `docs/integrations/`.
+- Las credenciales de cada servicio viven en `operator_secrets` (Class 1, server-side encrypted con `VFORGE_MASTER_PEPPER`). Resolución cascade `project_secrets → operator_secrets → process.env` ya implementada en `lib/vault/get-secret.ts`.
+- Multi-tenant en Fase 2 hereda gratis el modelo: cada tenant trae sus propias keys de OpenRouter, E2B, Polar, etc. vía el vault zero-knowledge (ADR-008).
+- Cost optimization vía OpenRouter → Gemini para tareas baratas reduce el costo de razonamiento de baja prioridad ~80%.
+
+**Difícil:**
+- 8 servicios externos = 8 SLAs distintos que monitorear. Necesitamos un health check endpoint (`/api/admin/health`) que pingue cada uno y reporte status agregado.
+- Onboarding inicial: hay que crear cuentas en 8 servicios, configurar billing en cada uno, generar keys, agregarlas a `operator_secrets`. Se mitiga: runbook por servicio en `docs/integrations/` con pasos exactos.
+- Vendor lock-in moderado por servicio. Mitigación: cada adapter expone una interfaz neutra; migrar a un competidor es reescribir un archivo.
+- Costos múltiples corrientes. Mitigación: tag de costo en `audit_events` por tool call, reporte mensual agregado.
+
+**Deuda técnica asumida:**
+- Cada SDK cambia con el tiempo. Necesitamos dependabot + tests de adapter por servicio.
+- Trigger.dev → Temporal migration si llega Fase 3 con workflows de horas.
+- Liveblocks free tier tiene cap (suficiente para Fase 2 con 5-10 usuarios; renegociar a paid en Fase 3).
+
+## Alternativas consideradas
+
+| Alternativa | Descartada porque |
+|---|---|
+| **Solo Anthropic SDK directo + cero servicios externos** | Funciona para Fase 1 hello-world pero no escala a M5 (sandbox), M9 (jobs largos), Fase 2 (multi-tenant). Imposible para SaaS. |
+| **Temporal.io como engine único de workflows** | Overhead operacional alto, statefulness explícita, requiere infra dedicada. Trigger.dev cubre 95% de los casos con 20% del esfuerzo. Evaluar Temporal en Fase 3 si los workflows del agente crecen a horas. |
+| **Inngest** | Buen producto pero overlap completo con Trigger.dev (event-driven workflows). Trigger.dev ganó por mejor DX TS-first y deploy más simple. |
+| **Browserbase** | Headless browser para que V navegue UIs. Considerado, descartado por ahora — la combinación de `anthropic-web-search` (Anthropic Web Search tool) + tools dedicadas (`vercel_*`, `github_*`, `namecom_*`) cubre 90% de los casos sin requerir browser real. Reevaluar si V necesita interactuar con dashboards de terceros sin API (ej. Squarespace, Wix). |
+| **Stripe directo** | Polar es Stripe with developer DX. Si Polar se cae como empresa, migración a Stripe directo es 2 semanas (data ya está en Stripe). |
+| **Clerk Machine Tokens** | Clerk + Unkey son complementarios: Clerk para usuarios humanos, Unkey para machines. Clerk's machine tokens existen pero no tienen rate limiting ni analytics que Unkey sí. |
+| **Convex / Supabase como replacement de Neon** | Neon ya en uso, branching como Git encaja con el flow de vForge ("cada feature branch tiene su propia DB preview"). Migrar a Convex/Supabase rompe ADR-003 (auth + DB nativo) sin upside claro. |
+| **Implementación casera de cada uno** | Cada uno son 1-3 sprints de construir y mantener. Total ~5-8 sprints solo en plumbing — costo de oportunidad enorme. |
+
+## Implementación
+
+### Estructura del codebase
+
+```
+lib/forge/
+├── adapters/                     ← NUEVO en M3
+│   ├── _contract.ts              ← ForgeAdapter<I,O>, Ring, Capability types
+│   ├── anthropic.ts              ← M3 — Anthropic SDK directo (ya parcialmente cableado en run/route.ts)
+│   ├── openrouter.ts             ← M3 — OpenAI-compatible SDK contra api.openrouter.ai
+│   ├── openai-image.ts           ← M6 — gpt-image-1
+│   ├── openai-whisper.ts         ← M10 — Whisper para mic input
+│   ├── e2b-sandbox.ts            ← M5 — wraps E2B SDK
+│   ├── claude-code-sdk.ts        ← M5 — corre dentro de e2b-sandbox.ts
+│   ├── trigger-bg.ts             ← M9 — enqueue + status check
+│   ├── resend-email.ts           ← M9.5 — confirmaciones + alerts
+│   ├── unkey-keys.ts             ← Fase 2 — API key issuance
+│   ├── polar-billing.ts          ← Fase 2 — subscriptions, usage
+│   ├── liveblocks-rooms.ts       ← Fase 2 — presence, cursors
+│   └── turso-edge.ts             ← Fase 2 — per-tenant edge DBs
+├── models.ts                     ← model registry — agrega rows por proveedor
+├── routing.ts                    ← routing policy v1 (heurística) — extiende switch a OpenRouter
+├── system-prompt.ts              ← ya existe
+└── tools.ts                      ← ya existe, agrega tools de cada nuevo adapter
+```
+
+### Resolución de credenciales
+
+Mismo modelo que el actual:
+
+```ts
+// Cada adapter al inicializar:
+const apiKey = await getOperatorSecret("OPENROUTER_API_KEY", { auditUserId: ctx.userId });
+if (!apiKey) throw new Error("OPENROUTER_API_KEY not configured in vault or env");
+```
+
+Variables de entorno canónicas (todas en `.env.example` y eventualmente en `operator_secrets`):
+
+```
+# LLMs
+OPENROUTER_API_KEY            sk-or-v1-...
+# Code execution
+E2B_API_KEY                   e2b_...
+# Background jobs
+TRIGGER_API_KEY               tr_pat_...
+TRIGGER_PROJECT_ID            proj_...
+# Edge DB (Fase 2)
+TURSO_AUTH_TOKEN              eyJ...
+TURSO_ORG_SLUG                vforge
+# Realtime collab (Fase 2)
+LIVEBLOCKS_SECRET_KEY         sk_prod_...
+NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY pk_prod_...
+# Billing (Fase 2)
+POLAR_ACCESS_TOKEN            polar_oat_...
+POLAR_ORGANIZATION_ID         org_...
+POLAR_WEBHOOK_SECRET          whsec_...
+# API key gateway (Fase 2)
+UNKEY_ROOT_KEY                unkey_...
+UNKEY_API_ID                  api_...
+# Email
+RESEND_API_KEY                re_...
+RESEND_FROM_ADDRESS           noreply@vforge.site
+```
+
+### Tools que se agregan al cerebro
+
+Por ahora `lib/forge/tools.ts` tiene 22 tools. ADR-009 introduce estas adicionales (en sus respectivos milestones):
+
+- `model_route(task, hint?)` — devuelve `{adapter, model}` segun routing policy.
+- `code_exec(repo_url, sub_plan)` — corre Claude Code SDK dentro de E2B, devuelve diff + logs.
+- `bg_enqueue(job_name, payload)` + `bg_status(run_id)` — Trigger.dev.
+- `email_send(to, subject, body)` — Resend.
+- `realtime_room_create(project_id)` — Liveblocks (Fase 2).
+- `billing_create_checkout(plan_id, user_id)` — Polar (Fase 2).
+- `apikey_issue(tenant_id, scopes)` + `apikey_revoke(key_id)` — Unkey (Fase 2).
+- `edge_db_create(tenant_id)` — Turso (Fase 2).
+
+Cada una respeta su anillo (declarado arriba). Tools de Anillo 2-3 disparan el flujo de confirmación humana ya cableado en el frontend (`<ConfirmActionPill>`).
+
+### Orden de adopción (ver `architecture.md §7` para detalles)
+
+1. **M3** — Anthropic adapter (oficializar lo ya cableado) + **OpenRouter** adapter (nuevo).
+2. **M5** — **E2B** + **Claude Code SDK** adapter (sandbox + code exec).
+3. **M9** — **Trigger.dev** adapter (background jobs) + audit log persistente.
+4. **M9.5** — **Resend** adapter (emails). Opcional pero recomendado.
+5. **M11-M15 (Fase 2)** — **Turso**, **Liveblocks**, **Polar**, **Unkey** en este orden.
+
+### Health check endpoint
+
+```
+GET /api/admin/health
+→ { 
+    db: "ok",                     // Neon
+    vault: "ok",                  // operator_secrets readable
+    adapters: {
+      anthropic: "ok",
+      openrouter: "missing-key" | "ok" | "401",
+      e2b: "ok",
+      ...
+    }
+  }
+```
+
+Disparado por cron de Trigger.dev cada 5 min, alert vía Resend si algo está rojo > 15 min.
+
+## Lo que esto significa para el operador (Luis)
+
+**En Fase 1 (próximas 4-6 semanas):**
+
+1. Crear cuenta en **OpenRouter**, generar API key, agregar a `operator_secrets` como `OPENROUTER_API_KEY`. (M3)
+2. Crear cuenta en **E2B**, generar API key, mismo lugar como `E2B_API_KEY`. (M5)
+3. Crear cuenta en **Trigger.dev**, crear proyecto vforge, generar key, mismo lugar. (M9)
+4. Crear cuenta en **Resend**, verificar dominio `vforge.site` (records DNS via Name.com tool), generar key. (M9.5)
+
+**En Fase 2 (después de M11):**
+
+5. **Turso**: cuenta, org slug, auth token.
+6. **Liveblocks**: cuenta, public + secret keys.
+7. **Polar.sh**: cuenta organization, products, webhook secret.
+8. **Unkey**: cuenta, root key, API.
+
+Cada paso tiene su runbook en `docs/integrations/<servicio>.md` con pasos exactos.
+
+## Referencias
+
+- OpenRouter: https://openrouter.ai/docs
+- E2B: https://e2b.dev/docs
+- Trigger.dev v3: https://trigger.dev/docs
+- Temporal (referencia, no adoptado todavía): https://docs.temporal.io
+- Turso: https://docs.turso.tech
+- Liveblocks: https://liveblocks.io/docs
+- Polar.sh: https://docs.polar.sh
+- Unkey: https://www.unkey.com/docs
+- Resend: https://resend.com/docs

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -44,6 +44,7 @@
 | [006](./006-operator-paid-billing-mvp.md) | Accepted | Billing en cuenta de operador en MVP, pass-through en v2 |
 | [007](./007-adopt-next-16-tailwind-4.md) | Accepted | Adoptar Next 16 + React 19 + Tailwind 4 (en vez de Next 14 + Tailwind 3.4) |
 | [008](./008-zero-knowledge-vault.md) | Accepted | Zero-Knowledge Vault con Vault Master Password separado del Clerk password |
+| [009](./009-external-service-stack.md) | Accepted | Stack de servicios externos: OpenRouter, E2B, Trigger.dev, Turso, Liveblocks, Polar.sh, Unkey, Resend |
 
 ---
 

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -1,0 +1,104 @@
+# Integración: E2B (sandbox microVM para code execution)
+
+> *Entra en M5 (Fase 1). Es el "dónde" del adapter `claude-code-sdk`: cada sesión de Claude Code se levanta dentro de un microVM Firecracker de E2B, no en el server de vForge. ADR-009 lo declara obligatorio para evitar RCE-by-design.*
+
+---
+
+## Resumen
+
+- **Provider:** [E2B](https://e2b.dev) — sandboxes microVM (Firecracker) on-demand, SDK JS nativo
+- **Rol en vForge:** sandbox aislado donde corre el adapter `claude-code-sdk` (M5). Cada sesión arranca un microVM dedicado con su propio filesystem y red controlada.
+- **Milestone:** M5 — Fase 1
+- **Anillo:** 1-2 (1 cuando opera sobre repos de feature branch; 2 cuando toca main o env real)
+- **Adapter file (futuro):** `lib/forge/adapters/e2b-sandbox.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+E2B_API_KEY    e2b_...   key del dashboard E2B, server-side encrypted
+```
+
+Una sola variable. La región y el template del sandbox se eligen por request via SDK.
+
+---
+
+## Cuenta y onboarding
+
+1. Ir a https://e2b.dev/dashboard/sign-in — registrarse con GitHub OAuth (recomendado, alinea con la identidad de los repos de Luis).
+2. Configurar billing en https://e2b.dev/dashboard/billing — free tier de 100 horas de sandbox/mes; suficiente para Fase 1. Cargar tarjeta si se espera superarlo.
+3. Generar key en https://e2b.dev/dashboard/keys → "Create API Key" → nombrar `vforge-prod`. Copiar el `e2b_...`.
+4. (Opcional) crear un template custom con dependencias precargadas (Node 22, pnpm, git, tsx) en https://e2b.dev/dashboard/templates. Para Fase 1 el template default `base` es suficiente; el custom acelera cold starts ~5s.
+5. Agregar la key a `operator_secrets` como `E2B_API_KEY` (o a Vercel env vars encrypted, production + preview + development).
+
+---
+
+## Endpoints / SDK usados
+
+E2B se consume vía SDK TypeScript oficial. No tocar la REST API directa salvo para diagnostics.
+
+```ts
+import { Sandbox } from "@e2b/code-interpreter";
+
+const sbx = await Sandbox.create({
+  apiKey: process.env.E2B_API_KEY,
+  timeoutMs: 5 * 60 * 1000, // 5 min default; ampliar para builds largos
+});
+
+await sbx.files.write("/home/user/hello.ts", `console.log("hi");`);
+const result = await sbx.commands.run("tsx /home/user/hello.ts");
+console.log(result.stdout);
+
+await sbx.kill();
+```
+
+Operaciones clave:
+
+| Método | Para qué |
+|---|---|
+| `Sandbox.create()` | Spin up de un microVM |
+| `sbx.files.write/read/list` | Filesystem ops dentro del VM |
+| `sbx.commands.run()` | Ejecutar comandos shell |
+| `sbx.uploadFile()` / `sbx.downloadFile()` | Transferir blobs grandes |
+| `sbx.kill()` | Apagar el VM (libera billing) |
+
+---
+
+## Runbook (cuando ejecutemos M5)
+
+1. Verificar `E2B_API_KEY` vía `getOperatorSecret("E2B_API_KEY", { auditUserId: ctx.userId })`. Si falta, abortar M5 con mensaje al operador.
+2. Crear `lib/forge/adapters/e2b-sandbox.ts` implementando el contract de `lib/forge/adapters/_contract.ts`. Capacidades: `["sandbox", "code-exec", "fs-write"]`. Anillo 1.
+3. Crear `lib/forge/adapters/claude-code-sdk.ts` que internamente recibe un sandbox de E2B como dependencia inyectada. La pareja es indivisible: code-exec sin sandbox = RCE.
+4. Agregar helper `spawnSandboxForRun(runId, repoUrl)` que clona el repo dentro del VM con un PAT de scope mínimo (read-only para el repo target + write para el branch claude/*).
+5. Wire `sbx.kill()` al `signal: AbortSignal` del contract — si el usuario cancela el run, el sandbox muere y se deja de cobrar.
+6. Test mínimo en `__tests__/e2b-sandbox.test.ts`: happy path (crear sandbox, escribir archivo, leerlo, matarlo) + missing-key + timeout.
+7. Update a `lib/forge/system-prompt.ts`: V debe saber que **todo `code_exec` corre en un VM efímero**, que el filesystem se borra al final del run salvo que se haga commit/push explícito, y que la red outbound está restringida a allowlist (npm registry, github, vercel, neon).
+
+---
+
+## Caveats / notas operativas
+
+- **Cold start ~2-5s** con template base; ~500ms con template custom precargado. Vale la pena el template custom desde M5.
+- **Timeout default 5 min.** Builds largos (Next.js producción) pueden tardar más; subir `timeoutMs` por request o enqueuar en Trigger.dev (M9) si excede.
+- **Free tier:** 100 horas/mes de sandbox. Cada `Sandbox.create()` que no se mate sigue contando hasta el timeout. **Siempre llamar `sbx.kill()` en `finally`**.
+- **Red outbound:** por default abierta. Restringir vía template config si se necesita aislamiento más estricto (Fase 2 multi-tenant).
+- **Rotación de key:** dashboard `/keys` → revoke + create. Sandboxes activos con la key vieja siguen vivos hasta su timeout.
+- **Vendor alternatives:** Modal, Daytona, GitHub Codespaces API. Migrar implica reescribir el adapter — pero Claude Code SDK es agnóstico al sandbox subyacente.
+
+---
+
+## Estado de env vars en Vercel
+
+```
+E2B_API_KEY    encrypted    PENDIENTE — agregar antes de M5
+```
+
+---
+
+## Referencias
+
+- Docs: https://e2b.dev/docs
+- SDK: https://github.com/e2b-dev/E2B
+- Dashboard: https://e2b.dev/dashboard

--- a/docs/integrations/liveblocks.md
+++ b/docs/integrations/liveblocks.md
@@ -1,0 +1,121 @@
+# Integración: Liveblocks (presencia + colab tiempo real)
+
+> *Entra en M13 (Fase 2). Cursors compartidos y presencia en `/forge` y `/projects/[id]` cuando Luis y un colaborador estén viendo el mismo proyecto. ADR-009 lo eligió sobre Yjs casero porque el upside (mantenimiento perpetuo de WebSocket sync) no se justifica para Fase 2.*
+
+---
+
+## Resumen
+
+- **Provider:** [Liveblocks](https://liveblocks.io) — presencia, cursors, comments, CRDTs gestionados
+- **Rol en vForge:** presencia y colab tiempo real en `/forge` (Luis + colaborador en el mismo chat), en `/projects/[id]` (cursors compartidos sobre el detalle del proyecto), y eventualmente en el editor de prompts.
+- **Milestone:** M13 — Fase 2
+- **Anillo:** 0-1 (presencia es read-only; comments y collab edits son write con scope a la room)
+- **Adapter file (futuro):** `lib/forge/adapters/liveblocks-rooms.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+LIVEBLOCKS_SECRET_KEY                 sk_prod_...   server-side, encrypted, NUNCA al cliente
+NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY     pk_prod_...   frontend-safe, exposed al browser
+```
+
+Dos variables. La secret va encrypted; la public va plain y se expone vía `NEXT_PUBLIC_` para que el SDK del cliente la lea.
+
+---
+
+## Cuenta y onboarding
+
+1. Ir a https://liveblocks.io/sign-up — registrarse con GitHub OAuth.
+2. Crear proyecto desde el dashboard → "Create Project" → nombrar `vforge` → seleccionar production environment.
+3. En https://liveblocks.io/dashboard/projects/{id}/apikeys copiar las dos keys: `pk_prod_...` (public) y `sk_prod_...` (secret).
+4. (Opcional) configurar webhooks en `/webhooks` para events `roomCreated`, `userEntered`, `userLeft` — útil para auditar quién entró a qué room. No requerido en M13.
+5. Agregar `LIVEBLOCKS_SECRET_KEY` (encrypted) y `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` (plain) a Vercel env vars en production + preview + development.
+
+---
+
+## Endpoints / SDK usados
+
+Liveblocks tiene dos lados: **backend** (`@liveblocks/node`) para autorizar sesiones e issue tokens; **frontend** (`@liveblocks/react`) para hooks de presencia/storage.
+
+```ts
+// app/api/liveblocks-auth/route.ts — backend authorization
+import { Liveblocks } from "@liveblocks/node";
+
+const liveblocks = new Liveblocks({ secret: process.env.LIVEBLOCKS_SECRET_KEY! });
+
+export async function POST(req: Request) {
+  const { user } = await getCurrentUser(req); // Clerk
+  const { room } = await req.json();
+
+  const session = liveblocks.prepareSession(user.id, {
+    userInfo: { name: user.name, avatar: user.imageUrl },
+  });
+  session.allow(room, session.FULL_ACCESS);
+  const { body, status } = await session.authorize();
+  return new Response(body, { status });
+}
+
+// app/forge/layout.tsx — frontend
+"use client";
+import { LiveblocksProvider, RoomProvider } from "@liveblocks/react";
+
+<LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+  <RoomProvider id="forge-main">
+    {children}
+  </RoomProvider>
+</LiveblocksProvider>
+```
+
+Endpoints relevantes (REST API bajo `https://api.liveblocks.io/v2`):
+
+| Endpoint | Método | Para qué |
+|---|---|---|
+| `/rooms` | GET/POST | Listar/crear rooms |
+| `/rooms/{id}` | GET/POST/DELETE | Inspeccionar/actualizar/borrar room |
+| `/rooms/{id}/active_users` | GET | Quién está conectado ahora |
+| `/rooms/{id}/storage` | GET | Snapshot del CRDT storage |
+
+---
+
+## Runbook (cuando ejecutemos M13)
+
+1. Verificar `LIVEBLOCKS_SECRET_KEY` y `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` vía `getOperatorSecret` y `process.env` respectivamente. Si falta, abortar M13.
+2. Crear `lib/forge/adapters/liveblocks-rooms.ts` implementando el contract. Capacidades: `["presence", "realtime", "comments"]`. Anillo 0-1.
+3. Métodos del adapter: `createRoom(projectId)`, `authorizeSession(userId, roomId)`, `deleteRoom(roomId)` (Anillo 2).
+4. Crear route `app/api/liveblocks-auth/route.ts` que valide Clerk session y autorice el room scoped a la membresía del usuario en el proyecto.
+5. Wrap el layout de `/forge` y `/projects/[id]` con `<LiveblocksProvider>` + `<RoomProvider>`. Room IDs: `forge-{userId}` para chat personal, `project-{projectId}` para vista compartida.
+6. Componente `<PresenceCursors>` que use `useOthers()` de `@liveblocks/react` para renderizar avatars + cursors. Tokens de color desde nuestro design system (`var(--green)`, `var(--accent)`).
+7. Agregar tool al cerebro: `realtime_room_create(project_id)` (Anillo 1).
+8. Test mínimo: dos pestañas del browser entrando al mismo room, verificar que cada una ve al otro user en `useOthers()`.
+
+---
+
+## Caveats / notas operativas
+
+- **Free tier:** 50 MAUs, 20 rooms simultáneas, 100 conexiones. Suficiente para Fase 2 con 5-10 usuarios; renegociar a paid en Fase 3 (ADR-009).
+- **Public key seguro de exponer.** Está restringida por dominio en el dashboard → settings; configurar allowlist con `vforge.site` y `*.vercel.app` para previews.
+- **Room IDs estables.** No regenerar room ID entre sesiones — los presence states se asocian al room, no al user.
+- **Storage CRDT** (futuro M16+) tiene un cap de 1 MB por room en free tier. Para colab en prompt editor, los prompts > 1 MB son improbables; si llega el caso, splittear en sub-rooms.
+- **Rotación de keys:** dashboard `/apikeys` → revoke + regenerate. El public key cambia y todos los clientes deben recargar; planear ventana de mantenimiento.
+- **Vendor alternatives:** Yjs + Hocuspocus self-hosted, PartyKit, Ably. Migrar implica reescribir el adapter + el provider del frontend; viable pero ~1 sprint.
+
+---
+
+## Estado de env vars en Vercel
+
+```
+LIVEBLOCKS_SECRET_KEY              encrypted    PENDIENTE — agregar antes de M13
+NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY  plain        PENDIENTE — agregar antes de M13
+```
+
+---
+
+## Referencias
+
+- Docs: https://liveblocks.io/docs
+- SDK Node: https://github.com/liveblocks/liveblocks/tree/main/packages/liveblocks-node
+- SDK React: https://github.com/liveblocks/liveblocks/tree/main/packages/liveblocks-react
+- Dashboard: https://liveblocks.io/dashboard

--- a/docs/integrations/openrouter.md
+++ b/docs/integrations/openrouter.md
@@ -1,0 +1,105 @@
+# Integración: OpenRouter (gateway secundario a LLMs no-Anthropic)
+
+> *Entra en M3 (Fase 1) como adapter paralelo al de Anthropic directo. No reemplaza a `anthropic-claude`; añade Gemini, Mistral, Llama y similares para tareas baratas o como fallback cuando Anthropic se degrade. ADR-009 lo declara secundario por decisión deliberada (ver ADR-005).*
+
+---
+
+## Resumen
+
+- **Provider:** [OpenRouter](https://openrouter.ai) — aggregator OpenAI-compatible sobre 100+ modelos
+- **Rol en vForge:** gateway secundario a LLMs no-Anthropic (Gemini, Mistral, Llama, etc.) para cost optimization y fallback. No reemplaza el adapter Anthropic directo cableado en `app/api/forge/run/route.ts`.
+- **Milestone:** M3 — Fase 1
+- **Anillo:** 0-1 (lectura/razonamiento; sin acción destructiva por sí solo)
+- **Adapter file (futuro):** `lib/forge/adapters/openrouter.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+OPENROUTER_API_KEY    sk-or-v1-...   key del dashboard OpenRouter, server-side encrypted
+```
+
+Una sola variable. El endpoint es estático y el modelo se elige por request, no se fija como env.
+
+---
+
+## Cuenta y onboarding
+
+Pasos exactos que Luis debe hacer:
+
+1. Ir a https://openrouter.ai/sign-up — registrarse con email o GitHub OAuth (recomendado GitHub para consolidar identidades).
+2. Cargar saldo en https://openrouter.ai/credits — OpenRouter es prepago, no suscripción. Cargar al menos $10 USD para Fase 1; el costo por request se descuenta del saldo.
+3. Generar key en https://openrouter.ai/keys → "Create Key" → nombrar `vforge-prod`. Copiar el `sk-or-v1-...` (no se vuelve a mostrar).
+4. (Opcional) configurar rate limit y spending cap por key desde el mismo dashboard.
+5. Agregar la key a `operator_secrets` vía vForge (cuando M0 esté listo) o a Vercel env vars como `OPENROUTER_API_KEY` (encrypted, production + preview + development).
+
+---
+
+## Endpoints / SDK usados
+
+OpenRouter es **OpenAI-compatible**. Se usa el SDK oficial de OpenAI apuntándolo al base URL de OpenRouter.
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  baseURL: "https://openrouter.ai/api/v1",
+  defaultHeaders: {
+    "HTTP-Referer": "https://vforge.site",
+    "X-Title": "vForge",
+  },
+});
+
+const res = await client.chat.completions.create({
+  model: "google/gemini-2.5-flash",
+  messages: [{ role: "user", content: "ping" }],
+});
+```
+
+Endpoints relevantes (todos bajo `https://openrouter.ai/api/v1`):
+
+| Endpoint | Método | Para qué |
+|---|---|---|
+| `/models` | GET | Listar modelos disponibles + pricing |
+| `/chat/completions` | POST | Inference (OpenAI-compatible) |
+| `/auth/key` | GET | Verificar key + saldo restante |
+
+---
+
+## Runbook (cuando ejecutemos M3)
+
+1. Verificar que `OPENROUTER_API_KEY` existe vía `getOperatorSecret("OPENROUTER_API_KEY", { auditUserId: ctx.userId })` en `lib/vault/get-secret.ts`. Si falla, devolver `missing-key` al health check.
+2. Crear `lib/forge/adapters/openrouter.ts` implementando el contract de `lib/forge/adapters/_contract.ts` (`ForgeAdapter<ChatInput, ChatOutput>`). Capacidades: `["reasoning", "classification", "summarization"]`. Anillo 0-1.
+3. Registrar entradas en `lib/forge/models.ts` para los modelos canónicos a ofrecer en Fase 1: `google/gemini-2.5-flash` (clasificación barata), `mistralai/mistral-large` (resúmenes), `meta-llama/llama-3.3-70b-instruct` (experimentos).
+4. Extender el switch de `lib/forge/routing.ts` para que `step.kind === "classify"` o `"summarize"` con hint `"cheap"` ruten a OpenRouter en vez de Anthropic Haiku.
+5. Agregar test mínimo en `lib/forge/adapters/__tests__/openrouter.test.ts`: happy path (mock 200) + missing-key (throw).
+6. Update a `lib/forge/system-prompt.ts`: documentar a V que puede pedir routing a Gemini/Mistral cuando la tarea sea simple y la velocidad/costo importen más que calidad de razonamiento.
+
+---
+
+## Caveats / notas operativas
+
+- **Prepago, no suscripción.** Si el saldo llega a $0, todas las requests fallan con 402. Health check debe alertar cuando el saldo baje de $5.
+- **Latencia variable por modelo.** Gemini Flash ~300ms; Llama 70B ~2-4s. La routing policy debe considerar latency en el adapter metadata.
+- **Headers `HTTP-Referer` y `X-Title`** son opcionales pero recomendados — habilitan el dashboard de analytics y dan ranking en el leaderboard público de OpenRouter (opt-out disponible).
+- **Rotación de key:** desde el dashboard `/keys` → revoke + create new. Actualizar `operator_secrets` y triggear redeploy de Vercel.
+- **Vendor lock-in:** trivial — al ser OpenAI-compatible, migrar a Together.ai, Fireworks, o a SDKs directos del proveedor (Google, Mistral, Meta) es cambiar `baseURL` y el formato del campo `model`.
+
+---
+
+## Estado de env vars en Vercel
+
+```
+OPENROUTER_API_KEY    encrypted    PENDIENTE — agregar antes de M3
+```
+
+---
+
+## Referencias
+
+- Docs: https://openrouter.ai/docs
+- Models + pricing: https://openrouter.ai/models
+- Dashboard: https://openrouter.ai/keys

--- a/docs/integrations/openrouter.md
+++ b/docs/integrations/openrouter.md
@@ -10,8 +10,9 @@
 - **Rol en vForge:** gateway secundario a LLMs no-Anthropic (Gemini, Mistral, Llama, etc.) para cost optimization y fallback. No reemplaza el adapter Anthropic directo cableado en `app/api/forge/run/route.ts`.
 - **Milestone:** M3 — Fase 1
 - **Anillo:** 0-1 (lectura/razonamiento; sin acción destructiva por sí solo)
-- **Adapter file (futuro):** `lib/forge/adapters/openrouter.ts`
-- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+- **Adapter file:** `lib/forge/adapters/openrouter.ts` ✅
+- **Tool registrada:** `openrouter_query` en `lib/forge/tools.ts`
+- **Estado actual:** ✅ Listo (M3 completado 2026-05-12). Key en vault (`operator_secrets`) y en Vercel env (production + preview + development). Smoke test E2E PASS contra `google/gemini-2.5-flash` y `anthropic/claude-haiku-4.5`.
 
 ---
 
@@ -93,7 +94,7 @@ Endpoints relevantes (todos bajo `https://openrouter.ai/api/v1`):
 ## Estado de env vars en Vercel
 
 ```
-OPENROUTER_API_KEY    encrypted    PENDIENTE — agregar antes de M3
+OPENROUTER_API_KEY    encrypted    production + preview + development  (✅ 2026-05-12)
 ```
 
 ---

--- a/docs/integrations/polar-sh.md
+++ b/docs/integrations/polar-sh.md
@@ -1,0 +1,123 @@
+# Integración: Polar.sh (billing + subscriptions + usage-based pass-through)
+
+> *Entra en M14 (Fase 2). Cumple el pass-through prometido en ADR-006: clientes externos pagan el costo de Anthropic/OpenAI + margen. Polar wrappea Stripe con DX para SaaS developer-first — customer portal, usage metering, webhooks ya implementados. ADR-009 lo eligió sobre Stripe directo por eso.*
+
+---
+
+## Resumen
+
+- **Provider:** [Polar.sh](https://polar.sh) — billing + monetización para developer SaaS, wrap sobre Stripe
+- **Rol en vForge:** subscriptions + usage-based billing pass-through del costo de Anthropic/OpenAI + margen. Customer portal embebido, webhooks para sync con Neon, checkout hosted.
+- **Milestone:** M14 — Fase 2
+- **Anillo:** 2-3 (checkout y subscriptions = Anillo 2; refunds y cancelaciones = Anillo 3)
+- **Adapter file (futuro):** `lib/forge/adapters/polar-billing.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+POLAR_ACCESS_TOKEN       polar_oat_...   organization access token, server-side encrypted
+POLAR_ORGANIZATION_ID    org_...         ID de la organización (plain)
+POLAR_WEBHOOK_SECRET     whsec_...       secret para validar firmas de webhooks
+```
+
+Tres variables. Webhook secret y access token van encrypted; organization ID es plain.
+
+---
+
+## Cuenta y onboarding
+
+1. Ir a https://polar.sh — sign up con GitHub OAuth (Polar es GitHub-first).
+2. Crear organización: nombrarla algo como `vforge` o `all-global-holding`. El slug se vuelve público en el customer portal.
+3. Conectar Stripe como underlying processor: dashboard → Settings → Payments → Connect Stripe. Polar pide la cuenta de Stripe del operador (Luis); todos los pagos llegan ahí, Polar toma fee 4% + Stripe fee.
+4. Configurar tax + business info (RFC mexicano, address): Settings → Tax. Necesario para emitir facturas/invoices válidas.
+5. Crear productos iniciales: dashboard → Products → "New product". Plan sugerido inicial: `vforge-starter` ($20/mes, 100 runs incluidos), `vforge-pro` ($100/mes, 1000 runs), pass-through extra runs.
+6. Generar organization access token: Settings → Developers → "Create Token" → scopes: `products:read`, `subscriptions:write`, `customers:read`, `webhooks:write`. Copiar el `polar_oat_...`.
+7. Crear webhook endpoint: Settings → Webhooks → "Add endpoint" → URL `https://vforge.site/api/webhooks/polar` → events: `subscription.created`, `subscription.updated`, `subscription.canceled`, `invoice.paid`. Copiar el `whsec_...`.
+8. Agregar `POLAR_ACCESS_TOKEN` (encrypted), `POLAR_ORGANIZATION_ID` (plain), `POLAR_WEBHOOK_SECRET` (encrypted) a Vercel env vars en production + preview + development.
+
+---
+
+## Endpoints / SDK usados
+
+Polar tiene SDK TypeScript oficial. Patrón típico: crear customer al onboarding del tenant, generar checkout URL, escuchar webhooks para activar features.
+
+```ts
+import { Polar } from "@polar-sh/sdk";
+
+const polar = new Polar({
+  accessToken: process.env.POLAR_ACCESS_TOKEN,
+});
+
+// 1. Crear checkout para un plan
+const checkout = await polar.checkouts.create({
+  productPriceId: priceId,
+  successUrl: "https://vforge.site/billing/success",
+  customerEmail: user.email,
+  customerExternalId: tenantId, // nuestro ID para sync via webhook
+});
+// redirect a checkout.url
+
+// 2. Reportar usage (usage-based billing)
+await polar.usage.ingest({
+  customerId: customer.id,
+  meterId: "anthropic-tokens",
+  value: tokensUsed,
+});
+```
+
+Endpoints relevantes (bajo `https://api.polar.sh/v1`):
+
+| Endpoint | Método | Para qué |
+|---|---|---|
+| `/checkouts` | POST | Crear checkout URL hosted |
+| `/customers` | GET/POST | CRUD customers (sincronizar con tenants en Neon) |
+| `/subscriptions` | GET/PATCH | Listar/modificar subs (upgrade, cancel) |
+| `/products` | GET | Listar productos para mostrar en pricing page |
+| `/events` (usage ingest) | POST | Reportar consumo medido (tokens, runs) |
+| `/customer-portal/sessions` | POST | Generar URL del customer portal |
+
+---
+
+## Runbook (cuando ejecutemos M14)
+
+1. Verificar las tres envs vía `getOperatorSecret`. Si falta alguna, abortar M14.
+2. Crear `lib/forge/adapters/polar-billing.ts` implementando el contract. Capacidades: `["billing", "subscriptions", "usage-metering"]`. Anillo 2 default, 3 para refunds.
+3. Métodos del adapter: `createCheckout(planId, tenantId)`, `getSubscription(tenantId)`, `reportUsage(tenantId, meter, value)`, `cancelSubscription(tenantId)` (Anillo 3).
+4. Crear route `app/api/webhooks/polar/route.ts` que valide la firma con `POLAR_WEBHOOK_SECRET`, parsee el event, y actualice la tabla `subscriptions` en Neon (linkear con `tenants.id` via `customer_external_id`).
+5. Crear página `/billing` con embed del customer portal de Polar (Polar genera el URL via SDK; redirect simple).
+6. Agregar tool al cerebro en `lib/forge/tools.ts`: `billing_create_checkout(plan_id, user_id)` (Anillo 2 — humano confirma).
+7. Wire usage reporting: cada `audit_event` con costo registra `polar.usage.ingest` async (vía Trigger.dev para no bloquear el run).
+8. Test mínimo: crear un checkout sandbox, completarlo con tarjeta de prueba, verificar que el webhook llega y la row en `subscriptions` se crea.
+
+---
+
+## Caveats / notas operativas
+
+- **Fee:** Polar cobra 4% + fees de Stripe (~2.9% + $0.30). Total ~7% efectivo. Considerar en el margen al pricing.
+- **Webhook signature validation es OBLIGATORIA.** Sin validar firma, cualquiera puede llamar a `/api/webhooks/polar` con un payload falso y activar features. Usar `@polar-sh/sdk/webhooks` helper.
+- **Customer external ID** es el pegamento entre Polar y nuestro modelo. Setearlo a `tenants.id` (UUID) al crear el customer; nunca cambiar.
+- **Sandbox environment:** Polar tiene `sandbox.polar.sh` separado. Usar para development/preview; production solo cuando se vaya live.
+- **Tax compliance:** Polar maneja VAT/IVA automáticamente si la dirección del business está bien configurada. Para clientes en EU/UK/MX se aplica el tax local.
+- **Rotación de access token:** dashboard `/developers` → revoke + create. Webhook secret rota por separado en `/webhooks/{id}` → regenerate.
+- **Vendor alternatives:** Stripe directo (ADR-006 lo descartó por DX), Lemon Squeezy (similar a Polar), Paddle (Merchant of Record más caro). Migrar a Stripe directo es ~2 semanas porque la data ya está allá under the hood.
+
+---
+
+## Estado de env vars en Vercel
+
+```
+POLAR_ACCESS_TOKEN       encrypted    PENDIENTE — agregar antes de M14
+POLAR_ORGANIZATION_ID    plain        PENDIENTE — agregar antes de M14
+POLAR_WEBHOOK_SECRET     encrypted    PENDIENTE — agregar antes de M14
+```
+
+---
+
+## Referencias
+
+- Docs: https://docs.polar.sh
+- SDK: https://github.com/polarsource/polar-js
+- Dashboard: https://polar.sh

--- a/docs/integrations/resend.md
+++ b/docs/integrations/resend.md
@@ -1,0 +1,120 @@
+# Integración: Resend (email transaccional dominio propio)
+
+> *Entra en M9.5 (Fase 1). Email transaccional con `noreply@vforge.site`: confirmaciones Ring 2/3 cuando el operador no está mirando el chat, recaps diarios, alerts de deploys fallidos a las 3 AM. ADR-009 lo eligió sobre SendGrid/Postmark por DX TS-first + React Email para templates.*
+
+---
+
+## Resumen
+
+- **Provider:** [Resend](https://resend.com) — email transaccional con DX de developer, React Email nativo
+- **Rol en vForge:** entrega de emails desde `@vforge.site` para confirmaciones de Anillo 2/3 fuera del chat, recaps diarios de actividad de Forge, alerts cuando un deploy de Vercel falla, magic links si llegan en Fase 2.
+- **Milestone:** M9.5 — Fase 1 (opcional pero recomendado)
+- **Anillo:** 1 (envío de email; no acción destructiva)
+- **Adapter file (futuro):** `lib/forge/adapters/resend-email.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+RESEND_API_KEY         re_...                   key del dashboard, server-side encrypted
+RESEND_FROM_ADDRESS    noreply@vforge.site      address verificada en Resend con DNS propios
+```
+
+Dos variables. `RESEND_FROM_ADDRESS` es plain (no sensible, pero útil para no hardcodear el address en código).
+
+---
+
+## Cuenta y onboarding
+
+1. Ir a https://resend.com/signup — registrarse con GitHub OAuth o email.
+2. En el dashboard, ir a Domains → "Add Domain" → ingresar `vforge.site`.
+3. Resend muestra los DNS records requeridos: 1 MX, 1 SPF (TXT), 1 DKIM (TXT), 1 DMARC (TXT). Copiar los valores exactos.
+4. Agregar esos records al dominio `vforge.site` vía la **tool `namecom_dns_record_create`** (Name.com es el registrar; ver `docs/integrations/name-com.md`). Crear 4 records, esperar propagación 5-30 min.
+5. Volver al dashboard de Resend → "Verify DNS Records". Status pasa a `verified`. Sin esto, todos los emails van a spam o son rechazados.
+6. Generar key en https://resend.com/api-keys → "Create API Key" → permission `Full access` (para Fase 1; restringir a `Sending access` después). Copiar el `re_...`.
+7. Agregar `RESEND_API_KEY` (encrypted) y `RESEND_FROM_ADDRESS` (plain, valor `noreply@vforge.site`) a Vercel env vars en production + preview + development.
+
+---
+
+## Endpoints / SDK usados
+
+Resend se usa via SDK TypeScript oficial. Templates con React Email para HTML; texto plano para alerts simples.
+
+```ts
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+await resend.emails.send({
+  from: process.env.RESEND_FROM_ADDRESS!,
+  to: ["turbillon50@gmail.com"],
+  subject: "vForge: deploy listo",
+  html: "<p>El deploy de <strong>vforge.site</strong> terminó OK.</p>",
+  // o reemplazar `html` con `react: <DeployDoneEmail url={url} />` para templates JSX
+});
+```
+
+Endpoints relevantes (bajo `https://api.resend.com`):
+
+| Endpoint | Método | Para qué |
+|---|---|---|
+| `/emails` | POST | Enviar un email |
+| `/emails/{id}` | GET | Estado de un envío (delivered, bounced, complained) |
+| `/domains/{id}` | GET | Verificar status DNS del dominio |
+| `/api-keys` | GET/POST | Gestionar keys (rotación) |
+
+---
+
+## Runbook (cuando ejecutemos M9.5)
+
+1. Verificar `RESEND_API_KEY` y `RESEND_FROM_ADDRESS` vía `getOperatorSecret`. Si falta cualquiera, marcar M9.5 como skipped y continuar.
+2. Verificar status del dominio vía `GET /domains/{id}` — si no está `verified`, abortar con mensaje claro al operador (los DNS no propagaron o están mal).
+3. Crear `lib/forge/adapters/resend-email.ts` implementando el contract: capacidades `["email-send"]`. Anillo 1. Método `send({ to, subject, html?, react?, text? })`.
+4. Crear `emails/` en la raíz con templates React Email:
+   - `DeployDone.tsx` — confirmación de deploy exitoso.
+   - `DeployFailed.tsx` — alert con stack trace.
+   - `Ring2Confirmation.tsx` — magic-link-style "Approve / Reject" para acciones de Anillo 2 cuando el operador no está en el chat.
+   - `DailyRecap.tsx` — resumen de actividad de Forge (runs ejecutados, costo, errores).
+5. Agregar tool al cerebro en `lib/forge/tools.ts`: `email_send(to, subject, body)`. Anillo 1.
+6. Wire el cron de Trigger.dev (M9) para el daily recap: scheduled task que corre 8 AM CDMX, agrega audit events del día, dispara `email_send`.
+7. Test mínimo: enviar un email a `turbillon50@gmail.com` desde un endpoint admin, verificar delivery en el dashboard de Resend.
+
+---
+
+## Caveats / notas operativas
+
+- **DNS es prerequisito.** Sin DKIM + SPF + DMARC verificados, Gmail/Outlook marcan como spam o rechazan. Esta es la parte tardada (propagación 5-30 min).
+- **DMARC `p=none` para empezar.** Subir a `p=quarantine` después de 1 semana de logs limpios; a `p=reject` después de 1 mes. Resend documenta el upgrade path.
+- **Free tier:** 3K emails/mes, 100/día. Suficiente para Fase 1 (Luis solo). En Fase 2 evaluar plan paid.
+- **Bounces y complaints** llegan via webhooks (no implementados en M9.5; agregar en Fase 2 si el volumen lo justifica). Por ahora consultar `GET /emails/{id}` para spot checks.
+- **Rotación de key:** dashboard `/api-keys` → revoke + create new. Redeploy de Vercel.
+- **Vendor alternatives:** Postmark, SendGrid, SES. Migrar implica reescribir el adapter (~30 min) y re-verificar DNS en el nuevo proveedor (~1h).
+
+---
+
+## Estado de env vars en Vercel
+
+```
+RESEND_API_KEY         encrypted    PENDIENTE — agregar antes de M9.5
+RESEND_FROM_ADDRESS    plain        PENDIENTE — agregar antes de M9.5 (valor: noreply@vforge.site)
+```
+
+DNS records en Name.com:
+
+```
+TXT @                  v=spf1 include:_spf.resend.com ~all          PENDIENTE
+TXT resend._domainkey  k=rsa; p=...                                  PENDIENTE
+TXT _dmarc             v=DMARC1; p=none; rua=mailto:...              PENDIENTE
+MX  send               feedback-smtp.us-east-1.amazonses.com (10)    PENDIENTE
+```
+
+---
+
+## Referencias
+
+- Docs: https://resend.com/docs
+- SDK: https://github.com/resend/resend-node
+- React Email: https://react.email
+- Dashboard: https://resend.com/overview

--- a/docs/integrations/trigger-dev.md
+++ b/docs/integrations/trigger-dev.md
@@ -1,0 +1,120 @@
+# Integración: Trigger.dev (background jobs durables > 60s)
+
+> *Entra en M9 (Fase 1). Resuelve el techo de 60s del Edge runtime de Vercel: cuando V ejecuta un sub-plan de 5+ pasos o un build largo, el endpoint `/api/forge/run` enqueua un job en Trigger y devuelve un `run_id` para polling/SSE. ADR-009 lo eligió sobre Temporal por DX TS-first.*
+
+---
+
+## Resumen
+
+- **Provider:** [Trigger.dev](https://trigger.dev) — background jobs durables, TS-first, v3
+- **Rol en vForge:** runs largos del cerebro (sub-planes multi-step, builds, deploys con verificación) que excedan los timeouts del Edge runtime. El job es durable, sobrevive a redeploys, y reporta estado vía API.
+- **Milestone:** M9 — Fase 1
+- **Anillo:** 1 (el job ejecuta lo que el orquestador ya validó; no introduce privilegio nuevo)
+- **Adapter file (futuro):** `lib/forge/adapters/trigger-bg.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+TRIGGER_API_KEY      tr_pat_...   personal access token del dashboard (server-side encrypted)
+TRIGGER_PROJECT_ID   proj_...     ID del proyecto vforge en Trigger.dev
+```
+
+Dos variables. El project ID es plain (no sensitive). El API key sí va encrypted.
+
+---
+
+## Cuenta y onboarding
+
+1. Ir a https://cloud.trigger.dev/login — registrarse con GitHub OAuth.
+2. Crear organización (default: nombre del usuario) y luego proyecto: "Create new project" → nombrar `vforge` → copiar el `proj_...` ID.
+3. Generar PAT en https://cloud.trigger.dev/account/tokens → "New token" → scope `read_write` para el proyecto vforge. Copiar el `tr_pat_...`.
+4. Localmente (o en CI), correr `npx trigger.dev@latest init` apuntando al project ID — esto genera `trigger.config.ts` en la raíz del repo y la carpeta `trigger/`.
+5. Deployar tasks iniciales con `npx trigger.dev@latest deploy` (después de M9 cuando las tasks existan).
+6. Agregar `TRIGGER_API_KEY` (encrypted) y `TRIGGER_PROJECT_ID` (plain) a Vercel env vars en production + preview + development.
+
+---
+
+## Endpoints / SDK usados
+
+Trigger.dev v3 se usa via SDK TypeScript. Hay dos lados: **definir tasks** (corren en su infra) y **disparar tasks** (desde nuestro backend).
+
+```ts
+// trigger/forge-long-run.ts — definición de la task (corre en Trigger.dev)
+import { task } from "@trigger.dev/sdk/v3";
+
+export const forgeLongRun = task({
+  id: "forge.long-run",
+  maxDuration: 30 * 60, // 30 min hard cap
+  run: async (payload: { runId: string; subPlan: PlanStep[] }) => {
+    // Ejecuta el sub-plan, emite progress via metadata
+    for (const step of payload.subPlan) {
+      // ... ejecutar step ...
+    }
+    return { status: "ok", artifacts: [] };
+  },
+});
+
+// lib/forge/adapters/trigger-bg.ts — disparar desde vForge
+import { tasks } from "@trigger.dev/sdk/v3";
+
+const handle = await tasks.trigger<typeof forgeLongRun>("forge.long-run", {
+  runId,
+  subPlan,
+});
+// handle.id es el run_id que devolvemos al cliente
+```
+
+Operaciones clave:
+
+| Método | Para qué |
+|---|---|
+| `tasks.trigger(id, payload)` | Enqueue async, devuelve handle |
+| `runs.retrieve(runId)` | Polling de estado |
+| `runs.subscribeToRun(runId)` | Stream de updates (SSE-compatible) |
+| `runs.cancel(runId)` | Cancelación manual desde el chat |
+
+---
+
+## Runbook (cuando ejecutemos M9)
+
+1. Verificar ambas envs (`TRIGGER_API_KEY`, `TRIGGER_PROJECT_ID`) vía `getOperatorSecret`. Si falta cualquiera, abortar M9.
+2. Correr `npx trigger.dev@latest init` en la raíz del repo. Confirmar que crea `trigger.config.ts` y carpeta `trigger/`.
+3. Crear las primeras tasks en `trigger/`:
+   - `forge-long-run.ts` — ejecuta sub-planes multi-step del cerebro.
+   - `health-check.ts` — cron cada 5 min que pinga cada adapter (ver ADR-009 §health check).
+4. Crear `lib/forge/adapters/trigger-bg.ts` implementando el contract: capacidades `["background-job", "scheduled"]`. Anillo 1. Métodos `enqueue(taskId, payload)`, `status(runId)`, `cancel(runId)`.
+5. Agregar tools al cerebro en `lib/forge/tools.ts`: `bg_enqueue(job_name, payload)` y `bg_status(run_id)`. Ambas Anillo 1.
+6. Wire SSE en `/api/forge/run/route.ts`: cuando el run es enqueable, devolver `run_id` inmediato y abrir stream desde `runs.subscribeToRun`.
+7. Deploy tasks: `npx trigger.dev@latest deploy --env prod`.
+8. Test: trigger un job dummy desde un endpoint admin, verificar que aparece en el dashboard de Trigger.
+
+---
+
+## Caveats / notas operativas
+
+- **v3 only.** v2 está deprecado; toda doc nueva apunta a v3. No mezclar SDKs.
+- **maxDuration es hard cap.** Un job que lo excede se mata. Para workflows > 30 min, partir en sub-tasks que se llaman entre sí.
+- **Free tier:** 10K runs/mes, suficiente para Fase 1. Pricing escala por run, no por compute time, lo cual es generoso para nuestro caso.
+- **Cold starts:** ~1-2s por task la primera vez después de redeploy. Despreciable para nuestros casos de uso.
+- **Rotación de key:** dashboard `/account/tokens` → revoke + create new. Redeploy de Vercel para que aplique.
+- **Vendor alternatives:** Inngest (overlap completo, perdió por DX), Temporal (overkill para Fase 1, posible migración en M18 si llegan workflows de horas). Migrar implica reescribir las task definitions y el adapter.
+
+---
+
+## Estado de env vars en Vercel
+
+```
+TRIGGER_API_KEY      encrypted    PENDIENTE — agregar antes de M9
+TRIGGER_PROJECT_ID   plain        PENDIENTE — agregar antes de M9
+```
+
+---
+
+## Referencias
+
+- Docs: https://trigger.dev/docs
+- SDK: https://github.com/triggerdotdev/trigger.dev
+- Dashboard: https://cloud.trigger.dev

--- a/docs/integrations/turso.md
+++ b/docs/integrations/turso.md
@@ -1,0 +1,124 @@
+# Integración: Turso (SQLite distribuido edge per-tenant)
+
+> *Entra en M12 (Fase 2). Complementa a Neon, no lo reemplaza: Neon sigue siendo source of truth central; Turso entra para session state per-tenant, telemetría de routing baja latencia, y eventualmente "vForge gestiona la DB que la app del cliente usa" (un Turso DB libre por cada app que Forge AI deploye).*
+
+---
+
+## Resumen
+
+- **Provider:** [Turso](https://turso.tech) — SQLite distribuido sobre libSQL, edge replicas globales
+- **Rol en vForge:** SQLite distribuido edge per-tenant para session caches, telemetría de routing, y future per-tenant local DBs cuando vForge sirva apps de clientes. No reemplaza Neon — convive con él (ADR-009).
+- **Milestone:** M12 — Fase 2
+- **Anillo:** 1 (read/write a DBs aisladas per-tenant; no acción destructiva cross-tenant sin escalation)
+- **Adapter file (futuro):** `lib/forge/adapters/turso-edge.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+TURSO_AUTH_TOKEN    eyJ...        token de admin de la org (server-side encrypted)
+TURSO_ORG_SLUG      vforge        slug de la organización en Turso (plain)
+```
+
+Dos variables. El token de admin permite crear DBs nuevas per-tenant via API; los tokens per-DB se generan dinámicamente por el adapter al provisionar cada DB.
+
+---
+
+## Cuenta y onboarding
+
+1. Ir a https://turso.tech — sign up con GitHub OAuth (recomendado).
+2. Instalar Turso CLI local: `curl -sSfL https://get.tur.so/install.sh | bash` (opcional, útil para debugging; no requerido en runtime).
+3. Crear organización con slug `vforge` desde https://app.turso.tech/account → "Create Organization". Si ya existe una personal con el username, usar esa y nombrar el slug `vforge` después en settings.
+4. Generar group/region default desde https://app.turso.tech/{org}/groups → "Create Group" → nombrar `default`, region: configurable, ver docs para la región más cercana a CDMX (probablemente `iad` o `lax`).
+5. Generar admin token en https://app.turso.tech/{org}/settings → "API Tokens" → "Create Token" → scope full-access. Copiar el `eyJ...` (JWT).
+6. Agregar `TURSO_AUTH_TOKEN` (encrypted) y `TURSO_ORG_SLUG` (plain, valor `vforge`) a Vercel env vars en production + preview + development.
+
+---
+
+## Endpoints / SDK usados
+
+Turso tiene dos APIs separadas: **Platform API** (CRUD de DBs) y **libSQL client** (queries dentro de una DB). El adapter usa ambas.
+
+```ts
+// Platform API — crear DB per-tenant (admin only)
+const res = await fetch(
+  `https://api.turso.tech/v1/organizations/${process.env.TURSO_ORG_SLUG}/databases`,
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.TURSO_AUTH_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: `tenant-${tenantId}`,
+      group: "default",
+    }),
+  },
+);
+const { database } = await res.json();
+
+// libSQL client — queries dentro de la DB
+import { createClient } from "@libsql/client";
+
+const db = createClient({
+  url: `libsql://${database.Hostname}`,
+  authToken: tenantToken, // generado por separado via /databases/{name}/auth/tokens
+});
+
+await db.execute({
+  sql: "INSERT INTO sessions (id, project_id, state) VALUES (?, ?, ?)",
+  args: [sessionId, projectId, JSON.stringify(state)],
+});
+```
+
+Endpoints Platform API (bajo `https://api.turso.tech/v1`):
+
+| Endpoint | Método | Para qué |
+|---|---|---|
+| `/organizations/{org}/databases` | POST/GET | Crear/listar DBs |
+| `/organizations/{org}/databases/{name}` | DELETE | Borrar DB (Anillo 3) |
+| `/organizations/{org}/databases/{name}/auth/tokens` | POST | Generar token per-DB |
+| `/organizations/{org}/groups` | GET | Listar regiones/grupos |
+
+---
+
+## Runbook (cuando ejecutemos M12)
+
+1. Verificar `TURSO_AUTH_TOKEN` y `TURSO_ORG_SLUG` vía `getOperatorSecret`. Si falta, abortar M12.
+2. Crear `lib/forge/adapters/turso-edge.ts` implementando el contract. Capacidades: `["edge-db", "kv", "sql"]`. Anillo 1 para queries; Anillo 3 para `dropDatabase`.
+3. Métodos del adapter: `provisionTenantDb(tenantId)`, `getClient(tenantId)`, `dropDatabase(tenantId)` (último requiere confirmación humana).
+4. Cachear el `@libsql/client` por tenantId en memoria del proceso para evitar handshake repetido.
+5. Agregar tool al cerebro en `lib/forge/tools.ts`: `edge_db_create(tenant_id)` (Anillo 2 — provisión real). Queries internas no son tools, son helpers.
+6. Migration runner: cada DB per-tenant arranca con un schema base (`sessions`, `routing_log`, `embeddings_cache`). Definir en `lib/turso/schema.sql` y aplicar en `provisionTenantDb` antes de devolver.
+7. Test mínimo: provisionar una DB sandbox, escribir/leer una row, dropearla.
+
+---
+
+## Caveats / notas operativas
+
+- **Free tier:** 500 DBs, 9 GB total storage, 1B row-reads/mes. Suficiente para Fase 2 con 50-100 tenants activos.
+- **Cold start de DB nueva:** ~1-2s la primera vez. Despreciable para nuestro caso (provisión es one-time per tenant).
+- **Region:** configurable por grupo. Crear el grupo `default` en la región más cercana al edge donde corren las Vercel functions del cliente. Para CDMX probablemente `iad` (us-east-1) o `lax`. Ver docs para detalles.
+- **Token per-DB scoping:** cada tenant debe recibir solo el token de SU DB, jamás el admin token. El adapter genera el token en `provisionTenantDb` y lo guarda encrypted en `operator_secrets` con key `TURSO_TOKEN_TENANT_{id}`.
+- **Rotación del admin token:** dashboard `/settings` → revoke + create new. Los tokens per-DB son independientes y siguen vivos.
+- **Vendor alternatives:** Cloudflare D1, Neon (con schema per-tenant), Litestream propio. Migrar implica reescribir el adapter; el SQL en sí es portable.
+
+---
+
+## Estado de env vars en Vercel
+
+```
+TURSO_AUTH_TOKEN    encrypted    PENDIENTE — agregar antes de M12
+TURSO_ORG_SLUG      plain        PENDIENTE — agregar antes de M12 (valor: vforge)
+```
+
+---
+
+## Referencias
+
+- Docs: https://docs.turso.tech
+- libSQL client: https://github.com/tursodatabase/libsql-client-ts
+- Platform API: https://docs.turso.tech/api-reference/introduction
+- Dashboard: https://app.turso.tech

--- a/docs/integrations/unkey.md
+++ b/docs/integrations/unkey.md
@@ -1,0 +1,119 @@
+# Integración: Unkey (API keys per-tenant)
+
+> *Entra en M15 (Fase 2). Reemplaza el `VFORGE_OPERATOR_TOKEN` actual (token único hardcodeado) con keys gestionadas, revocables, rate-limited, con analytics por tenant. ADR-009 lo eligió sobre implementación casera porque rebuilding key management es 1-2 sprints + mantenimiento perpetuo.*
+
+---
+
+## Resumen
+
+- **Provider:** [Unkey](https://unkey.com) — API key management as a service
+- **Rol en vForge:** API keys per-cliente cuando terceros usen vForge desde sus propias apps. Issuance, revocation, rotation, rate limiting, analytics y scoping a endpoints específicos.
+- **Milestone:** M15 — Fase 2
+- **Anillo:** 3 (emite y revoca credenciales reales con poder sobre el agente)
+- **Adapter file (futuro):** `lib/forge/adapters/unkey-keys.ts`
+- **Estado actual:** Pendiente (cuenta no creada) — actualizar cuando el operador la cree
+
+---
+
+## Inputs requeridos del operador
+
+```
+UNKEY_ROOT_KEY    unkey_...   root key con permisos de admin, server-side encrypted
+UNKEY_API_ID      api_...     ID del "API" en Unkey contra el que se emiten keys (plain)
+```
+
+Dos variables. Root key va encrypted con prioridad Class 1 (rotation periódica). API ID es plain.
+
+---
+
+## Cuenta y onboarding
+
+1. Ir a https://app.unkey.com/auth/sign-up — sign up con GitHub OAuth.
+2. Crear workspace (free tier por default). Nombrarlo `vforge`.
+3. Crear un "API" desde dashboard → APIs → "Create new API" → nombrar `vforge-public`. Copiar el `api_...` ID.
+4. Generar root key: dashboard → Settings → Root Keys → "Create Root Key" → permissions: `*` (full admin para Fase 2 inicial; restringir a `api.*.create_key`, `api.*.revoke_key`, `api.*.read_key` en hardening posterior). Copiar el `unkey_...`.
+5. (Opcional) configurar rate limit defaults para todas las keys emitidas: dashboard → APIs → vforge-public → Settings → Rate Limit → `100 req/min` default. Sobreescribible por key.
+6. Agregar `UNKEY_ROOT_KEY` (encrypted) y `UNKEY_API_ID` (plain) a Vercel env vars en production + preview + development.
+
+---
+
+## Endpoints / SDK usados
+
+Unkey tiene SDK TypeScript oficial. Dos operaciones principales: **issuance** (cuando un tenant se onboardea o pide key) y **verification** (en cada request entrante a la API pública de vForge).
+
+```ts
+import { Unkey, verifyKey } from "@unkey/api";
+
+const unkey = new Unkey({ rootKey: process.env.UNKEY_ROOT_KEY! });
+
+// 1. Emitir key per-tenant
+const { result } = await unkey.keys.create({
+  apiId: process.env.UNKEY_API_ID!,
+  prefix: "vfk", // vForge Key — visible en la key emitida
+  ownerId: tenantId,
+  meta: { tenantId, planId, createdAt: new Date().toISOString() },
+  ratelimit: { type: "fast", limit: 1000, refillInterval: 60_000, refillRate: 100 },
+  expires: null, // sin expiración por default; rotación manual
+});
+// result.key es lo que se devuelve UNA VEZ al cliente. Nunca se vuelve a mostrar.
+
+// 2. Verificar key en cada request entrante
+const { result: v } = await verifyKey({
+  key: req.headers.get("authorization")?.replace("Bearer ", "") ?? "",
+  apiId: process.env.UNKEY_API_ID!,
+});
+if (!v.valid) return new Response("unauthorized", { status: 401 });
+const tenantId = v.ownerId;
+```
+
+Endpoints relevantes (bajo `https://api.unkey.dev/v1`):
+
+| Endpoint | Método | Para qué |
+|---|---|---|
+| `/keys.createKey` | POST | Emitir nueva key |
+| `/keys.verifyKey` | POST | Verificar key entrante (también vía SDK helper) |
+| `/keys.deleteKey` | POST | Revocar key (Anillo 3) |
+| `/keys.updateKey` | POST | Actualizar rate limit, scopes, metadata |
+| `/apis.listKeys` | GET | Listar keys de un API (paginado) |
+
+---
+
+## Runbook (cuando ejecutemos M15)
+
+1. Verificar `UNKEY_ROOT_KEY` y `UNKEY_API_ID` vía `getOperatorSecret`. Si falta, abortar M15.
+2. Crear `lib/forge/adapters/unkey-keys.ts` implementando el contract. Capacidades: `["key-issuance", "key-verification", "rate-limiting"]`. Anillo 3 default (issuance y revoke); verification es Anillo 0.
+3. Métodos del adapter: `issueKey(tenantId, scopes, ratelimit?)`, `verifyKey(rawKey)`, `revokeKey(keyId)` (Anillo 3 — humano confirma).
+4. Crear middleware `lib/api/auth.ts` que use `verifyKey` en cada request a `/api/public/*`. Cachear verificaciones positivas 60s en memoria para reducir round-trips.
+5. Reemplazar `VFORGE_OPERATOR_TOKEN` check en endpoints existentes con el nuevo middleware. Migration path: aceptar ambos durante 1 semana, deprecar el viejo.
+6. Agregar tools al cerebro en `lib/forge/tools.ts`: `apikey_issue(tenant_id, scopes)` y `apikey_revoke(key_id)`. Ambas Anillo 3.
+7. UI: añadir sección "API Keys" en `/settings/tenant` que liste keys del tenant (sin mostrar el secret — solo prefix + last 4 chars + meta), permita revocar, y issue nuevas.
+8. Test mínimo: emitir key, verificarla (200), revocarla, verificarla again (401).
+
+---
+
+## Caveats / notas operativas
+
+- **La key se muestra UNA VEZ.** En `keys.createKey` el `result.key` solo viene en la respuesta de creación; después solo se puede ver el hash. Si el tenant la pierde, hay que emitir una nueva (no recover).
+- **Free tier:** 150 monthly active keys, 2500 verifications/mes. Suficiente para Fase 2 con 50-150 tenants ligeros. Verificaciones se cobran por uso después.
+- **Rate limit por key.** Configurar default conservador (100 req/min); escalable por plan via `keys.updateKey`. Para clientes enterprise, override individual.
+- **Owner ID** debe mapear 1:1 a nuestro `tenants.id`. Sirve para listar keys de un tenant y para extraer tenantId desde `verifyKey`.
+- **Meta payload** se puede usar para guardar `planId`, `createdBy`, `lastRotated`. Útil para analytics; no usar para secrets.
+- **Rotación del root key:** dashboard `/settings/root-keys` → revoke + create. CRITICO: todas las keys emitidas siguen vivas (no dependen del root key específico); el root key solo controla quién puede emitir/revocar.
+- **Vendor alternatives:** Clerk Machine Tokens (sin rate limiting ni analytics — ADR-009 lo descartó), implementación casera con Neon + bcrypt (1-2 sprints), AWS API Gateway keys (overkill). Migrar a Unkey alternativo implica reescribir el adapter; las keys mismas se rotan al migrar.
+
+---
+
+## Estado de env vars en Vercel
+
+```
+UNKEY_ROOT_KEY    encrypted    PENDIENTE — agregar antes de M15
+UNKEY_API_ID      plain        PENDIENTE — agregar antes de M15
+```
+
+---
+
+## Referencias
+
+- Docs: https://www.unkey.com/docs
+- SDK: https://github.com/unkeyed/unkey
+- Dashboard: https://app.unkey.com

--- a/lib/forge/adapters/README.md
+++ b/lib/forge/adapters/README.md
@@ -1,0 +1,60 @@
+# `lib/forge/adapters/`
+
+Canonical home of every external capability the Forge brain (V) can invoke.
+
+## Contract
+
+All adapters implement `ForgeAdapter<Input, Output>` from
+[`_contract.ts`](./_contract.ts). The interface is small on purpose: `name`,
+`ring`, `capabilities`, `costPerCall`, `health`, `execute`. See
+[`docs/architecture.md §3.1`](../../../docs/architecture.md) for the design.
+
+## Rules
+
+1. **Never** read `process.env` directly. Use `ctx.vault.getOperatorSecret(...)`
+   or `ctx.vault.getProjectSecret(...)`. Local dev falls through to env via
+   `lib/vault/get-secret.ts`.
+2. **Never** make a destructive call (Ring 2/3) without surfacing a confirmation
+   step. The brain's tool loop handles that — your job is to declare your
+   `ring` correctly.
+3. **Emit progress** for anything that takes >500ms. The SSE stream needs the
+   feedback to keep the chat alive.
+4. **Return normalized errors** via `AdapterError(adapter, message, cause)` so
+   the brain handles all failures the same way.
+
+## Catalog
+
+| File | Status | Adapter | Milestone | ADR |
+|---|---|---|---|---|
+| `_contract.ts` | ✅ ready | — | M3 | — |
+| `anthropic.ts` | 🔜 M3 | `anthropic-claude` | M3 | ADR-002, ADR-005 |
+| `openrouter.ts` | 🔜 M3 | `openrouter-gateway` | M3 | ADR-005, ADR-009 |
+| `openai-image.ts` | 🔜 M6 | `openai-image` | M6 | ADR-005 |
+| `e2b-sandbox.ts` | 🔜 M5 | `e2b-microvm` | M5 | ADR-009 |
+| `claude-code-sdk.ts` | 🔜 M5 | `claude-code-sdk` (runs in `e2b-microvm`) | M5 | ADR-002, ADR-009 |
+| `openai-whisper.ts` | 🔜 M10 | `openai-whisper` | M10 | ADR-005 |
+| `anthropic-web-search.ts` | 🔜 M4 | `anthropic-web-search` | M4 | ADR-002 |
+| `vercel-deploy.ts` | 🟡 partial | `vercel-deploy` (today lives in `lib/vercel/client.ts`, will move here) | M7 | — |
+| `github-octokit.ts` | 🟡 partial | `github-octokit` (today in `lib/github/client.ts`) | M8 | — |
+| `namecom-dns.ts` | 🟡 partial | `namecom-dns` (today in `lib/namecom/client.ts`) | M7 | — |
+| `trigger-bg.ts` | 🔜 M9 | `trigger-bg` (Trigger.dev) | M9 | ADR-009 |
+| `resend-email.ts` | 🔜 M9.5 | `resend-email` | M9.5 | ADR-009 |
+| `turso-edge.ts` | 🔜 Fase 2 | `turso-edge` (per-tenant SQLite) | M12 | ADR-009 |
+| `liveblocks-rooms.ts` | 🔜 Fase 2 | `liveblocks-rooms` | M13 | ADR-009 |
+| `polar-billing.ts` | 🔜 Fase 2 | `polar-billing` | M14 | ADR-006, ADR-009 |
+| `unkey-keys.ts` | 🔜 Fase 2 | `unkey-keys` | M15 | ADR-008, ADR-009 |
+
+> `🟡 partial` means the capability already exists as a `lib/<x>/client.ts`
+> module from before ADR-009. The eventual M-task is to wrap it in the
+> ForgeAdapter shape so the routing policy can treat it uniformly with the
+> rest. No behavior change to the existing code until that move happens.
+
+## Adding a new adapter
+
+1. Create `lib/forge/adapters/<service>.ts`. Implement `ForgeAdapter<Input, Output>`.
+2. Add an entry to `lib/forge/models.ts` (or the relevant registry) so the
+   routing policy can pick it.
+3. Add the credential names to `.env.example`, the runbook to
+   `docs/integrations/<service>.md`, and the audit `ring` to ADR-009 if new.
+4. Add one test in `lib/forge/adapters/__tests__/<service>.test.ts` covering
+   the happy path and the `missing-key` health state.

--- a/lib/forge/adapters/README.md
+++ b/lib/forge/adapters/README.md
@@ -28,7 +28,7 @@ All adapters implement `ForgeAdapter<Input, Output>` from
 |---|---|---|---|---|
 | `_contract.ts` | ✅ ready | — | M3 | — |
 | `anthropic.ts` | 🔜 M3 | `anthropic-claude` | M3 | ADR-002, ADR-005 |
-| `openrouter.ts` | 🔜 M3 | `openrouter-gateway` | M3 | ADR-005, ADR-009 |
+| `openrouter.ts` | ✅ ready | `openrouter-gateway` | M3 | ADR-005, ADR-009 |
 | `openai-image.ts` | 🔜 M6 | `openai-image` | M6 | ADR-005 |
 | `e2b-sandbox.ts` | 🔜 M5 | `e2b-microvm` | M5 | ADR-009 |
 | `claude-code-sdk.ts` | 🔜 M5 | `claude-code-sdk` (runs in `e2b-microvm`) | M5 | ADR-002, ADR-009 |

--- a/lib/forge/adapters/_contract.ts
+++ b/lib/forge/adapters/_contract.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical ForgeAdapter contract.
+ *
+ * Every external capability that the Forge brain (V) can invoke implements
+ * this interface. See `docs/architecture.md §3.1` for the design and
+ * `docs/decisions/009-external-service-stack.md` for the catalog.
+ *
+ * Implementation files live alongside this one (`openrouter.ts`,
+ * `e2b-sandbox.ts`, …). Each file is added when its milestone (M3, M5, M9,
+ * etc.) lands — not before, to avoid orphan stubs.
+ */
+
+/** Permission rings — see AGENTS.md §2 and architecture.md §4. */
+export type Ring = 0 | 1 | 2 | 3;
+
+/** Capability tags used by the routing policy (lib/forge/routing.ts). */
+export type Capability =
+  | "reasoning"
+  | "code-edit"
+  | "code-exec"
+  | "classification"
+  | "image-gen"
+  | "voice-transcribe"
+  | "voice-tts"
+  | "web-search"
+  | "browser"
+  | "repo-op"
+  | "deploy"
+  | "dns-op"
+  | "secret-rw"
+  | "email"
+  | "bg-job"
+  | "realtime"
+  | "billing"
+  | "apikey-issue"
+  | "edge-db";
+
+/** Read-only handle the adapter uses to fetch its credentials. */
+export interface VaultReader {
+  getOperatorSecret(name: string): Promise<string | null>;
+  getProjectSecret(projectId: string, name: string): Promise<string | null>;
+}
+
+/** Event sink — adapter emits progress, the brain forwards to SSE. */
+export type AdapterEvent =
+  | { type: "step"; label: string }
+  | { type: "stream"; chunk: string }
+  | { type: "warn"; message: string };
+
+export interface AdapterContext {
+  /** Vercel user id (operator_luis in Phase 1, real Clerk user_id in Phase 2). */
+  userId: string;
+  /** Current chat session id, for audit correlation. */
+  sessionId: string;
+  /** Project the call belongs to, if scoped. */
+  projectId?: string | null;
+  /** Aborts the call when the user disconnects from the SSE stream. */
+  signal: AbortSignal;
+  /** Vault accessor — adapter MUST NOT read env directly. */
+  vault: VaultReader;
+  /** Optional progress sink — bubbled to the SSE stream. */
+  emit?: (event: AdapterEvent) => void;
+}
+
+export interface ForgeAdapter<Input, Output> {
+  /** Stable identifier — used in routing tables, audit logs, model registry. */
+  readonly name: string;
+  /** Privilege ring — 2+ require human confirmation in the UI. */
+  readonly ring: Ring;
+  /** What this adapter knows how to do; consumed by the router. */
+  readonly capabilities: readonly Capability[];
+  /** Best-effort USD estimate, used for cost caps + audit. */
+  costPerCall(input: Input): number;
+  /** Quick health check; called by /api/admin/health. */
+  health(ctx: Pick<AdapterContext, "vault">): Promise<AdapterHealth>;
+  /** The actual call. Adapter is responsible for its own SDK + auth. */
+  execute(input: Input, ctx: AdapterContext): Promise<Output>;
+}
+
+export type AdapterHealth =
+  | { status: "ok" }
+  | { status: "missing-key"; key: string }
+  | { status: "degraded"; reason: string }
+  | { status: "error"; message: string };
+
+/** Helper: throw a normalized error so the brain handles them uniformly. */
+export class AdapterError extends Error {
+  constructor(
+    public readonly adapter: string,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(`[${adapter}] ${message}`);
+    this.name = "AdapterError";
+  }
+}

--- a/lib/forge/adapters/openrouter.ts
+++ b/lib/forge/adapters/openrouter.ts
@@ -1,0 +1,170 @@
+/**
+ * OpenRouter adapter — secondary LLM gateway (ADR-005, ADR-009).
+ *
+ * OpenRouter exposes 300+ models behind one OpenAI-compatible endpoint.
+ * In vForge it's the "cost optimization" lane: V routes cheap tasks
+ * (classification, summary, routing decisions) through Gemini Flash /
+ * Llama / Mistral via OpenRouter while keeping Anthropic SDK direct
+ * for the primary chat loop. See ADR-005 §"OpenRouter como única capa"
+ * for why this stays secondary.
+ *
+ * The adapter uses `fetch` directly (no SDK) to avoid pulling another
+ * dependency. Streaming is intentionally NOT implemented in M3 — the
+ * use case is short side-tasks, not the main chat. Add streaming in a
+ * later milestone if Forge needs it.
+ */
+import {
+  type ForgeAdapter,
+  type AdapterContext,
+  type AdapterHealth,
+  AdapterError,
+} from "./_contract";
+
+interface OpenRouterMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface OpenRouterInput {
+  /** OpenRouter model slug, e.g. "google/gemini-2.5-flash" or
+   *  "anthropic/claude-haiku-4.5". See https://openrouter.ai/models. */
+  model: string;
+  messages: OpenRouterMessage[];
+  /** Default 1024 — keep callers honest about cost. */
+  maxTokens?: number;
+  /** 0-2, default 0.7. */
+  temperature?: number;
+}
+
+export interface OpenRouterOutput {
+  content: string;
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+  finishReason: string | null;
+  costUsd: number;
+}
+
+const ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
+const MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models";
+
+// Rough per-1M-token USD pricing for the models we route through
+// OpenRouter. Used only for cost estimation; real billing happens at
+// OpenRouter. Update from https://openrouter.ai/models as needed.
+const PRICING: Record<string, { input: number; output: number }> = {
+  "google/gemini-2.5-flash": { input: 0.075, output: 0.3 },
+  "google/gemini-2.5-pro": { input: 1.25, output: 5 },
+  "anthropic/claude-haiku-4.5": { input: 0.8, output: 4 },
+  "anthropic/claude-sonnet-4.6": { input: 3, output: 15 },
+  "meta-llama/llama-3.3-70b-instruct": { input: 0.13, output: 0.4 },
+  "mistralai/mistral-large-2411": { input: 2, output: 6 },
+  // Fallback when an unknown model is invoked.
+  default: { input: 1, output: 3 },
+};
+
+function priceFor(model: string): { input: number; output: number } {
+  return PRICING[model] ?? PRICING.default;
+}
+
+export const openRouterAdapter: ForgeAdapter<OpenRouterInput, OpenRouterOutput> = {
+  name: "openrouter-gateway",
+  ring: 0,
+  capabilities: ["reasoning", "classification"] as const,
+
+  costPerCall(input) {
+    const p = priceFor(input.model);
+    const inTokens = input.messages.reduce(
+      (sum, m) => sum + Math.ceil(m.content.length / 4),
+      0,
+    );
+    const outBudget = input.maxTokens ?? 1024;
+    return Number(
+      ((inTokens / 1_000_000) * p.input + (outBudget / 1_000_000) * p.output).toFixed(6),
+    );
+  },
+
+  async health(ctx): Promise<AdapterHealth> {
+    const apiKey = await ctx.vault.getOperatorSecret("OPENROUTER_API_KEY");
+    if (!apiKey) return { status: "missing-key", key: "OPENROUTER_API_KEY" };
+    try {
+      const r = await fetch(MODELS_ENDPOINT, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (r.status === 401) return { status: "error", message: "401 unauthorized" };
+      if (!r.ok) return { status: "degraded", reason: `models endpoint returned ${r.status}` };
+      return { status: "ok" };
+    } catch (err) {
+      return {
+        status: "error",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+
+  async execute(input, ctx: AdapterContext): Promise<OpenRouterOutput> {
+    const apiKey = await ctx.vault.getOperatorSecret("OPENROUTER_API_KEY");
+    if (!apiKey) {
+      throw new AdapterError(this.name, "OPENROUTER_API_KEY missing in vault");
+    }
+    ctx.emit?.({ type: "step", label: `openrouter → ${input.model}` });
+
+    const body = {
+      model: input.model,
+      messages: input.messages,
+      max_tokens: input.maxTokens ?? 1024,
+      temperature: input.temperature ?? 0.7,
+    };
+
+    let resp: Response;
+    try {
+      resp = await fetch(ENDPOINT, {
+        method: "POST",
+        signal: ctx.signal,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": "https://vforge.site",
+          "X-Title": "vForge",
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      throw new AdapterError(this.name, "network error", err);
+    }
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      throw new AdapterError(
+        this.name,
+        `${resp.status} ${resp.statusText}: ${text.slice(0, 200)}`,
+      );
+    }
+
+    interface ORResponse {
+      model: string;
+      choices: Array<{ message: { content: string }; finish_reason: string | null }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    }
+    const data = (await resp.json()) as ORResponse;
+    const choice = data.choices?.[0];
+    if (!choice) {
+      throw new AdapterError(this.name, "no choices in response");
+    }
+
+    const tokensIn = data.usage?.prompt_tokens ?? 0;
+    const tokensOut = data.usage?.completion_tokens ?? 0;
+    const p = priceFor(data.model ?? input.model);
+    const costUsd = Number(
+      ((tokensIn / 1_000_000) * p.input + (tokensOut / 1_000_000) * p.output).toFixed(6),
+    );
+
+    return {
+      content: choice.message.content,
+      model: data.model ?? input.model,
+      tokensIn,
+      tokensOut,
+      finishReason: choice.finish_reason,
+      costUsd,
+    };
+  },
+};

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -423,6 +423,35 @@ export const TOOLS: Tool[] = [
       "Cruza la lista de proyectos de Vercel con los repos de GitHub y los sincroniza a la tabla `projects` de vForge. Usa esta tool cuando Luis pregunte 'qué proyectos tengo' y la tabla esté vacía/desactualizada, o cuando agregue un proyecto nuevo. Idempotente: actualiza existentes, inserta los nuevos, no borra nada.",
     input_schema: { type: "object", properties: {} },
   },
+
+  // ─── OpenRouter (ADR-009, M3) ─────────────────────────────────────
+  {
+    name: "openrouter_query",
+    description:
+      "Hace una consulta one-shot a un modelo accesible vía OpenRouter (Gemini, Mistral, Llama, Claude alternativo, etc.). Úsala cuando necesites una clasificación rápida y barata (ej. categorizar un repo, resumir un dump de logs, decidir si un archivo es código vs documentación) y no quieras gastar tokens de Anthropic en ello. NO la uses para conversación con Luis — esa va por el cerebro principal. Devuelve { content, model, tokensIn, tokensOut, costUsd }. Modelos sugeridos: 'google/gemini-2.5-flash' (más barato), 'anthropic/claude-haiku-4.5' (cuando el costo es secundario), 'meta-llama/llama-3.3-70b-instruct' (open-source).",
+    input_schema: {
+      type: "object",
+      properties: {
+        model: {
+          type: "string",
+          description: "Slug del modelo en OpenRouter (ej. 'google/gemini-2.5-flash'). Ver openrouter.ai/models.",
+        },
+        system: {
+          type: "string",
+          description: "System prompt opcional para el modelo.",
+        },
+        prompt: {
+          type: "string",
+          description: "El input del usuario (la pregunta o tarea concreta).",
+        },
+        max_tokens: {
+          type: "number",
+          description: "Tope de tokens de output. Default 512.",
+        },
+      },
+      required: ["model", "prompt"],
+    },
+  },
 ];
 
 export interface ToolExecutionContext {
@@ -1065,6 +1094,53 @@ async function dispatch(
           total: byKey.size,
         }),
         summary: `proyectos sync: +${inserted} nuevos, ${updated} actualizados`,
+      };
+    }
+
+    case "openrouter_query": {
+      const model = requireString(input.model, "model");
+      const prompt = requireString(input.prompt, "prompt");
+      const system =
+        typeof input.system === "string" && input.system.length > 0
+          ? input.system
+          : null;
+      const maxTokens = clampNumber(input.max_tokens, 1, 4096, 512);
+
+      const { openRouterAdapter } = await import("./adapters/openrouter");
+      const messages: Array<{ role: "system" | "user" | "assistant"; content: string }> = [];
+      if (system) messages.push({ role: "system", content: system });
+      messages.push({ role: "user", content: prompt });
+
+      const result = await openRouterAdapter.execute(
+        { model, messages, maxTokens },
+        {
+          userId: ctx.userId,
+          sessionId: ctx.sessionId,
+          signal: AbortSignal.timeout(60_000),
+          vault: {
+            async getOperatorSecret(name) {
+              const { getOperatorSecret } = await import("@/lib/vault/get-secret");
+              return getOperatorSecret(name, { auditUserId: ctx.userId });
+            },
+            async getProjectSecret(projectId, name) {
+              const { getOperatorSecret } = await import("@/lib/vault/get-secret");
+              return getOperatorSecret(name, { auditUserId: ctx.userId, projectId });
+            },
+          },
+        },
+      );
+
+      return {
+        ok: true,
+        content: JSON.stringify({
+          content: result.content,
+          model: result.model,
+          tokensIn: result.tokensIn,
+          tokensOut: result.tokensOut,
+          costUsd: result.costUsd,
+          finishReason: result.finishReason,
+        }),
+        summary: `${result.model}: ${result.tokensIn}+${result.tokensOut} tok ($${result.costUsd.toFixed(6)})`,
       };
     }
 

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -20,6 +20,11 @@ import {
   getRepo,
   listRecentCommits,
   getFileContent,
+  createFile as ghCreateFile,
+  updateFile as ghUpdateFile,
+  deleteFile as ghDeleteFile,
+  createBranch as ghCreateBranch,
+  createPullRequest as ghCreatePullRequest,
 } from "@/lib/github/client";
 import {
   listProjects as vercelListProjects,
@@ -111,6 +116,106 @@ export const TOOLS: Tool[] = [
       required: ["owner", "repo", "path"],
     },
   },
+
+  // ─── GitHub write (Ring 1, escrituras en feature branches) ───────────
+  // Por AGENTS.md §2: escribir a la rama 'main' es Ring 2 (destructivo
+  // potencial sobre prod). El dispatcher rechaza writes a main salvo
+  // que el caller pase allow_main=true explícito.
+  {
+    name: "github_create_file",
+    description:
+      "Crea un archivo nuevo en un repo (Ring 1). Falla 422 si el path ya existe — usa github_update_file en ese caso. El contenido se manda en plain UTF-8, la tool lo encodea a base64. Por seguridad RECHAZA escribir a la rama 'main' salvo que pases allow_main=true (Ring 2 — confirmar con Luis). Default branch = 'main' (lo cual obliga a especificar feature branch).",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        path: { type: "string", description: "Ruta relativa (ej. 'docs/runbook.md')" },
+        content: { type: "string", description: "Contenido en UTF-8 plain (sin base64)" },
+        message: { type: "string", description: "Commit message (Conventional Commits preferred)" },
+        branch: { type: "string", description: "Branch destino. Default 'main' (rechazado salvo allow_main)" },
+        allow_main: {
+          type: "boolean",
+          description: "Set true SOLO si Luis confirmó escribir directo a main. Default false.",
+        },
+      },
+      required: ["owner", "repo", "path", "content", "message"],
+    },
+  },
+  {
+    name: "github_update_file",
+    description:
+      "Actualiza un archivo existente en un repo (Ring 1). Si no le pasas sha, lo busca con un GET previo. Mismo guard contra rama 'main' que github_create_file.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        path: { type: "string" },
+        content: { type: "string", description: "Nuevo contenido completo en UTF-8 plain" },
+        message: { type: "string", description: "Commit message" },
+        sha: {
+          type: "string",
+          description: "Blob SHA del archivo. Si no se pasa, se resuelve automáticamente con un GET previo.",
+        },
+        branch: { type: "string" },
+        allow_main: { type: "boolean" },
+      },
+      required: ["owner", "repo", "path", "content", "message"],
+    },
+  },
+  {
+    name: "github_delete_file",
+    description:
+      "Borra un archivo de un repo (Ring 2 — destructivo). Si no le pasas sha, lo resuelve automáticamente. Confirma con Luis antes; el dispatcher exige allow_main=true para borrar de main.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        path: { type: "string" },
+        message: { type: "string", description: "Commit message del delete" },
+        sha: { type: "string", description: "Blob SHA. Opcional." },
+        branch: { type: "string" },
+        allow_main: { type: "boolean" },
+      },
+      required: ["owner", "repo", "path", "message"],
+    },
+  },
+  {
+    name: "github_create_branch",
+    description:
+      "Crea una rama nueva en un repo a partir de una rama existente (Ring 1). Resuelve el SHA del head de from_branch internamente. Convención vForge: nombrar como 'claude/<feature>-<id>' o 'forge/<feature>-<id>' (ver AGENTS.md §3).",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        branch: { type: "string", description: "Nombre de la rama nueva (ej. 'claude/add-spec-XYZ')" },
+        from_branch: { type: "string", description: "Branch base. Default 'main'." },
+      },
+      required: ["owner", "repo", "branch"],
+    },
+  },
+  {
+    name: "github_create_pull_request",
+    description:
+      "Abre un Pull Request en un repo (Ring 1). Por default es DRAFT (Luis decide cuándo pasarlo a 'Ready for review' y mergear). El head debe ser una rama que ya exista; usa github_create_branch + github_create_file primero si construyes el cambio desde cero.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string" },
+        repo: { type: "string" },
+        title: { type: "string", description: "Título del PR (<70 chars)" },
+        body: { type: "string", description: "Markdown completo del PR description" },
+        head: { type: "string", description: "Branch con los cambios" },
+        base: { type: "string", description: "Branch destino. Default 'main'." },
+        draft: { type: "boolean", description: "Default true. Pon false solo si Luis pide directo 'ready'." },
+      },
+      required: ["owner", "repo", "title", "head"],
+    },
+  },
+
   {
     name: "vault_list_secrets",
     description:
@@ -592,6 +697,129 @@ async function dispatch(
         summary: `${path} (${file.size} B${truncated ? ", truncado a 5KB" : ""})`,
       };
     }
+
+    // ─── GitHub write ────────────────────────────────────────────────
+    case "github_create_file": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const path = requireString(input.path, "path");
+      const content = requireString(input.content, "content");
+      const message = requireString(input.message, "message");
+      const branch =
+        typeof input.branch === "string" && input.branch.length > 0
+          ? input.branch
+          : "main";
+      const allowMain = input.allow_main === true;
+      if (branch === "main" && !allowMain) {
+        throw new Error(
+          "Refusing to create file directly on 'main'. Crea una feature branch (github_create_branch) y commitea ahí, o pasa allow_main=true tras confirmar con Luis (Ring 2).",
+        );
+      }
+      const result = await ghCreateFile(owner, repo, path, content, message, {
+        branch,
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `created ${owner}/${repo}#${branch}:${path}`,
+      };
+    }
+    case "github_update_file": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const path = requireString(input.path, "path");
+      const content = requireString(input.content, "content");
+      const message = requireString(input.message, "message");
+      const branch =
+        typeof input.branch === "string" && input.branch.length > 0
+          ? input.branch
+          : "main";
+      const allowMain = input.allow_main === true;
+      if (branch === "main" && !allowMain) {
+        throw new Error(
+          "Refusing to update file directly on 'main'. Pasa allow_main=true tras confirmar con Luis (Ring 2).",
+        );
+      }
+      const result = await ghUpdateFile(owner, repo, path, content, message, {
+        sha: typeof input.sha === "string" ? input.sha : undefined,
+        branch,
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `updated ${owner}/${repo}#${branch}:${path}`,
+      };
+    }
+    case "github_delete_file": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const path = requireString(input.path, "path");
+      const message = requireString(input.message, "message");
+      const branch =
+        typeof input.branch === "string" && input.branch.length > 0
+          ? input.branch
+          : "main";
+      const allowMain = input.allow_main === true;
+      if (branch === "main" && !allowMain) {
+        throw new Error(
+          "Refusing to delete file from 'main'. Esta tool es Ring 2 (destructivo). Pasa allow_main=true SOLO tras confirmar con Luis.",
+        );
+      }
+      const result = await ghDeleteFile(owner, repo, path, message, {
+        sha: typeof input.sha === "string" ? input.sha : undefined,
+        branch,
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `deleted ${owner}/${repo}#${branch}:${path}`,
+      };
+    }
+    case "github_create_branch": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const branch = requireString(input.branch, "branch");
+      const fromBranch =
+        typeof input.from_branch === "string" && input.from_branch.length > 0
+          ? input.from_branch
+          : "main";
+      const result = await ghCreateBranch(owner, repo, branch, {
+        fromBranch,
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `branch ${owner}/${repo}#${branch} created from ${fromBranch}`,
+      };
+    }
+    case "github_create_pull_request": {
+      const owner = requireString(input.owner, "owner");
+      const repo = requireString(input.repo, "repo");
+      const title = requireString(input.title, "title");
+      const head = requireString(input.head, "head");
+      const result = await ghCreatePullRequest(
+        owner,
+        repo,
+        {
+          title,
+          body: typeof input.body === "string" ? input.body : undefined,
+          head,
+          base: typeof input.base === "string" ? input.base : "main",
+          draft: input.draft === false ? false : true,
+        },
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `PR #${result.number} ${result.draft ? "(draft)" : ""}: ${head} → ${result.base}`,
+      };
+    }
+
     case "vault_list_secrets": {
       const rows = (await sql`
         SELECT name, provider, description, created_at, last_used_at

--- a/lib/github/client.ts
+++ b/lib/github/client.ts
@@ -239,3 +239,210 @@ export async function getFileContent(
     encoding: data.encoding,
   };
 }
+
+// ─── Write ops (Ring 1-2) ─────────────────────────────────────────────
+// Per ADR-009 / AGENTS.md, these are gated by branch name in the tool
+// dispatcher: writes to "main" require an explicit override flag,
+// otherwise V is forced to land changes on a feature branch.
+
+export interface FileMutationResult {
+  path: string;
+  sha: string;
+  branch: string;
+  commit_sha: string;
+  commit_url: string;
+}
+
+/**
+ * Create a new file in a repo. Fails with 422 if the path already
+ * exists — the caller should use updateFile in that case.
+ */
+export async function createFile(
+  owner: string,
+  repo: string,
+  path: string,
+  content: string,
+  message: string,
+  options: { branch?: string; auditUserId?: string } = {},
+): Promise<FileMutationResult> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  const { data } = await octokit.request(
+    "PUT /repos/{owner}/{repo}/contents/{path}",
+    {
+      owner,
+      repo,
+      path,
+      message,
+      content: Buffer.from(content, "utf8").toString("base64"),
+      branch: options.branch,
+    },
+  );
+  return {
+    path,
+    sha: data.content?.sha ?? "",
+    branch: options.branch ?? "main",
+    commit_sha: data.commit.sha ?? "",
+    commit_url: data.commit.html_url ?? "",
+  };
+}
+
+/**
+ * Update an existing file. The blob SHA is required by the API; if not
+ * provided, we fetch it with a GET so the caller doesn't have to wire
+ * two calls together.
+ */
+export async function updateFile(
+  owner: string,
+  repo: string,
+  path: string,
+  content: string,
+  message: string,
+  options: { sha?: string; branch?: string; auditUserId?: string } = {},
+): Promise<FileMutationResult> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  let sha = options.sha;
+  if (!sha) {
+    const existing = await getFileContent(owner, repo, path, {
+      branch: options.branch,
+      auditUserId: options.auditUserId,
+    });
+    sha = existing.sha;
+  }
+  const { data } = await octokit.request(
+    "PUT /repos/{owner}/{repo}/contents/{path}",
+    {
+      owner,
+      repo,
+      path,
+      message,
+      content: Buffer.from(content, "utf8").toString("base64"),
+      sha,
+      branch: options.branch,
+    },
+  );
+  return {
+    path,
+    sha: data.content?.sha ?? "",
+    branch: options.branch ?? "main",
+    commit_sha: data.commit.sha ?? "",
+    commit_url: data.commit.html_url ?? "",
+  };
+}
+
+/**
+ * Delete a file. Same SHA-resolution shortcut as updateFile.
+ */
+export async function deleteFile(
+  owner: string,
+  repo: string,
+  path: string,
+  message: string,
+  options: { sha?: string; branch?: string; auditUserId?: string } = {},
+): Promise<{ path: string; branch: string; commit_sha: string; commit_url: string }> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  let sha = options.sha;
+  if (!sha) {
+    const existing = await getFileContent(owner, repo, path, {
+      branch: options.branch,
+      auditUserId: options.auditUserId,
+    });
+    sha = existing.sha;
+  }
+  const { data } = await octokit.request(
+    "DELETE /repos/{owner}/{repo}/contents/{path}",
+    {
+      owner,
+      repo,
+      path,
+      message,
+      sha,
+      branch: options.branch,
+    },
+  );
+  return {
+    path,
+    branch: options.branch ?? "main",
+    commit_sha: data.commit.sha ?? "",
+    commit_url: data.commit.html_url ?? "",
+  };
+}
+
+/**
+ * Create a new branch from an existing one. Resolves the source SHA
+ * with a GET on /git/refs/heads/<from_branch> so the caller can pass
+ * just branch names.
+ */
+export async function createBranch(
+  owner: string,
+  repo: string,
+  branch: string,
+  options: { fromBranch?: string; auditUserId?: string } = {},
+): Promise<{ branch: string; sha: string; ref: string }> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  const fromBranch = options.fromBranch ?? "main";
+  const { data: refData } = await octokit.request(
+    "GET /repos/{owner}/{repo}/git/ref/{ref}",
+    { owner, repo, ref: `heads/${fromBranch}` },
+  );
+  const sourceSha = refData.object.sha;
+  const { data } = await octokit.request(
+    "POST /repos/{owner}/{repo}/git/refs",
+    {
+      owner,
+      repo,
+      ref: `refs/heads/${branch}`,
+      sha: sourceSha,
+    },
+  );
+  return {
+    branch,
+    sha: data.object.sha,
+    ref: data.ref,
+  };
+}
+
+/**
+ * Create a Pull Request. Defaults to draft so V can prepare changes
+ * without requesting review until the human approves.
+ */
+export async function createPullRequest(
+  owner: string,
+  repo: string,
+  input: {
+    title: string;
+    body?: string;
+    head: string;
+    base?: string;
+    draft?: boolean;
+  },
+  options: { auditUserId?: string } = {},
+): Promise<{
+  number: number;
+  url: string;
+  state: string;
+  draft: boolean;
+  head: string;
+  base: string;
+}> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  const { data } = await octokit.request(
+    "POST /repos/{owner}/{repo}/pulls",
+    {
+      owner,
+      repo,
+      title: input.title,
+      body: input.body,
+      head: input.head,
+      base: input.base ?? "main",
+      draft: input.draft ?? true,
+    },
+  );
+  return {
+    number: data.number,
+    url: data.html_url,
+    state: data.state,
+    draft: data.draft ?? false,
+    head: data.head.ref,
+    base: data.base.ref,
+  };
+}


### PR DESCRIPTION
## Resumen

V ya podía leer GitHub. Ahora puede **escribir**: crear archivos, actualizar, borrar, crear branches y abrir PRs. Suficiente para que el flujo *"V edita un repo de Luis end-to-end con confirmación humana"* arranque.

Esto es el **paso intermedio para M8** del roadmap en `docs/architecture.md`. Falta el adapter `claude-code-sdk` (M5) para edits multi-archivo coordinados, pero con estas 5 tools V ya puede ejecutar PRs simples (un archivo o un PR de docs).

## Tools nuevas (5)

| Tool | Ring | Notas |
|---|---|---|
| `github_create_file` | 1 | Rechaza `branch === 'main'` salvo `allow_main=true` (Ring 2) |
| `github_update_file` | 1 | SHA auto-resolve via GET si el caller no lo pasa — single tool call para el LLM |
| `github_delete_file` | 2 | Destructivo. Mismo guard contra main |
| `github_create_branch` | 1 | Resuelve SHA del head de `from_branch` internamente |
| `github_create_pull_request` | 1 | Default `draft: true` (por AGENTS.md §3) |

## Cambios

- `lib/github/client.ts`: +207 líneas — 5 funciones helper que envuelven Octokit con el mismo patrón que las read tools (`getGithubClient()` → `requireOperatorSecret("GITHUB_TOKEN")`).
- `lib/forge/tools.ts`: +228 líneas — 5 tool defs + 5 dispatcher cases. Importa los nuevos helpers.

## Guards de seguridad

Las 3 tools de archivo verifican `branch === 'main'` y lanzan error pidiendo `allow_main=true` explícito. Esto fuerza a V a operar en feature branches por default. Si el cambio toca main directo, Luis tiene que confirmar (Ring 2) → la tool definition pide el flag en el schema.

## Smoke test E2E

Ejecutado contra `turbillon50/vforge` real con cleanup completo:

```
[1/6] createBranch        → tmp/v-write-smoke-* @ 054c1bb7
[2/6] createFile          → commit 1d3d6b26
[3/6] updateFile          → commit 4fa9cb3b  (sha auto-resolve OK)
[4/6] createPullRequest   → draft PR #26
[5/6] deleteFile          → commit 36a1f583  (sha auto-resolve OK)
[6/6] cleanup             → PR #26 closed, branch deleted
```

Cero rastro en el repo después del test.

## Lo que NO incluye

- Refactor de las read tools existentes — siguen como están.
- Cambios al dispatch pattern, audit wrapper, system prompt, vault, anillos UI.
- Deps nuevas.

## Test plan

- [x] `tsc --noEmit` pasa
- [x] Smoke E2E las 5 ops contra GitHub real PASS
- [ ] CI Build + lint (esperando que termine)
- [ ] Validar producción: pedir a V "crea un archivo de prueba en mi repo X" desde el chat y ver que abre PR draft

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_