### PR TITLE
feat(forge): M16 skills + M18 subagents in-process + fix read_file cap

### DIFF
--- a/app/api/admin/health/route.ts
+++ b/app/api/admin/health/route.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/admin/health
+ *
+ * Liveness check for the brain's dependencies. Returns whatever
+ * passes (best-effort — never throws). Used by:
+ *   - /activity UI for status pill
+ *   - V's forge_cost_report flow when it wants to confirm provider OK
+ *   - Future Trigger.dev cron alert (M9.5)
+ *
+ * Response shape:
+ *   {
+ *     ts: ISO,
+ *     ok: boolean,
+ *     db: { status, latency_ms? },
+ *     vault: { status, error? },
+ *     openrouter: { status, balance_usd?, usage_usd?, latency_ms?, error? }
+ *   }
+ *
+ * No auth in the operator MVP. Lock down behind Clerk when M11 lands.
+ */
+import { sql } from "@/lib/db/client";
+import { getOperatorSecret } from "@/lib/vault/get-secret";
+import { vaultSelfTest } from "@/lib/vault/operator-crypto";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface DbHealth {
+  status: "ok" | "error";
+  latency_ms?: number;
+  error?: string;
+}
+
+interface VaultHealth {
+  status: "ok" | "error";
+  error?: string;
+}
+
+interface OpenRouterHealth {
+  status: "ok" | "missing-key" | "error";
+  balance_usd?: number;
+  usage_usd?: number;
+  latency_ms?: number;
+  error?: string;
+}
+
+export async function GET() {
+  const ts = new Date().toISOString();
+
+  const [db, vault, openrouter] = await Promise.all([
+    checkDb(),
+    Promise.resolve(checkVault()),
+    checkOpenRouter(),
+  ]);
+
+  const ok =
+    db.status === "ok" &&
+    vault.status === "ok" &&
+    (openrouter.status === "ok" || openrouter.status === "missing-key");
+
+  return new Response(
+    JSON.stringify({ ts, ok, db, vault, openrouter }),
+    {
+      status: ok ? 200 : 503,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+async function checkDb(): Promise<DbHealth> {
+  const start = Date.now();
+  try {
+    await sql`SELECT 1`;
+    return { status: "ok", latency_ms: Date.now() - start };
+  } catch (err) {
+    return {
+      status: "error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function checkVault(): VaultHealth {
+  const probe = vaultSelfTest();
+  if (probe.ok) return { status: "ok" };
+  return { status: "error", error: probe.error };
+}
+
+async function checkOpenRouter(): Promise<OpenRouterHealth> {
+  const apiKey = await getOperatorSecret("OPENROUTER_API_KEY", {
+    auditUserId: "health-check",
+  }).catch(() => null);
+  if (!apiKey) return { status: "missing-key" };
+
+  const start = Date.now();
+  try {
+    const resp = await fetch("https://openrouter.ai/api/v1/credits", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const latency = Date.now() - start;
+    if (!resp.ok) {
+      return {
+        status: "error",
+        latency_ms: latency,
+        error: `${resp.status} ${resp.statusText}`,
+      };
+    }
+    const json = (await resp.json()) as {
+      data?: { total_credits?: number; total_usage?: number };
+    };
+    return {
+      status: "ok",
+      latency_ms: latency,
+      balance_usd: json.data?.total_credits ?? 0,
+      usage_usd: json.data?.total_usage ?? 0,
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/app/api/forge/cost/route.ts
+++ b/app/api/forge/cost/route.ts
@@ -1,0 +1,160 @@
+/**
+ * GET /api/forge/cost?period=today|24h|this_month|last_7d|last_30d
+ *
+ * Real-time consumption report aggregated from the conversations table.
+ * Used by /activity dashboard and by V's forge_cost_report tool to
+ * surface live spend without inventing numbers.
+ *
+ * Response shape:
+ *   {
+ *     period: string,
+ *     since: string (ISO),
+ *     until: string (ISO),
+ *     total_usd: number,
+ *     total_turns: number,
+ *     total_tokens_in: number,
+ *     total_tokens_out: number,
+ *     by_model: [{ model, turns, tokens_in, tokens_out, cost_usd }],
+ *     by_day:   [{ day, turns, cost_usd }],   // last N days, oldest first
+ *     fallback_events: number,                 // cuántos turnos hicieron fallback
+ *   }
+ *
+ * Read-only. No auth required for the operator-MVP (Clerk lands in M11).
+ */
+import { sql } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Period = "today" | "24h" | "this_month" | "last_7d" | "last_30d";
+
+function resolvePeriod(input: string | null): {
+  period: Period;
+  since: Date;
+  until: Date;
+} {
+  const now = new Date();
+  const p = (input ?? "today") as Period;
+  let since: Date;
+  switch (p) {
+    case "24h":
+      since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      break;
+    case "this_month":
+      since = new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
+      break;
+    case "last_7d":
+      since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      break;
+    case "last_30d":
+      since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      break;
+    case "today":
+    default:
+      since = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+      );
+      break;
+  }
+  return { period: p, since, until: now };
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const { period, since, until } = resolvePeriod(searchParams.get("period"));
+  const sinceIso = since.toISOString();
+  const untilIso = until.toISOString();
+
+  // Aggregate totals across all assistant turns in the window.
+  const [totals] = (await sql`
+    SELECT
+      COALESCE(SUM(cost_usd), 0)::numeric(12,6) AS total_usd,
+      COUNT(*)::int AS total_turns,
+      COALESCE(SUM(tokens_in), 0)::int AS total_tokens_in,
+      COALESCE(SUM(tokens_out), 0)::int AS total_tokens_out
+    FROM conversations
+    WHERE role = 'assistant'
+      AND created_at >= ${sinceIso}
+      AND created_at <= ${untilIso}
+  `) as Array<{
+    total_usd: string;
+    total_turns: number;
+    total_tokens_in: number;
+    total_tokens_out: number;
+  }>;
+
+  // Per-model breakdown.
+  const byModel = (await sql`
+    SELECT
+      COALESCE(model, '(unknown)') AS model,
+      COUNT(*)::int AS turns,
+      COALESCE(SUM(tokens_in), 0)::int AS tokens_in,
+      COALESCE(SUM(tokens_out), 0)::int AS tokens_out,
+      COALESCE(SUM(cost_usd), 0)::numeric(12,6) AS cost_usd
+    FROM conversations
+    WHERE role = 'assistant'
+      AND created_at >= ${sinceIso}
+      AND created_at <= ${untilIso}
+    GROUP BY model
+    ORDER BY cost_usd DESC
+  `) as Array<{
+    model: string;
+    turns: number;
+    tokens_in: number;
+    tokens_out: number;
+    cost_usd: string;
+  }>;
+
+  // Per-day breakdown.
+  const byDay = (await sql`
+    SELECT
+      date_trunc('day', created_at)::date AS day,
+      COUNT(*)::int AS turns,
+      COALESCE(SUM(cost_usd), 0)::numeric(12,6) AS cost_usd
+    FROM conversations
+    WHERE role = 'assistant'
+      AND created_at >= ${sinceIso}
+      AND created_at <= ${untilIso}
+    GROUP BY day
+    ORDER BY day
+  `) as Array<{ day: string; turns: number; cost_usd: string }>;
+
+  // Count how many turns triggered model_fallback (audit_events
+  // payload->fallbacks is a JSON array; we check that it's non-empty).
+  const [fallbackCount] = (await sql`
+    SELECT COUNT(*)::int AS n
+    FROM audit_events
+    WHERE action = 'forge.chat.turn'
+      AND created_at >= ${sinceIso}
+      AND created_at <= ${untilIso}
+      AND jsonb_array_length(COALESCE(payload->'fallbacks', '[]'::jsonb)) > 0
+  `) as Array<{ n: number }>;
+
+  return new Response(
+    JSON.stringify({
+      period,
+      since: sinceIso,
+      until: untilIso,
+      total_usd: Number(totals.total_usd),
+      total_turns: totals.total_turns,
+      total_tokens_in: totals.total_tokens_in,
+      total_tokens_out: totals.total_tokens_out,
+      by_model: byModel.map((m) => ({
+        model: m.model,
+        turns: m.turns,
+        tokens_in: m.tokens_in,
+        tokens_out: m.tokens_out,
+        cost_usd: Number(m.cost_usd),
+      })),
+      by_day: byDay.map((d) => ({
+        day: d.day,
+        turns: d.turns,
+        cost_usd: Number(d.cost_usd),
+      })),
+      fallback_events: fallbackCount.n,
+    }),
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}

--- a/app/api/forge/run/route.ts
+++ b/app/api/forge/run/route.ts
@@ -9,6 +9,8 @@ import { sql } from "@/lib/db/client";
 import { buildSystemPrompt } from "@/lib/forge/system-prompt";
 import { TOOLS, executeTool } from "@/lib/forge/tools";
 import { getOperatorSecret } from "@/lib/vault/get-secret";
+import { routeFor } from "@/lib/forge/routing";
+import { estimateCostForModel, MODELS, normalizeSlug } from "@/lib/forge/models";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -35,14 +37,6 @@ interface RunRequest {
 const OPERATOR_USER_ID = "operator_luis";
 const MAX_TOOL_ROUNDS = 5;
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
-
-// Default fallback when the config's model slug is the legacy Anthropic
-// short name and we need to map it to an OpenRouter-style slug.
-const LEGACY_MODEL_MAP: Record<string, string> = {
-  "claude-opus-4-7": "anthropic/claude-opus-4.7",
-  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
-  "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
-};
 
 export async function POST(req: Request) {
   let body: RunRequest;
@@ -73,12 +67,19 @@ export async function POST(req: Request) {
     projectId: body.projectId ?? null,
   });
 
-  // Resolve the model: prefer OpenRouter-format slugs, fall back via
-  // LEGACY_MODEL_MAP for rows still using the Anthropic short name.
+  // Resolve the model cascade via the routing policy. If the operator
+  // pinned a specific slug in system_config.default_model (and it's in
+  // our registry), we honor it as the primary and let routing.ts supply
+  // its fallback chain. If the slug isn't in the registry, we treat
+  // it as a free-form override and skip cascade.
   const configuredModel = config.default_model;
-  const model =
-    LEGACY_MODEL_MAP[configuredModel] ??
-    (configuredModel.includes("/") ? configuredModel : "anthropic/claude-sonnet-4.6");
+  const isKnownSlug = !!MODELS[normalizeSlug(configuredModel)];
+  const routing = isKnownSlug
+    ? routeFor("chat-main", { forceSlug: normalizeSlug(configuredModel) })
+    : routeFor("chat-main");
+  const cascade = isKnownSlug
+    ? routing.cascade
+    : [configuredModel, ...routing.cascade];
 
   const lastUserTurn = messages[messages.length - 1];
   if (lastUserTurn.role === "user") {
@@ -120,7 +121,10 @@ export async function POST(req: Request) {
   ];
 
   const encoder = new TextEncoder();
-  let actualModel = model;
+  let actualModel = cascade[0];
+  let cascadeIdx = 0;
+  const triedSlugs: string[] = [];
+  const fallbackEvents: Array<{ from: string; to: string; status: number | null; reason: string }> = [];
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -137,14 +141,49 @@ export async function POST(req: Request) {
 
       try {
         for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-          const completion = await openrouter.chat.completions.create({
-            model,
-            messages: conversationMessages,
-            tools: openaiTools.length > 0 ? openaiTools : undefined,
-            max_tokens: 2048,
-            stream: true,
-            stream_options: { include_usage: true },
-          });
+          // Try the primary model and cascade through fallbacks on
+          // recoverable errors (402 = balance, 429 = rate limit,
+          // 5xx = provider down). Non-recoverable errors bubble.
+          let completion: Awaited<
+            ReturnType<typeof openrouter.chat.completions.create>
+          > | null = null;
+          while (true) {
+            const currentSlug = cascade[cascadeIdx];
+            if (!triedSlugs.includes(currentSlug)) triedSlugs.push(currentSlug);
+            actualModel = currentSlug;
+            try {
+              completion = await openrouter.chat.completions.create({
+                model: currentSlug,
+                messages: conversationMessages,
+                tools: openaiTools.length > 0 ? openaiTools : undefined,
+                max_tokens: 2048,
+                stream: true,
+                stream_options: { include_usage: true },
+              });
+              break;
+            } catch (err) {
+              const status = errorStatus(err);
+              const recoverable =
+                status === 402 ||
+                status === 429 ||
+                (status !== null && status >= 500 && status <= 599);
+              const hasNext = cascadeIdx + 1 < cascade.length;
+              if (!recoverable || !hasNext) throw err;
+              const next = cascade[cascadeIdx + 1];
+              const reason =
+                err instanceof Error ? err.message.slice(0, 180) : String(err);
+              fallbackEvents.push({ from: currentSlug, to: next, status, reason });
+              send({
+                type: "model_fallback",
+                from: currentSlug,
+                to: next,
+                status,
+                reason,
+              });
+              cascadeIdx += 1;
+            }
+          }
+          if (!completion) throw new Error("completion is null after cascade");
 
           let roundText = "";
           let roundFinish: string | null = null;
@@ -283,7 +322,7 @@ export async function POST(req: Request) {
             ${userId}, ${sessionId}, 'assistant', ${assistantTextBuffer},
             ${actualModel},
             ${totalTokensIn}, ${totalTokensOut},
-            ${estimateCost(actualModel, totalTokensIn, totalTokensOut)}
+            ${estimateCostForModel(actualModel, totalTokensIn, totalTokensOut)}
           )
         `;
 
@@ -297,6 +336,9 @@ export async function POST(req: Request) {
               model: actualModel,
               provider: "openrouter",
               stop_reason: lastStopReason,
+              cascade_tried: triedSlugs,
+              fallbacks: fallbackEvents,
+              routing_reason: routing.reason,
             })}::jsonb
           )
         `;
@@ -383,33 +425,19 @@ function jsonError(message: string, status: number): Response {
   });
 }
 
-// OpenRouter pricing per 1M tokens (USD). Used only for the cost_usd
-// column in conversations; real billing happens at OpenRouter. Refresh
-// from https://openrouter.ai/models when adding a model.
-const PRICING: Record<string, { input: number; output: number }> = {
-  "anthropic/claude-opus-4.7": { input: 15, output: 75 },
-  "anthropic/claude-sonnet-4.6": { input: 3, output: 15 },
-  "anthropic/claude-haiku-4.5": { input: 0.8, output: 4 },
-  "google/gemini-2.5-flash": { input: 0.075, output: 0.3 },
-  "google/gemini-2.5-pro": { input: 1.25, output: 5 },
-  "meta-llama/llama-3.3-70b-instruct": { input: 0.13, output: 0.4 },
-  "mistralai/mistral-large-2411": { input: 2, output: 6 },
-};
-
-function estimateCost(
-  model: string,
-  tokensIn: number,
-  tokensOut: number,
-): number {
-  // OpenRouter sometimes returns a versioned model name in the response
-  // (e.g. "anthropic/claude-4.6-sonnet-20260217"); strip the suffix.
-  const normalized = model.replace(/(-\d{8}|-\d{6}|-\d{4})$/, "");
-  const p =
-    PRICING[normalized] ??
-    PRICING[model] ??
-    // Fall back to Sonnet pricing if we don't know the model.
-    { input: 3, output: 15 };
-  const cost =
-    (tokensIn / 1_000_000) * p.input + (tokensOut / 1_000_000) * p.output;
-  return Number(cost.toFixed(6));
+/**
+ * Best-effort extraction of HTTP status from an OpenAI SDK error.
+ * The SDK throws `APIError` subclasses with a `status` field; for any
+ * other error shape we try to parse the typical "402 ..." prefix.
+ */
+function errorStatus(err: unknown): number | null {
+  if (err && typeof err === "object" && "status" in err) {
+    const s = (err as { status: unknown }).status;
+    if (typeof s === "number") return s;
+  }
+  if (err instanceof Error) {
+    const m = err.message.match(/^\s*(\d{3})\b/);
+    if (m) return Number(m[1]);
+  }
+  return null;
 }

--- a/lib/forge/models.ts
+++ b/lib/forge/models.ts
@@ -1,0 +1,256 @@
+/**
+ * Model registry for the Forge brain (V).
+ *
+ * Source of truth for every LLM V can route to via OpenRouter. The
+ * routing policy in lib/forge/routing.ts consumes this catalog to
+ * decide which model to invoke for a given task, and the fallback
+ * chain in /api/forge/run uses the `fallback_chain` field to recover
+ * from provider failures.
+ *
+ * Pricing per 1M tokens (USD) — sourced from https://openrouter.ai/models.
+ * Update when adding/removing models or when OpenRouter publishes a
+ * price change. The estimateCost path in /api/forge/run reads from
+ * here so the audit log stays accurate.
+ */
+
+export type ModelTier = "cheap" | "balanced" | "premium";
+export type ModelKind = "paid" | "free";
+
+export interface ModelInfo {
+  /** OpenRouter slug as used in API requests. */
+  slug: string;
+  /** Short human label. */
+  label: string;
+  /** USD per 1M input tokens. 0 for :free models (subject to OR's 50/day cap). */
+  costInPer1M: number;
+  /** USD per 1M output tokens. */
+  costOutPer1M: number;
+  tier: ModelTier;
+  kind: ModelKind;
+  /** Whether the model supports OpenAI-format function/tool calling. */
+  supportsTools: boolean;
+  /** Max context window in tokens. */
+  contextWindow: number;
+  /** Hints about what this model is good at. Used by routing.ts. */
+  goodFor: ReadonlyArray<TaskKind>;
+  /**
+   * Ordered list of slugs to try if THIS model fails (402/429/5xx).
+   * Convention: cascade from same-tier → cheaper-tier → free.
+   */
+  fallbackChain: ReadonlyArray<string>;
+}
+
+export type TaskKind =
+  | "chat-main" // primary conversation with V
+  | "reasoning" // multi-step plans, code review, debugging
+  | "code-edit" // editing existing code
+  | "classification" // categorize a repo, score a file
+  | "summarization" // condense a chat / dump / doc
+  | "extraction" // pull structured data from text
+  | "web-search" // not used directly — anthropic-web-search handles
+  | "embedding"; // text-embedding-3-small etc.
+
+export const MODELS: Record<string, ModelInfo> = {
+  // ─── Anthropic via OpenRouter (paid premium) ─────────────────────
+  "anthropic/claude-opus-4.7": {
+    slug: "anthropic/claude-opus-4.7",
+    label: "Claude Opus 4.7",
+    costInPer1M: 15,
+    costOutPer1M: 75,
+    tier: "premium",
+    kind: "paid",
+    supportsTools: true,
+    contextWindow: 200_000,
+    goodFor: ["reasoning", "code-edit"],
+    fallbackChain: [
+      "anthropic/claude-sonnet-4.6",
+      "openai/gpt-5",
+      "anthropic/claude-haiku-4.5",
+    ],
+  },
+  "anthropic/claude-sonnet-4.6": {
+    slug: "anthropic/claude-sonnet-4.6",
+    label: "Claude Sonnet 4.6",
+    costInPer1M: 3,
+    costOutPer1M: 15,
+    tier: "balanced",
+    kind: "paid",
+    supportsTools: true,
+    contextWindow: 200_000,
+    goodFor: ["chat-main", "reasoning", "code-edit", "extraction"],
+    fallbackChain: [
+      "anthropic/claude-haiku-4.5",
+      "google/gemini-2.5-pro",
+      "openai/gpt-5",
+      "minimax/minimax-m2.5:free",
+    ],
+  },
+  "anthropic/claude-haiku-4.5": {
+    slug: "anthropic/claude-haiku-4.5",
+    label: "Claude Haiku 4.5",
+    costInPer1M: 0.8,
+    costOutPer1M: 4,
+    tier: "cheap",
+    kind: "paid",
+    supportsTools: true,
+    contextWindow: 200_000,
+    goodFor: ["classification", "summarization", "extraction"],
+    fallbackChain: [
+      "google/gemini-2.5-flash",
+      "minimax/minimax-m2.5:free",
+      "google/gemma-4-31b-it:free",
+    ],
+  },
+
+  // ─── Google via OpenRouter (paid) ────────────────────────────────
+  "google/gemini-2.5-pro": {
+    slug: "google/gemini-2.5-pro",
+    label: "Gemini 2.5 Pro",
+    costInPer1M: 1.25,
+    costOutPer1M: 5,
+    tier: "balanced",
+    kind: "paid",
+    supportsTools: true,
+    contextWindow: 1_048_576,
+    goodFor: ["reasoning", "extraction", "summarization"],
+    fallbackChain: [
+      "anthropic/claude-sonnet-4.6",
+      "google/gemini-2.5-flash",
+    ],
+  },
+  "google/gemini-2.5-flash": {
+    slug: "google/gemini-2.5-flash",
+    label: "Gemini 2.5 Flash",
+    costInPer1M: 0.075,
+    costOutPer1M: 0.3,
+    tier: "cheap",
+    kind: "paid",
+    supportsTools: true,
+    contextWindow: 1_048_576,
+    goodFor: ["classification", "summarization", "extraction"],
+    fallbackChain: [
+      "anthropic/claude-haiku-4.5",
+      "minimax/minimax-m2.5:free",
+      "google/gemma-4-31b-it:free",
+    ],
+  },
+
+  // ─── OpenAI via OpenRouter (paid) ────────────────────────────────
+  "openai/gpt-5": {
+    slug: "openai/gpt-5",
+    label: "GPT-5",
+    costInPer1M: 1.25,
+    costOutPer1M: 10,
+    tier: "balanced",
+    kind: "paid",
+    supportsTools: true,
+    contextWindow: 200_000,
+    goodFor: ["reasoning", "code-edit"],
+    fallbackChain: [
+      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-haiku-4.5",
+    ],
+  },
+
+  // ─── Free models (subject to 50/day cap; 1000/day if account has $10 loaded) ───
+  "minimax/minimax-m2.5:free": {
+    slug: "minimax/minimax-m2.5:free",
+    label: "MiniMax M2.5 (free)",
+    costInPer1M: 0,
+    costOutPer1M: 0,
+    tier: "cheap",
+    kind: "free",
+    supportsTools: true,
+    contextWindow: 196_608,
+    goodFor: ["chat-main", "classification", "summarization"],
+    fallbackChain: [
+      "google/gemma-4-31b-it:free",
+      "google/gemini-2.5-flash",
+    ],
+  },
+  "google/gemma-4-31b-it:free": {
+    slug: "google/gemma-4-31b-it:free",
+    label: "Gemma 4 31B (free)",
+    costInPer1M: 0,
+    costOutPer1M: 0,
+    tier: "cheap",
+    kind: "free",
+    supportsTools: true,
+    contextWindow: 262_144,
+    goodFor: ["classification", "summarization", "extraction"],
+    fallbackChain: ["minimax/minimax-m2.5:free", "google/gemini-2.5-flash"],
+  },
+};
+
+/**
+ * Models indexed by TaskKind, sorted by recommended preference for that
+ * task. routing.ts picks from here.
+ */
+export const TASK_PREFERENCES: Record<TaskKind, ReadonlyArray<string>> = {
+  "chat-main": [
+    "anthropic/claude-sonnet-4.6",
+    "google/gemini-2.5-pro",
+    "anthropic/claude-haiku-4.5",
+    "minimax/minimax-m2.5:free",
+  ],
+  reasoning: [
+    "anthropic/claude-opus-4.7",
+    "anthropic/claude-sonnet-4.6",
+    "openai/gpt-5",
+    "google/gemini-2.5-pro",
+  ],
+  "code-edit": [
+    "anthropic/claude-sonnet-4.6",
+    "anthropic/claude-opus-4.7",
+    "openai/gpt-5",
+  ],
+  classification: [
+    "google/gemini-2.5-flash",
+    "anthropic/claude-haiku-4.5",
+    "minimax/minimax-m2.5:free",
+    "google/gemma-4-31b-it:free",
+  ],
+  summarization: [
+    "google/gemini-2.5-flash",
+    "anthropic/claude-haiku-4.5",
+    "minimax/minimax-m2.5:free",
+  ],
+  extraction: [
+    "anthropic/claude-haiku-4.5",
+    "google/gemini-2.5-flash",
+    "anthropic/claude-sonnet-4.6",
+  ],
+  "web-search": [],
+  embedding: [],
+};
+
+/**
+ * Estimate cost for a given model + token counts. Falls back to Sonnet
+ * pricing if the model isn't in the registry (defensive — OpenRouter
+ * sometimes returns versioned slugs like 'anthropic/claude-4.6-sonnet-20260217').
+ */
+export function estimateCostForModel(
+  slug: string,
+  tokensIn: number,
+  tokensOut: number,
+): number {
+  const normalized = normalizeSlug(slug);
+  const m = MODELS[normalized] ?? MODELS["anthropic/claude-sonnet-4.6"];
+  return Number(
+    (
+      (tokensIn / 1_000_000) * m.costInPer1M +
+      (tokensOut / 1_000_000) * m.costOutPer1M
+    ).toFixed(6),
+  );
+}
+
+/**
+ * Strip OpenRouter's versioned date suffix so registry lookups hit
+ * even when the response shape is "anthropic/claude-4.6-sonnet-20260217".
+ */
+export function normalizeSlug(slug: string): string {
+  // Replace "claude-4.6-sonnet-20260217" → "claude-sonnet-4.6"
+  const m = slug.match(/^anthropic\/claude-(\d+\.\d+)-(opus|sonnet|haiku)/);
+  if (m) return `anthropic/claude-${m[2]}-${m[1]}`;
+  return slug.replace(/(-\d{8}|-\d{6})$/, "");
+}

--- a/lib/forge/routing.ts
+++ b/lib/forge/routing.ts
@@ -1,0 +1,138 @@
+/**
+ * Routing policy v1 — picks an OpenRouter model for a given task.
+ *
+ * Inputs the router considers:
+ *   - task kind (chat-main, classification, etc.)
+ *   - cost preference (cheapest | balanced | premium)
+ *   - free-tier override (e.g. when balance is low)
+ *   - excluded models (e.g. previously failed in this turn)
+ *
+ * Output: a primary slug + its fallback_chain from the registry. The
+ * caller in /api/forge/run iterates the chain when the primary errors.
+ *
+ * v2 (M11+) will use a classifier trained on past runs vs success. For
+ * now, heuristics + the curated TASK_PREFERENCES table are enough.
+ */
+import { MODELS, TASK_PREFERENCES, type TaskKind, type ModelKind } from "./models";
+
+export interface RoutingDecision {
+  primary: string;
+  /** All slugs to try in order: [primary, ...fallbacks]. */
+  cascade: string[];
+  reason: string;
+}
+
+export interface RoutingOptions {
+  /**
+   * 'cheapest'  → prefer cheap-tier, fall back to free
+   * 'balanced'  → prefer balanced-tier (Sonnet, Gemini Pro)
+   * 'premium'   → Opus first
+   * 'free-only' → only kind='free'
+   */
+  costPreference?: "cheapest" | "balanced" | "premium" | "free-only";
+  /** Slugs to skip (e.g. failed earlier in this round). */
+  excludeSlugs?: ReadonlyArray<string>;
+  /** Force a specific model (overrides everything else). */
+  forceSlug?: string;
+}
+
+const TIER_WEIGHT: Record<"cheap" | "balanced" | "premium", number> = {
+  cheap: 1,
+  balanced: 2,
+  premium: 3,
+};
+
+export function routeFor(
+  task: TaskKind,
+  options: RoutingOptions = {},
+): RoutingDecision {
+  if (options.forceSlug) {
+    const m = MODELS[options.forceSlug];
+    if (!m) {
+      throw new Error(`Unknown forceSlug '${options.forceSlug}'`);
+    }
+    return {
+      primary: m.slug,
+      cascade: [m.slug, ...m.fallbackChain.filter((s) => !options.excludeSlugs?.includes(s))],
+      reason: "forced by caller",
+    };
+  }
+
+  const preferences = TASK_PREFERENCES[task] ?? [];
+  const excluded = new Set(options.excludeSlugs ?? []);
+  const pref = options.costPreference ?? "balanced";
+
+  // Filter by costPreference and exclusion.
+  const candidates = preferences
+    .map((slug) => MODELS[slug])
+    .filter((m): m is NonNullable<typeof m> => !!m)
+    .filter((m) => !excluded.has(m.slug))
+    .filter((m) => kindMatchesPreference(m.kind, m.tier, pref));
+
+  if (candidates.length === 0) {
+    // Fall back to any model in TASK_PREFERENCES not excluded, regardless of preference.
+    const looser = preferences
+      .map((slug) => MODELS[slug])
+      .filter((m): m is NonNullable<typeof m> => !!m)
+      .filter((m) => !excluded.has(m.slug));
+    if (looser.length === 0) {
+      throw new Error(`No model available for task='${task}' after exclusions`);
+    }
+    const choice = looser[0];
+    return {
+      primary: choice.slug,
+      cascade: [choice.slug, ...choice.fallbackChain.filter((s) => !excluded.has(s))],
+      reason: `loose-match (costPreference=${pref} had no eligible models)`,
+    };
+  }
+
+  const choice = candidates[0];
+  return {
+    primary: choice.slug,
+    cascade: [choice.slug, ...choice.fallbackChain.filter((s) => !excluded.has(s))],
+    reason: `task=${task} pref=${pref} tier=${choice.tier} kind=${choice.kind}`,
+  };
+}
+
+function kindMatchesPreference(
+  kind: ModelKind,
+  tier: "cheap" | "balanced" | "premium",
+  pref: NonNullable<RoutingOptions["costPreference"]>,
+): boolean {
+  if (pref === "free-only") return kind === "free";
+  if (pref === "cheapest") return tier === "cheap";
+  if (pref === "premium") return tier === "premium" || tier === "balanced";
+  // 'balanced': any tier OK but bias toward balanced when sorting
+  return true;
+}
+
+/**
+ * Heuristic to detect a low-stakes side task vs the main chat turn.
+ * The caller can use this to pick costPreference automatically.
+ */
+export function inferTaskKind(promptHint: {
+  hasTools?: boolean;
+  bytesIn: number;
+  isFollowUp?: boolean;
+}): TaskKind {
+  // Long context with tools → main chat
+  if (promptHint.hasTools && promptHint.bytesIn > 4_000) return "chat-main";
+  // Very short prompt → likely classification or extraction
+  if (promptHint.bytesIn < 500) return "classification";
+  return "chat-main";
+}
+
+/**
+ * Compute the rough running-second cost cap suggestion: which tier the
+ * caller should pick given a remaining monthly budget.
+ *
+ * Trivial table for now; v2 can use historical avg-cost-per-turn.
+ */
+export function suggestTierForBudget(
+  budgetRemainingUsd: number,
+): NonNullable<RoutingOptions["costPreference"]> {
+  if (budgetRemainingUsd <= 0) return "free-only";
+  if (budgetRemainingUsd < 1) return "cheapest";
+  if (budgetRemainingUsd < 10) return "balanced";
+  return "balanced"; // 'premium' only when caller asks explicitly
+}

--- a/lib/forge/skills.ts
+++ b/lib/forge/skills.ts
@@ -1,0 +1,168 @@
+/**
+ * Skills registry — search + invoke (M16).
+ *
+ * A skill is a self-describing capability bundle that V can discover
+ * and "install" at runtime. Each skill provides:
+ *   - system_prompt: a fragment V reads to frame its next reasoning step.
+ *   - required_tools: list of tool names V should rely on while operating.
+ *   - tags + description: used by skill_search to surface matches.
+ *
+ * Search uses pg_trgm ILIKE (no embeddings) — coherent with the "only
+ * OpenRouter" directive since OpenRouter doesn't sell embeddings. Add
+ * pgvector + OpenAI text-embedding-3-small later if we outgrow it.
+ *
+ * Install is stateless: skill_install returns the full body to V; V
+ * uses that info during the same turn. No cross-turn persistence yet.
+ * Add an active_skills_per_session table if a use case appears.
+ */
+import { sql } from "@/lib/db/client";
+
+export interface SkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  required_tools: string[];
+  ring_max: number;
+  tags: string[];
+  score: number;
+}
+
+export interface SkillBody extends SkillSummary {
+  system_prompt: string;
+  examples: unknown | null;
+}
+
+/**
+ * Search skills by free-text query. Matches against name, description,
+ * and tags using ILIKE on trigram indexes. Returns top_k ranked by
+ * a simple priority: tag exact match > name substring > description
+ * substring.
+ */
+/** Stop-words to skip when tokenizing a free-text query. Keeps the
+ *  scoring noise-free for common Spanish + English filler.
+ */
+const STOP_WORDS = new Set([
+  "el", "la", "los", "las", "un", "una", "unos", "unas",
+  "de", "del", "al", "a", "en", "con", "por", "para", "sin",
+  "y", "o", "u", "que", "qué", "mi", "mis", "tu", "tus",
+  "es", "son", "ser", "estar", "está", "están", "hay",
+  "the", "a", "an", "to", "of", "in", "on", "at", "by",
+  "for", "with", "and", "or", "is", "are", "be", "from",
+]);
+
+function tokenize(q: string): string[] {
+  return q
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // strip accents so "rescatar" matches "rescate"
+    .split(/[^a-z0-9]+/i)
+    .filter((t) => t.length >= 3 && !STOP_WORDS.has(t));
+}
+
+export async function searchSkills(
+  query: string,
+  topK = 5,
+): Promise<SkillSummary[]> {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
+
+  // Per-token ILIKE matches contribute to a score. Tag exact match >
+  // name substring > description substring > tag substring.
+  // We compute the score in SQL using a generated_subquery over
+  // unnest(tokens) so the planner can use the GIN trigram indexes.
+  const tokensArr = tokens;
+  const rows = (await sql`
+    WITH tokens AS (
+      SELECT lower(unnest(${tokensArr}::text[])) AS tok
+    )
+    SELECT
+      s.id, s.name, s.description, s.required_tools, s.ring_max, s.tags,
+      (
+        SELECT COALESCE(SUM(
+          CASE WHEN EXISTS (SELECT 1 FROM unnest(s.tags) tag WHERE lower(tag) = t.tok) THEN 100 ELSE 0 END +
+          CASE WHEN lower(s.name) LIKE '%' || t.tok || '%' THEN 50 ELSE 0 END +
+          CASE WHEN lower(s.description) LIKE '%' || t.tok || '%' THEN 25 ELSE 0 END +
+          CASE WHEN EXISTS (SELECT 1 FROM unnest(s.tags) tag WHERE lower(tag) LIKE '%' || t.tok || '%') THEN 30 ELSE 0 END
+        ), 0) FROM tokens t
+      )::int AS score
+    FROM skills s
+    WHERE EXISTS (
+      SELECT 1 FROM tokens t
+      WHERE
+        lower(s.name) LIKE '%' || t.tok || '%'
+        OR lower(s.description) LIKE '%' || t.tok || '%'
+        OR EXISTS (SELECT 1 FROM unnest(s.tags) tag WHERE lower(tag) LIKE '%' || t.tok || '%')
+    )
+    ORDER BY score DESC, invocation_count DESC, id ASC
+    LIMIT ${topK}
+  `) as Array<SkillSummary>;
+
+  return rows;
+}
+
+/**
+ * Fetch the full body of one skill. Bumps invocation_count + records
+ * the invocation so we can later score "most useful skills".
+ */
+export async function getSkillBody(
+  id: string,
+  options: { sessionId?: string; userId?: string } = {},
+): Promise<SkillBody | null> {
+  const rows = (await sql`
+    SELECT
+      id, name, description, required_tools, ring_max, tags,
+      system_prompt, examples
+    FROM skills
+    WHERE id = ${id}
+  `) as Array<SkillBody>;
+  if (rows.length === 0) return null;
+  const skill = rows[0];
+
+  // Record invocation (fire-and-forget on auxiliary tables)
+  if (options.sessionId) {
+    try {
+      await sql`
+        INSERT INTO skill_invocations (skill_id, session_id, user_id, outcome)
+        VALUES (${id}, ${options.sessionId}, ${options.userId ?? null}, 'pending')
+      `;
+    } catch {
+      /* non-blocking */
+    }
+  }
+  try {
+    await sql`
+      UPDATE skills
+      SET invocation_count = invocation_count + 1,
+          last_invoked_at = now()
+      WHERE id = ${id}
+    `;
+  } catch {
+    /* non-blocking */
+  }
+
+  return {
+    id: skill.id,
+    name: skill.name,
+    description: skill.description,
+    required_tools: skill.required_tools,
+    ring_max: skill.ring_max,
+    tags: skill.tags,
+    system_prompt: skill.system_prompt,
+    examples: skill.examples ?? null,
+    score: 0,
+  };
+}
+
+/** List all builtin skills (useful for /modules UI). */
+export async function listSkills(
+  options: { source?: "builtin" | "user" | "marketplace" } = {},
+): Promise<SkillSummary[]> {
+  const src = options.source ?? null;
+  const rows = (await sql`
+    SELECT id, name, description, required_tools, ring_max, tags, 0::int AS score
+    FROM skills
+    WHERE (${src}::text IS NULL OR source = ${src})
+    ORDER BY id
+  `) as Array<SkillSummary>;
+  return rows;
+}

--- a/lib/forge/subagents.ts
+++ b/lib/forge/subagents.ts
@@ -1,0 +1,233 @@
+/**
+ * Subagents — in-process parallel sub-tasks (M18 light).
+ *
+ * V can spawn one or many subagents in a single tool round; the
+ * dispatcher already runs tool calls via Promise.all, so N spawn_subagent
+ * calls execute concurrently. No background jobs, no durability: if the
+ * SSE stream is closed before all subagents return, results are lost.
+ * For long durable workflows, upgrade to Trigger.dev (M9 of ADR-009).
+ *
+ * Roles are predefined system prompts paired with a default model. The
+ * caller can override the model. Subagents do NOT have tool access by
+ * default — V is responsible for fetching data with its own tools and
+ * passing it to the subagent as context in the task string.
+ *
+ * Output goes back to V's conversation as a tool_result; V synthesizes
+ * the final answer for Luis.
+ */
+import { openRouterAdapter } from "./adapters/openrouter";
+import { getOperatorSecret } from "@/lib/vault/get-secret";
+import { sql } from "@/lib/db/client";
+
+export type SubagentRole =
+  | "researcher"
+  | "reviewer"
+  | "coder"
+  | "tester"
+  | "categorizer"
+  | "summarizer"
+  | "extractor"
+  | "translator";
+
+interface RoleSpec {
+  systemPrompt: string;
+  defaultModel: string;
+  defaultMaxTokens: number;
+}
+
+const ROLES: Record<SubagentRole, RoleSpec> = {
+  researcher: {
+    systemPrompt:
+      "Eres un investigador. Sintetizas información dada en la tarea. Respondes en bullets concisos, citando los datos exactos. Si la información es insuficiente para concluir, lo dices explícito. NO inventes datos.",
+    defaultModel: "google/gemini-2.5-flash",
+    defaultMaxTokens: 800,
+  },
+  reviewer: {
+    systemPrompt:
+      "Eres un code reviewer senior. Evalúas el código provisto según: bugs > security > performance > style. Reportas findings ordenados por severidad con file:line si aplica. Cada finding: 1-2 oraciones + propuesta de fix mínimo. NO propongas refactors innecesarios.",
+    defaultModel: "anthropic/claude-sonnet-4.6",
+    defaultMaxTokens: 1200,
+  },
+  coder: {
+    systemPrompt:
+      "Eres un coder senior. Recibes una spec corta y devuelves el código solicitado en el lenguaje pedido. Sin explicación verbosa — solo el código en un bloque, con comentarios mínimos solo donde el QUÉ no sea obvio. Si la spec es ambigua, pides UNA aclaración antes de codear.",
+    defaultModel: "anthropic/claude-sonnet-4.6",
+    defaultMaxTokens: 1500,
+  },
+  tester: {
+    systemPrompt:
+      "Eres un tester. Recibes código + casos de prueba. Predices qué retorna cada caso. Si encuentras un bug o caso no manejado, lo señalas. Output: tabla con caso/expected/actual/status (pass|fail|unknown).",
+    defaultModel: "anthropic/claude-haiku-4.5",
+    defaultMaxTokens: 600,
+  },
+  categorizer: {
+    systemPrompt:
+      'Eres un clasificador. Recibes un texto (README, descripción, etc.) y devuelves UN JSON estricto: {"category": <enum del task>, "score": 1-10, "reason": "<una línea>"}. NADA fuera del JSON. Si dudas, score bajo + reason explica.',
+    defaultModel: "google/gemini-2.5-flash",
+    defaultMaxTokens: 200,
+  },
+  summarizer: {
+    systemPrompt:
+      "Eres un sumarizador. Recibes texto largo y devuelves resumen en 3-5 bullets, máximo 80 palabras totales. Sin preámbulo, solo los bullets.",
+    defaultModel: "anthropic/claude-haiku-4.5",
+    defaultMaxTokens: 300,
+  },
+  extractor: {
+    systemPrompt:
+      'Eres un extractor de datos estructurados. Recibes texto + schema descrito en el task. Devuelves SOLO el JSON que cumple el schema. Si un campo no se puede inferir, usa null. NADA fuera del JSON.',
+    defaultModel: "anthropic/claude-haiku-4.5",
+    defaultMaxTokens: 800,
+  },
+  translator: {
+    systemPrompt:
+      "Eres un traductor. Recibes texto + idioma destino. Devuelves SOLO la traducción, sin notas ni explicación.",
+    defaultModel: "google/gemini-2.5-flash",
+    defaultMaxTokens: 1000,
+  },
+};
+
+export interface SubagentResult {
+  role: SubagentRole;
+  model: string;
+  content: string;
+  tokens_in: number;
+  tokens_out: number;
+  cost_usd: number;
+  duration_ms: number;
+  finish_reason: string | null;
+}
+
+/**
+ * Run a single subagent. Pure function — no DB writes, no audit. The
+ * caller (the tool dispatcher) is responsible for any audit/persistence.
+ */
+export async function runSubagent(input: {
+  role: SubagentRole;
+  task: string;
+  model?: string;
+  maxTokens?: number;
+  userId?: string;
+  sessionId?: string;
+  signal?: AbortSignal;
+}): Promise<SubagentResult> {
+  const spec = ROLES[input.role];
+  if (!spec) {
+    throw new Error(`Unknown subagent role: ${input.role}`);
+  }
+  const model = input.model ?? spec.defaultModel;
+  const maxTokens = input.maxTokens ?? spec.defaultMaxTokens;
+  const startedAt = Date.now();
+
+  const vault = {
+    async getOperatorSecret(name: string) {
+      return getOperatorSecret(name, {
+        auditUserId: input.userId ?? "subagent",
+      });
+    },
+    async getProjectSecret(projectId: string, name: string) {
+      return getOperatorSecret(name, {
+        auditUserId: input.userId ?? "subagent",
+        projectId,
+      });
+    },
+  };
+
+  const out = await openRouterAdapter.execute(
+    {
+      model,
+      messages: [
+        { role: "system", content: spec.systemPrompt },
+        { role: "user", content: input.task },
+      ],
+      maxTokens,
+    },
+    {
+      userId: input.userId ?? "operator_luis",
+      sessionId: input.sessionId ?? "subagent",
+      signal: input.signal ?? AbortSignal.timeout(60_000),
+      vault,
+    },
+  );
+
+  return {
+    role: input.role,
+    model: out.model,
+    content: out.content,
+    tokens_in: out.tokensIn,
+    tokens_out: out.tokensOut,
+    cost_usd: out.costUsd,
+    duration_ms: Date.now() - startedAt,
+    finish_reason: out.finishReason,
+  };
+}
+
+/**
+ * Persist a subagent run to conversations + audit_events so it counts
+ * toward the cost dashboard. Called by the tool dispatcher AFTER
+ * runSubagent succeeds.
+ */
+export async function recordSubagentRun(
+  result: SubagentResult,
+  ctx: { userId: string; sessionId: string; task: string },
+): Promise<void> {
+  try {
+    await sql`
+      INSERT INTO conversations (
+        user_id, session_id, role, content, model,
+        tokens_in, tokens_out, cost_usd
+      )
+      VALUES (
+        ${ctx.userId},
+        ${ctx.sessionId + ":subagent:" + result.role},
+        'assistant',
+        ${`[subagent:${result.role}] ${result.content.slice(0, 4000)}`},
+        ${result.model},
+        ${result.tokens_in},
+        ${result.tokens_out},
+        ${result.cost_usd}
+      )
+    `;
+  } catch {
+    /* non-blocking */
+  }
+  try {
+    await sql`
+      INSERT INTO audit_events (
+        user_id, action, resource_type, resource_id, ring, payload
+      )
+      VALUES (
+        ${ctx.userId},
+        'forge.subagent.run',
+        'subagent',
+        ${result.role},
+        0,
+        ${JSON.stringify({
+          role: result.role,
+          model: result.model,
+          tokens_in: result.tokens_in,
+          tokens_out: result.tokens_out,
+          cost_usd: result.cost_usd,
+          duration_ms: result.duration_ms,
+          parent_session: ctx.sessionId,
+          task_preview: ctx.task.slice(0, 200),
+        })}::jsonb
+      )
+    `;
+  } catch {
+    /* non-blocking */
+  }
+}
+
+export function listSubagentRoles(): Array<{
+  role: SubagentRole;
+  default_model: string;
+  default_max_tokens: number;
+  description: string;
+}> {
+  return (Object.keys(ROLES) as SubagentRole[]).map((r) => ({
+    role: r,
+    default_model: ROLES[r].defaultModel,
+    default_max_tokens: ROLES[r].defaultMaxTokens,
+    description: ROLES[r].systemPrompt.slice(0, 120) + "…",
+  }));
+}

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -46,6 +46,8 @@ import {
 } from "@/lib/namecom/client";
 import { encryptOperatorSecret } from "@/lib/vault/operator-crypto";
 import { invalidateSecretCache } from "@/lib/vault/get-secret";
+import { routeFor } from "@/lib/forge/routing";
+import { MODELS } from "@/lib/forge/models";
 
 export const TOOLS: Tool[] = [
   {
@@ -527,6 +529,48 @@ export const TOOLS: Tool[] = [
     description:
       "Cruza la lista de proyectos de Vercel con los repos de GitHub y los sincroniza a la tabla `projects` de vForge. Usa esta tool cuando Luis pregunte 'qué proyectos tengo' y la tabla esté vacía/desactualizada, o cuando agregue un proyecto nuevo. Idempotente: actualiza existentes, inserta los nuevos, no borra nada.",
     input_schema: { type: "object", properties: {} },
+  },
+
+  // ─── Model routing + cost observability (M3.5) ────────────────────
+  {
+    name: "model_recommend",
+    description:
+      "Pregunta al router qué modelo usar para una tarea. Devuelve { primary, cascade, reason }. Úsala antes de invocar openrouter_query para tareas side cuando quieras elegir modelo barato/balanceado consciente. Task kinds: 'chat-main', 'reasoning', 'code-edit', 'classification', 'summarization', 'extraction'. costPreference: 'cheapest' | 'balanced' | 'premium' | 'free-only' (default 'balanced').",
+    input_schema: {
+      type: "object",
+      properties: {
+        task: {
+          type: "string",
+          enum: [
+            "chat-main",
+            "reasoning",
+            "code-edit",
+            "classification",
+            "summarization",
+            "extraction",
+          ],
+        },
+        cost_preference: {
+          type: "string",
+          enum: ["cheapest", "balanced", "premium", "free-only"],
+        },
+      },
+      required: ["task"],
+    },
+  },
+  {
+    name: "forge_cost_report",
+    description:
+      "Reporte de costos de V agregado en una ventana de tiempo. Útil cuando Luis pregunta cuánto vas gastando, qué modelo es más caro, o cuántas veces fallaste y hubo fallback. period: 'today' | '24h' | 'this_month' | 'last_7d' | 'last_30d' (default 'today').",
+    input_schema: {
+      type: "object",
+      properties: {
+        period: {
+          type: "string",
+          enum: ["today", "24h", "this_month", "last_7d", "last_30d"],
+        },
+      },
+    },
   },
 
   // ─── OpenRouter (ADR-009, M3) ─────────────────────────────────────
@@ -1322,6 +1366,123 @@ async function dispatch(
           total: byKey.size,
         }),
         summary: `proyectos sync: +${inserted} nuevos, ${updated} actualizados`,
+      };
+    }
+
+    case "model_recommend": {
+      const task = requireString(input.task, "task") as
+        | "chat-main"
+        | "reasoning"
+        | "code-edit"
+        | "classification"
+        | "summarization"
+        | "extraction";
+      const pref =
+        typeof input.cost_preference === "string"
+          ? (input.cost_preference as
+              | "cheapest"
+              | "balanced"
+              | "premium"
+              | "free-only")
+          : "balanced";
+      const decision = routeFor(task, { costPreference: pref });
+      const primary = MODELS[decision.primary];
+      return {
+        ok: true,
+        content: JSON.stringify({
+          primary: decision.primary,
+          cascade: decision.cascade,
+          reason: decision.reason,
+          primary_info: primary
+            ? {
+                label: primary.label,
+                tier: primary.tier,
+                kind: primary.kind,
+                cost_in_per_M_usd: primary.costInPer1M,
+                cost_out_per_M_usd: primary.costOutPer1M,
+                context_window: primary.contextWindow,
+                supports_tools: primary.supportsTools,
+              }
+            : null,
+        }),
+        summary: `route ${task}/${pref} → ${decision.primary}`,
+      };
+    }
+
+    case "forge_cost_report": {
+      const period =
+        typeof input.period === "string" ? input.period : "today";
+      const now = new Date();
+      let since: Date;
+      switch (period) {
+        case "24h":
+          since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+          break;
+        case "this_month":
+          since = new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
+          break;
+        case "last_7d":
+          since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+          break;
+        case "last_30d":
+          since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+          break;
+        case "today":
+        default:
+          since = new Date(
+            Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+          );
+      }
+      const sinceIso = since.toISOString();
+      const totals = (await sql`
+        SELECT
+          COALESCE(SUM(cost_usd), 0)::numeric(12,6) AS total_usd,
+          COUNT(*)::int AS turns,
+          COALESCE(SUM(tokens_in), 0)::int AS tokens_in,
+          COALESCE(SUM(tokens_out), 0)::int AS tokens_out
+        FROM conversations
+        WHERE role = 'assistant' AND created_at >= ${sinceIso}
+      `) as Array<{
+        total_usd: string;
+        turns: number;
+        tokens_in: number;
+        tokens_out: number;
+      }>;
+      const byModel = (await sql`
+        SELECT
+          COALESCE(model, '(unknown)') AS model,
+          COUNT(*)::int AS turns,
+          COALESCE(SUM(cost_usd), 0)::numeric(12,6) AS cost_usd
+        FROM conversations
+        WHERE role = 'assistant' AND created_at >= ${sinceIso}
+        GROUP BY model
+        ORDER BY cost_usd DESC
+        LIMIT 8
+      `) as Array<{ model: string; turns: number; cost_usd: string }>;
+      const fallbackRows = (await sql`
+        SELECT COUNT(*)::int AS n
+        FROM audit_events
+        WHERE action = 'forge.chat.turn'
+          AND created_at >= ${sinceIso}
+          AND jsonb_array_length(COALESCE(payload->'fallbacks', '[]'::jsonb)) > 0
+      `) as Array<{ n: number }>;
+      return {
+        ok: true,
+        content: JSON.stringify({
+          period,
+          since: sinceIso,
+          total_usd: Number(totals[0].total_usd),
+          total_turns: totals[0].turns,
+          total_tokens_in: totals[0].tokens_in,
+          total_tokens_out: totals[0].tokens_out,
+          by_model: byModel.map((m) => ({
+            model: m.model,
+            turns: m.turns,
+            cost_usd: Number(m.cost_usd),
+          })),
+          fallback_events: fallbackRows[0].n,
+        }),
+        summary: `${period}: $${Number(totals[0].total_usd).toFixed(4)} / ${totals[0].turns} turns / ${fallbackRows[0].n} fallbacks`,
       };
     }
 

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -48,6 +48,7 @@ import { encryptOperatorSecret } from "@/lib/vault/operator-crypto";
 import { invalidateSecretCache } from "@/lib/vault/get-secret";
 import { routeFor } from "@/lib/forge/routing";
 import { MODELS } from "@/lib/forge/models";
+import { searchSkills, getSkillBody } from "@/lib/forge/skills";
 
 export const TOOLS: Tool[] = [
   {
@@ -570,6 +571,42 @@ export const TOOLS: Tool[] = [
           enum: ["today", "24h", "this_month", "last_7d", "last_30d"],
         },
       },
+    },
+  },
+
+  // ─── Skills registry (M16) ────────────────────────────────────────
+  {
+    name: "skill_search",
+    description:
+      "Busca habilidades (skills) que V puede aplicar para un tipo de tarea. Cada skill agrupa un fragment de instrucciones + un set de tools recomendadas. Devuelve top_k matches ranked. Úsala ANTES de empezar a operar cuando Luis describa una tarea recurrente (ej. 'arrancar proyecto', 'rescatar repo', 'apuntar dominio', 'clasificar mis repos'). Después, llama skill_install(skill_id) del top match para cargar las instrucciones completas.",
+    input_schema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Texto libre. Ej. 'rescatar repo roto', 'apuntar dominio a vercel', 'clasificar todos mis repos en masa'.",
+        },
+        top_k: {
+          type: "number",
+          description: "Cuántas habilidades devolver (1-10, default 5)",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "skill_install",
+    description:
+      "Carga la habilidad completa: system_prompt fragment + lista de tools requeridas + reglas. Llama esto DESPUÉS de skill_search cuando hayas elegido el skill apropiado. La respuesta contiene instrucciones que debes seguir EXACTAMENTE para el resto del turno. Si el ring_max del skill es > 1, confirma con Luis antes de ejecutar acciones destructivas.",
+    input_schema: {
+      type: "object",
+      properties: {
+        skill_id: {
+          type: "string",
+          description: "id devuelto por skill_search (ej. 'repo-rescue', 'github-pr-author').",
+        },
+      },
+      required: ["skill_id"],
     },
   },
 
@@ -1483,6 +1520,60 @@ async function dispatch(
           fallback_events: fallbackRows[0].n,
         }),
         summary: `${period}: $${Number(totals[0].total_usd).toFixed(4)} / ${totals[0].turns} turns / ${fallbackRows[0].n} fallbacks`,
+      };
+    }
+
+    case "skill_search": {
+      const query = requireString(input.query, "query");
+      const topK = clampNumber(input.top_k, 1, 10, 5);
+      const results = await searchSkills(query, topK);
+      return {
+        ok: true,
+        content: JSON.stringify({
+          query,
+          total: results.length,
+          skills: results.map((s) => ({
+            id: s.id,
+            name: s.name,
+            description: s.description,
+            ring_max: s.ring_max,
+            tags: s.tags,
+            required_tools_preview: s.required_tools.slice(0, 5),
+            score: s.score,
+          })),
+        }),
+        summary: results.length
+          ? `${results.length} skills: ${results.map((s) => s.id).join(", ")}`
+          : `no match for "${query}"`,
+      };
+    }
+    case "skill_install": {
+      const skillId = requireString(input.skill_id, "skill_id");
+      const body = await getSkillBody(skillId, {
+        sessionId: ctx.sessionId,
+        userId: ctx.userId,
+      });
+      if (!body) {
+        return {
+          ok: false,
+          content: JSON.stringify({ error: `skill '${skillId}' not found` }),
+          summary: `skill ${skillId} not found`,
+        };
+      }
+      return {
+        ok: true,
+        content: JSON.stringify({
+          installed: true,
+          id: body.id,
+          name: body.name,
+          ring_max: body.ring_max,
+          system_prompt: body.system_prompt,
+          required_tools: body.required_tools,
+          examples: body.examples,
+          instructions:
+            "Las instrucciones de este skill ahora aplican al resto de tu turno. Síguelas exactamente, usando las tools listadas en required_tools. Si ring_max es 2+, pide confirmación a Luis antes de ejecutar acciones destructivas.",
+        }),
+        summary: `installed: ${body.id} (${body.name})`,
       };
     }
 

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -49,6 +49,12 @@ import { invalidateSecretCache } from "@/lib/vault/get-secret";
 import { routeFor } from "@/lib/forge/routing";
 import { MODELS } from "@/lib/forge/models";
 import { searchSkills, getSkillBody } from "@/lib/forge/skills";
+import {
+  runSubagent,
+  recordSubagentRun,
+  listSubagentRoles,
+  type SubagentRole,
+} from "@/lib/forge/subagents";
 
 export const TOOLS: Tool[] = [
   {
@@ -101,7 +107,7 @@ export const TOOLS: Tool[] = [
   {
     name: "github_read_file",
     description:
-      "Lee el contenido de un archivo de un repo (README, package.json, configs, etc.). El contenido se trunca a 5KB para no inflar el contexto.",
+      "Lee el contenido de un archivo de un repo (README, package.json, configs, código). Default devuelve hasta 50KB. Si el archivo es más grande, usa offset + max_bytes para paginar. Pide max_bytes hasta 500KB cuando necesites leer todo un archivo grande de una sola vez (ej. tools.ts que pesa 58KB).",
     input_schema: {
       type: "object",
       properties: {
@@ -114,6 +120,14 @@ export const TOOLS: Tool[] = [
         branch: {
           type: "string",
           description: "Branch a leer (default: el default branch del repo)",
+        },
+        max_bytes: {
+          type: "number",
+          description: "Tope de bytes a devolver (1-500000, default 50000). Sube esto si necesitas leer todo un archivo grande.",
+        },
+        offset: {
+          type: "number",
+          description: "Byte offset desde el que empezar a leer (default 0). Úsalo con max_bytes para paginar archivos enormes.",
         },
       },
       required: ["owner", "repo", "path"],
@@ -574,6 +588,51 @@ export const TOOLS: Tool[] = [
     },
   },
 
+  // ─── Subagents in-process (M18 light) ─────────────────────────────
+  {
+    name: "spawn_subagent",
+    description:
+      "Despacha una tarea a un subagente especializado con su propio system prompt + modelo. Útil cuando V quiere descargar trabajo paralelo: clasificar 50 repos con Gemini Flash, revisar 5 archivos con Sonnet, sumarizar 10 docs largos. Llama spawn_subagent N veces en la misma tool round y el dispatcher los ejecuta en paralelo (Promise.all). Cada subagente NO tiene tools propios — V le pasa el contexto necesario en task. Roles disponibles: 'researcher', 'reviewer', 'coder', 'tester', 'categorizer', 'summarizer', 'extractor', 'translator'.",
+    input_schema: {
+      type: "object",
+      properties: {
+        role: {
+          type: "string",
+          enum: [
+            "researcher",
+            "reviewer",
+            "coder",
+            "tester",
+            "categorizer",
+            "summarizer",
+            "extractor",
+            "translator",
+          ],
+          description: "Rol del subagente. Cada uno trae su system prompt y modelo default.",
+        },
+        task: {
+          type: "string",
+          description: "Tarea concreta + todo el contexto que el subagente necesita (texto, código, README, etc.). Incluye el output esperado.",
+        },
+        model: {
+          type: "string",
+          description: "Override del modelo OpenRouter (ej. 'google/gemini-2.5-flash'). Opcional — cada rol trae un default.",
+        },
+        max_tokens: {
+          type: "number",
+          description: "Tope de tokens del output (32-4000). Opcional — cada rol trae un default.",
+        },
+      },
+      required: ["role", "task"],
+    },
+  },
+  {
+    name: "list_subagent_roles",
+    description:
+      "Lista los roles de subagente disponibles con su modelo default y descripción. Úsala cuando no recuerdes los roles exactos antes de spawn_subagent.",
+    input_schema: { type: "object", properties: {} },
+  },
+
   // ─── Skills registry (M16) ────────────────────────────────────────
   {
     name: "skill_search",
@@ -759,23 +818,31 @@ async function dispatch(
         typeof input.branch === "string" && input.branch.length > 0
           ? input.branch
           : undefined;
+      const maxBytes = clampNumber(input.max_bytes, 1, 500_000, 50_000);
+      const offset = clampNumber(input.offset, 0, 50_000_000, 0);
       const file = await getFileContent(owner, repo, path, {
         branch,
         auditUserId: ctx.userId,
       });
-      const MAX_BYTES = 5000;
-      const truncated = file.content.length > MAX_BYTES;
-      const slice = truncated ? file.content.slice(0, MAX_BYTES) : file.content;
+      const total = file.content.length;
+      const end = Math.min(offset + maxBytes, total);
+      const slice = file.content.slice(offset, end);
+      const truncated = end < total;
+      const nextOffset = truncated ? end : null;
       return {
         ok: true,
         content: JSON.stringify({
           path,
           size: file.size,
           sha: file.sha,
+          total_bytes: total,
+          offset,
+          returned_bytes: slice.length,
           truncated,
+          next_offset: nextOffset,
           content: slice,
         }),
-        summary: `${path} (${file.size} B${truncated ? ", truncado a 5KB" : ""})`,
+        summary: `${path} (${file.size} B${truncated ? `, range ${offset}-${end} of ${total}, more available — next_offset=${nextOffset}` : ", full"})`,
       };
     }
 
@@ -1520,6 +1587,55 @@ async function dispatch(
           fallback_events: fallbackRows[0].n,
         }),
         summary: `${period}: $${Number(totals[0].total_usd).toFixed(4)} / ${totals[0].turns} turns / ${fallbackRows[0].n} fallbacks`,
+      };
+    }
+
+    case "spawn_subagent": {
+      const role = requireString(input.role, "role") as SubagentRole;
+      const task = requireString(input.task, "task");
+      const model =
+        typeof input.model === "string" && input.model.length > 0
+          ? input.model
+          : undefined;
+      const maxTokens =
+        typeof input.max_tokens === "number"
+          ? Math.max(32, Math.min(4000, input.max_tokens))
+          : undefined;
+      const result = await runSubagent({
+        role,
+        task,
+        model,
+        maxTokens,
+        userId: ctx.userId,
+        sessionId: ctx.sessionId,
+      });
+      // Fire-and-forget persistence for the cost dashboard.
+      recordSubagentRun(result, {
+        userId: ctx.userId,
+        sessionId: ctx.sessionId,
+        task,
+      }).catch(() => {});
+      return {
+        ok: true,
+        content: JSON.stringify({
+          role: result.role,
+          model: result.model,
+          content: result.content,
+          tokens_in: result.tokens_in,
+          tokens_out: result.tokens_out,
+          cost_usd: result.cost_usd,
+          duration_ms: result.duration_ms,
+          finish_reason: result.finish_reason,
+        }),
+        summary: `${result.role} via ${result.model}: ${result.tokens_in}+${result.tokens_out} tok ($${result.cost_usd.toFixed(6)}, ${result.duration_ms}ms)`,
+      };
+    }
+    case "list_subagent_roles": {
+      const roles = listSubagentRoles();
+      return {
+        ok: true,
+        content: JSON.stringify({ roles }),
+        summary: `${roles.length} subagent roles available`,
       };
     }
 

--- a/migrations/005_skills.sql
+++ b/migrations/005_skills.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- vForge M16 — Skills registry (ADR-009 extension)
+-- ============================================================================
+-- Skills are reusable, self-describing packages that V can discover and
+-- invoke. Each skill bundles: a system prompt fragment, a list of tools
+-- it needs, examples, and a ring level.
+--
+-- Search is full-text (Postgres ts_vector) — no external embedding
+-- provider needed for v1. If we later want semantic search, add a
+-- pgvector column and backfill from OpenAI text-embedding-3-small;
+-- the table shape stays compatible.
+--
+-- Two tools consume this table (see lib/forge/tools.ts):
+--   skill_search(query, top_k)   → ranked summaries
+--   skill_install(skill_id)      → returns full body so V can use it
+--                                  in the rest of the turn
+--
+-- Skills can be 'builtin' (seeded), 'user' (added by Luis), or
+-- 'marketplace' (Fase 2, imported from external sources). Source is
+-- used to gate edit/delete permissions later.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS skills (
+  id                text PRIMARY KEY,                -- 'repo-rescue', 'github-pr-author'
+  name              text NOT NULL,
+  description       text NOT NULL,                   -- 1-2 line semantic blurb
+  system_prompt     text NOT NULL,                   -- fragment V reads on install
+  required_tools    text[] NOT NULL DEFAULT '{}',    -- tool names V should use
+  examples          jsonb,                           -- few-shot examples or example flows
+  ring_max          int NOT NULL DEFAULT 1
+                    CHECK (ring_max BETWEEN 0 AND 3),
+  source            text NOT NULL DEFAULT 'builtin'
+                    CHECK (source IN ('builtin', 'user', 'marketplace')),
+  tags              text[] NOT NULL DEFAULT '{}',
+  invocation_count  int NOT NULL DEFAULT 0,
+  last_invoked_at   timestamptz,
+  created_by        text REFERENCES users(id) ON DELETE SET NULL,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now()
+);
+
+-- Search uses ILIKE + tag containment. Postgres pg_trgm extension
+-- gives us a GIN index over trigrams so ILIKE '%foo%' is fast even on
+-- a large catalog. Suficiente para Fase 1 (≤100 skills). Si el catálogo
+-- crece, migramos a tsvector con trigger en M16.5.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_skills_name_trgm
+  ON skills USING GIN (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_skills_description_trgm
+  ON skills USING GIN (description gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_skills_tags
+  ON skills USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_skills_source
+  ON skills (source);
+
+-- Tracking which skills got invoked, by which session, with what outcome.
+-- Used to surface "most useful skills" + populate the rating in v2.
+CREATE TABLE IF NOT EXISTS skill_invocations (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id      text NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+  session_id    text NOT NULL,
+  user_id       text REFERENCES users(id) ON DELETE SET NULL,
+  outcome       text NOT NULL DEFAULT 'pending'
+                CHECK (outcome IN ('pending', 'success', 'failed', 'aborted')),
+  invoked_at    timestamptz NOT NULL DEFAULT now(),
+  completed_at  timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_skill_invocations_skill
+  ON skill_invocations (skill_id, invoked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_skill_invocations_session
+  ON skill_invocations (session_id, invoked_at DESC);
+
+INSERT INTO schema_migrations (version) VALUES ('005_skills')
+  ON CONFLICT (version) DO NOTHING;

--- a/migrations/006_skills_builtin.sql
+++ b/migrations/006_skills_builtin.sql
@@ -1,0 +1,137 @@
+-- ============================================================================
+-- vForge M16 — Skills built-in (7 skills sembrados)
+-- ============================================================================
+-- Catálogo inicial de habilidades de V. Diseñadas pensando en los flujos
+-- que ya se documentaron en knowledge_base (protocolos NUEVO/RESCATE) y
+-- en architecture.md.
+--
+-- Cada uno define:
+--   - system_prompt: fragmento que V lee tras skill_install para
+--     enmarcar su próximo razonamiento dentro del turno actual.
+--   - required_tools: tools que V probablemente invoque mientras opera
+--     bajo este skill (informativo + permite que el frontend muestre
+--     "Forge usando: github_create_branch, github_create_file").
+--   - tags: para búsqueda.
+-- ============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- repo-rescue — Diagnosticar y rescatar un repo roto
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO skills (id, name, description, system_prompt, required_tools, ring_max, source, tags, created_by) VALUES
+('repo-rescue',
+ 'Repo Rescue — Diagnóstico y plan de rescate de un repo roto',
+ 'Audita un repo existente que no compila / no deploya / está abandonado. Lee README, package.json, configs de build, últimos commits, status de Vercel, errores recientes. Propone fix incremental (parche) vs rewrite con trade-offs cuantificados.',
+ E'PROTOCOLO RESCATE — ACTIVO.\n\nFlujo obligatorio cuando V opera bajo este skill:\n1. github_get_repo + github_read_file (README.md, package.json, vite.config.* / next.config.*, tsconfig).\n2. github_list_commits (últimos 20) para entender qué se ha tocado.\n3. Si tiene Vercel: vercel_get_project + vercel_list_deployments + vercel_get_deployment del último READY o ERROR.\n4. Reporta diagnóstico en formato: "El bug está en path:line (descripción). Root cause: X. Fix mínimo: Y. Rewrite costaría: Z."\n5. NUNCA propongas rewrite sin haber leído el código primero.\n6. Si el operador aprueba el parche: github_create_branch + github_create_file/update_file + github_create_pull_request (draft).\n\nReglas:\n- Cita archivos como path:line.\n- Parche mínimo > rewrite (regla del playbook).\n- Si Luis dice "modo rescate" o "este repo está roto", entras aquí.',
+ ARRAY['github_get_repo','github_read_file','github_list_commits','vercel_get_project','vercel_list_deployments','vercel_get_deployment','github_create_branch','github_create_file','github_update_file','github_create_pull_request'],
+ 1, 'builtin', ARRAY['rescate','rescue','diagnostico','repo','audit'], 'operator_luis')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  required_tools = EXCLUDED.required_tools,
+  tags = EXCLUDED.tags,
+  updated_at = now();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- new-project-bootstrap — Arrancar proyecto nuevo
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO skills (id, name, description, system_prompt, required_tools, ring_max, source, tags, created_by) VALUES
+('new-project-bootstrap',
+ 'New Project Bootstrap — Crear proyecto desde cero (protocolo NUEVO)',
+ 'Cuando Luis dice "arrancar proyecto X" o "modo nuevo". Pregunta lo mínimo (audiencia, 3-5 features, vibe), genera prompt maestro para v0.dev, sugiere repo name kebab-case, audita el repo cuando v0 lo exporte, despliega a Vercel, configura dominio si aplica, guarda decisiones en memory.',
+ E'PROTOCOLO NUEVO — ACTIVO.\n\nFlujo:\n1. Pregunta lo mínimo: qué hace, audiencia (2-3 oraciones max), 3-5 features core, vibe/marca de referencia.\n2. Genera master prompt para v0.dev en formato vForge: identidad + tokens (no hex) + screens + tono.\n3. Sugiere repo name: turbillon50/<kebab-case>.\n4. Cuando v0 exporte → github_get_repo + github_read_file para auditar.\n5. vercel_create_project con framework auto-detect, gitRepository linkeado.\n6. Si Luis pide dominio: vercel_add_domain + vercel_get_domain_config + namecom_upsert_record.\n7. memory_save de las decisiones clave (audiencia, broker, tech stack que aplica).\n\nStack default: Next.js 16 + React 19 + Tailwind 4 + shadcn + Neon DB.\nNUNCA arranques con Railway worker hasta saber qué WebSocket/broker se necesita.\nNUNCA pongas Mongo / pnpm / Chakra / MUI sin ADR explícito.',
+ ARRAY['github_get_repo','github_read_file','github_create_branch','github_create_file','vercel_create_project','vercel_set_env_var','vercel_add_domain','namecom_upsert_record','memory_save'],
+ 1, 'builtin', ARRAY['nuevo','new','bootstrap','arrancar','proyecto'], 'operator_luis')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  required_tools = EXCLUDED.required_tools,
+  tags = EXCLUDED.tags,
+  updated_at = now();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- dns-vercel-namecom — Apuntar dominio Name.com → Vercel
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO skills (id, name, description, system_prompt, required_tools, ring_max, source, tags, created_by) VALUES
+('dns-vercel-namecom',
+ 'DNS Vercel + Name.com — Conectar un dominio a un proyecto Vercel',
+ 'Apunta un dominio (apex y/o www) a un proyecto de Vercel. Hace el ciclo completo: vercel_add_domain → vercel_get_domain_config → namecom_upsert_record con los valores exactos que Vercel pide, sin que el operador tenga que tocar dashboards.',
+ E'SKILL: DNS Vercel + Name.com — ACTIVO.\n\nFlujo obligatorio:\n1. vercel_add_domain con el dominio (apex Y www, ambos). Si www debe redirigir, pásalo con redirect=apexDomain.\n2. vercel_get_domain_config para LEER qué registros DNS espera Vercel (no inventes IPs).\n3. namecom_list_records primero para ver qué existe (no dupliques).\n4. namecom_upsert_record para cada registro necesario (típicamente A apex → 216.150.1.1, CNAME www → cname.vercel-dns.com).\n5. Reporta al operador con los registros creados, TTL, y tiempo esperado de propagación (suele ser <5 min en Name.com).\n\nGotchas:\n- NUNCA inventes la IP de Vercel; lee de vercel_get_domain_config.\n- Si el dominio tiene CNAME en apex y conflicta con A, name.com no permite ambos.\n- Si Vercel ya tenía el dominio antes, vercel_add_domain devuelve verified=true sin error.',
+ ARRAY['vercel_add_domain','vercel_get_domain_config','namecom_list_records','namecom_upsert_record','namecom_get_domain'],
+ 1, 'builtin', ARRAY['dns','vercel','name.com','dominio','domain'], 'operator_luis')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  required_tools = EXCLUDED.required_tools,
+  tags = EXCLUDED.tags,
+  updated_at = now();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- github-pr-author — Cambio en repo via PR (draft)
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO skills (id, name, description, system_prompt, required_tools, ring_max, source, tags, created_by) VALUES
+('github-pr-author',
+ 'GitHub PR Author — Hacer un cambio en un repo de Luis vía Pull Request',
+ 'Crea una feature branch, mete uno o varios cambios (create/update/delete archivos), y abre PR draft con Conventional Commits. Garantiza que NO escribe a main directo. El PR queda en draft para que Luis lo revise antes de merge.',
+ E'SKILL: GitHub PR Author — ACTIVO.\n\nFlujo obligatorio:\n1. github_create_branch desde main (o from_branch que Luis especifique). Nombre: "claude/<feature>-<id>" o "forge/<feature>-<id>" según AGENTS.md §3.\n2. github_create_file (o github_update_file si existe) con el contenido. Repite por cada archivo. SIEMPRE pasando branch=<la branch que creaste>.\n3. github_create_pull_request con title <70 chars, body en markdown, head=<tu branch>, base="main", draft=true.\n4. Reporta al operador: PR #N, link, y resumen de los cambios.\n\nCommit messages: Conventional Commits (feat:, fix:, docs:, refactor:, chore:, test:).\nTítulo del PR: refleja el feature/fix principal. Body: ## Summary, ## Cambios, ## Test plan.\nNUNCA pases allow_main=true salvo que Luis lo pida explícito.',
+ ARRAY['github_create_branch','github_create_file','github_update_file','github_delete_file','github_create_pull_request','github_read_file','github_get_repo'],
+ 1, 'builtin', ARRAY['github','pr','pull-request','commit','escribir'], 'operator_luis')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  required_tools = EXCLUDED.required_tools,
+  tags = EXCLUDED.tags,
+  updated_at = now();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- vercel-deploy-debug — Diagnosticar un deploy de Vercel fallido
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO skills (id, name, description, system_prompt, required_tools, ring_max, source, tags, created_by) VALUES
+('vercel-deploy-debug',
+ 'Vercel Deploy Debug — Diagnosticar build/deploy fallido',
+ 'Cuando un proyecto en Vercel falla deploy. Lee el último deployment, busca el error real (no el síntoma), correlaciona con commits recientes, y propone fix concreto (env var faltante, build command malo, outDir, etc.).',
+ E'SKILL: Vercel Deploy Debug — ACTIVO.\n\nFlujo:\n1. vercel_list_deployments del proyecto, filtra los ERROR/CANCELED.\n2. vercel_get_deployment del último que falló — lee errorMessage + meta.\n3. vercel_get_project para confirmar framework + rootDirectory + buildCommand + outputDirectory.\n4. Si el error no está claro: github_read_file de vite.config.* / next.config.* / package.json del repo correspondiente.\n5. github_list_commits últimos 5 para correlacionar el cambio que rompió.\n6. Reporta: "Causa raíz: X. Fix: Y." con paths concretos.\n7. Si Luis pide ejecutar el fix: github_create_branch + github_update_file con el cambio + github_create_pull_request.\n\nGotchas comunes:\n- Vite outDir "dist/public" vs Vercel esperando "dist".\n- Missing env var (VITE_*, NEXT_PUBLIC_*).\n- rootDirectory en monorepos.\n- Node version mismatch (Vercel default vs project).',
+ ARRAY['vercel_list_deployments','vercel_get_deployment','vercel_get_project','vercel_set_env_var','github_read_file','github_list_commits','github_create_branch','github_update_file','github_create_pull_request'],
+ 1, 'builtin', ARRAY['vercel','deploy','debug','build','fallo'], 'operator_luis')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  required_tools = EXCLUDED.required_tools,
+  tags = EXCLUDED.tags,
+  updated_at = now();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- code-review — Revisar un archivo o repo
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO skills (id, name, description, system_prompt, required_tools, ring_max, source, tags, created_by) VALUES
+('code-review',
+ 'Code Review — Revisar código de un repo con criterio senior',
+ 'Lee N archivos clave del repo, evalúa según la doctrina del senior engineer (parche mínimo, root cause, no backwards-compat innecesaria), y reporta findings ordenados por severidad: bugs > security > performance > style.',
+ E'SKILL: Code Review — ACTIVO.\n\nFlujo:\n1. github_get_repo para entender framework + lenguaje.\n2. github_read_file de los archivos clave (package.json, configs, entry points). Lee también el archivo que Luis te pide si lo dijo.\n3. github_list_commits últimos 20 para entender el contexto de cambios.\n4. Evalúa con la doctrina: ¿hay un bug que vale más arreglar que tres mejoras de estilo? ¿hay try/catch que esconde root cause? ¿hay código muerto o backwards-compat innecesaria?\n5. Reporta findings:\n   - SEVERITY: BUG | SECURITY | PERF | STYLE\n   - file:line\n   - 1-2 oraciones por finding\n   - propuesta de fix mínimo\n6. NO ejecutes los fixes en este skill — solo reporta. Si Luis aprueba alguno, cambia a github-pr-author.\n\nReglas:\n- Cita archivos como path:line.\n- No menciones cosas que requieren ver MÁS contexto sin pedirlo (no especules).\n- Si una crítica es subjetiva, dilo: "preferencia de estilo".',
+ ARRAY['github_get_repo','github_read_file','github_list_commits'],
+ 0, 'builtin', ARRAY['review','codigo','audit','revisar','quality'], 'operator_luis')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  required_tools = EXCLUDED.required_tools,
+  tags = EXCLUDED.tags,
+  updated_at = now();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- bulk-categorizer — Clasificar 50+ repos en masa
+-- ─────────────────────────────────────────────────────────────────────────
+INSERT INTO skills (id, name, description, system_prompt, required_tools, ring_max, source, tags, created_by) VALUES
+('bulk-categorizer',
+ 'Bulk Categorizer — Clasificar el catálogo de repos en masa',
+ 'Cuando Luis tiene N repos en estado "en_revision|unknown" y quiere categorizarlos rápido. Itera por cada repo, llama a un modelo barato (Gemini Flash o Haiku) vía openrouter_query con el README + last commit como contexto, propone categoría (produccion / activo / archivo / pendiente_borrado) + score 1-10 de actividad.',
+ E'SKILL: Bulk Categorizer — ACTIVO.\n\nObjetivo: clasificar repos en masa, barato (~$0.001 por repo con Gemini Flash).\n\nFlujo:\n1. Lee el catálogo (puedes llamar al endpoint /api/projects o usar la info que ya tienes en memoria).\n2. Para cada repo:\n   - github_read_file README.md (truncado a 5KB).\n   - github_list_commits (limit 5) para ver actividad reciente.\n   - openrouter_query con model="google/gemini-2.5-flash", prompt="<README+commits+meta>", system="Devuelve JSON {category: produccion|activo|archivo|pendiente_borrado, score: 1-10, reason: <una linea>}".\n   - Parsea respuesta, valida que category está en el enum.\n3. Reporta tabla agregada al operador: counts por categoría + URLs de los pendiente_borrado para que Luis confirme.\n4. NO modifiques DB directamente — pide al operador que confirme antes de UPDATE projects SET category.\n\nReglas:\n- Usa Gemini Flash o Haiku, NUNCA Sonnet/Opus para esto (es desperdicio).\n- Si un repo no tiene README, marca category=pendiente_borrado con reason="sin README ni commits recientes".\n- Cap máximo de 100 repos por invocación. Si Luis tiene más, pide confirmación.',
+ ARRAY['github_read_file','github_list_commits','openrouter_query','model_recommend','memory_save'],
+ 1, 'builtin', ARRAY['categorize','clasificar','bulk','masa','catalog','repos'], 'operator_luis')
+ON CONFLICT (id) DO UPDATE SET
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  required_tools = EXCLUDED.required_tools,
+  tags = EXCLUDED.tags,
+  updated_at = now();
+
+INSERT INTO schema_migrations (version) VALUES ('006_skills_builtin')
+  ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Resumen

Tres avances en un PR. V ahora descubre skills relevantes, los aplica, y delega trabajo paralelo a sub-agentes especializados. Plus un bug fix crítico: V dejaba de ver archivos > 5KB.

## M16 — Skills registry (commit `5925c1c`)

V tiene un catálogo de **7 habilidades reusables** que puede buscar por texto natural y "instalar" al vuelo:

| Skill | Ring | Use case |
|---|---|---|
| `repo-rescue` | 1 | "este repo está roto, arréglalo" |
| `new-project-bootstrap` | 1 | "modo nuevo, arranca proyecto X" |
| `dns-vercel-namecom` | 1 | "apunta dominio.com a vercel" |
| `github-pr-author` | 1 | "haz un PR con esto en repo X" |
| `vercel-deploy-debug` | 1 | "el build está fallando" |
| `code-review` | 0 | "revisa este archivo / repo" |
| `bulk-categorizer` | 1 | "clasifica mis 52 repos" |

Tools: `skill_search(query, top_k)` + `skill_install(skill_id)`. Search por trigram ILIKE + tokenize ES+EN + stopwords. Cada query natural devuelve el skill correcto en top 1 (smoke contra Neon production con 6 queries PASS).

## M18 light — Subagentes paralelos in-process (commit `02f0441`)

V puede invocar N sub-agentes en una sola tool round → el dispatcher los corre con `Promise.all`. Smoke test 3 subagents en paralelo → **speedup 2.48x** (3.67s vs 9.1s serial), costo total $0.000442.

8 roles built-in con modelo optimizado:

| Rol | Modelo default | Para qué |
|---|---|---|
| `researcher` | Gemini 2.5 Flash | Sintetizar info |
| `reviewer` | Sonnet 4.6 | Code review |
| `coder` | Sonnet 4.6 | Escribir código corto |
| `tester` | Haiku 4.5 | Predecir comportamiento |
| `categorizer` | Gemini 2.5 Flash | JSON estricto |
| `summarizer` | Haiku 4.5 | 3-5 bullets |
| `extractor` | Haiku 4.5 | JSON desde texto |
| `translator` | Gemini 2.5 Flash | Traducir |

Tools: `spawn_subagent(role, task, model?, max_tokens?)` + `list_subagent_roles()`. Persistencia automática a `conversations` + `audit_events` con session_id = parent + ':subagent:' + role para que el cost dashboard agregue.

**Sin Trigger.dev** todavía (M9 lo upgrade a durable). Si el SSE cierra, results se pierden. Suficiente para tareas < 60s totales.

## Fix bug crítico: `github_read_file` cap

V reportó hoy: *"Mi tool github_read_file trunca a 5KB y el repo tiene archivos de 58KB+. No puedo ver el código completo — estoy ciega en archivos grandes."*

- Default cap subido de **5KB → 50KB**
- Nuevo param `max_bytes` (hasta 500KB)
- Nuevo param `offset` para paginar archivos enormes
- Response devuelve `total_bytes` + `next_offset` para que V sepa cuándo seguir

## Archivos

| Archivo | Líneas | Estado |
|---|---|---|
| `migrations/005_skills.sql` | +76 | Aplicado a Neon |
| `migrations/006_skills_builtin.sql` | +137 | Aplicado a Neon |
| `lib/forge/skills.ts` | +168 | Nuevo |
| `lib/forge/subagents.ts` | +233 | Nuevo |
| `lib/forge/tools.ts` | +222, -5 | 4 tools nuevas (skill_search, skill_install, spawn_subagent, list_subagent_roles) + fix read_file |

## Test plan

- [x] `tsc --noEmit` pasa
- [x] Skill search: 6 queries naturales devuelven skill correcto en top 1
- [x] Subagents: 3 en paralelo, speedup 2.48x, total cost $0.000442
- [ ] CI build + lint (en curso)
- [ ] Vercel preview build OK
- [ ] Validar en producción: pedirle a V "modo rescate" + dale un repo, debe invocar skill_search → skill_install('repo-rescue') → tools

## Lo que NO incluye

- M9 Trigger.dev — los subagentes son in-process (no durables)
- Embeddings — el skill_search usa ILIKE + trigram (suficiente para 7-20 skills)
- M11 Clerk — sigue auth única
- UI changes — todo es backend

## Pendiente próxima tanda

- M9 Trigger.dev para subagentes durables (necesario antes de "audita 52 repos" 2-3 min wall)
- M4 anthropic-web-search via OpenRouter (web search general)
- Bumpear seed migrations a un splitter robusto para que /api/admin/migrate las pueda reaplicar en preview/staging

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_