### PR TITLE
fix(forge): 3 bugs (legacy slug, this_month UTC, dispatcher owner-vacío)

### DIFF
--- a/app/api/forge/cost/route.ts
+++ b/app/api/forge/cost/route.ts
@@ -41,7 +41,11 @@ function resolvePeriod(input: string | null): {
       since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
       break;
     case "this_month":
-      since = new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
+      // Day 1 of the current month at 00:00:00 UTC. The previous form
+      // (new Date(year, month, 1)) used the local-time constructor and
+      // shifted the boundary by the runtime's TZ offset, skewing
+      // month-to-date totals by several hours (Codex P2).
+      since = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
       break;
     case "last_7d":
       since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);

--- a/lib/forge/models.ts
+++ b/lib/forge/models.ts
@@ -245,11 +245,27 @@ export function estimateCostForModel(
 }
 
 /**
+ * Legacy short-name slugs (Anthropic SDK era) → OpenRouter slugs.
+ * Some installs still have system_config.default_model = 'claude-sonnet-4-6'
+ * from the seed migration. Without this map the cascade was starting
+ * with an invalid OR slug and the first call returned a non-recoverable
+ * 4xx, aborting the whole turn (Codex P0).
+ */
+const LEGACY_SLUG_MAP: Record<string, string> = {
+  "claude-opus-4-7": "anthropic/claude-opus-4.7",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+  "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
+};
+
+/**
  * Strip OpenRouter's versioned date suffix so registry lookups hit
  * even when the response shape is "anthropic/claude-4.6-sonnet-20260217".
+ * Also maps legacy Anthropic-SDK short names to OR slugs.
  */
 export function normalizeSlug(slug: string): string {
-  // Replace "claude-4.6-sonnet-20260217" → "claude-sonnet-4.6"
+  // Legacy short names from pre-OpenRouter era.
+  if (LEGACY_SLUG_MAP[slug]) return LEGACY_SLUG_MAP[slug];
+  // Versioned OR responses: "claude-4.6-sonnet-20260217" → "claude-sonnet-4.6"
   const m = slug.match(/^anthropic\/claude-(\d+\.\d+)-(opus|sonnet|haiku)/);
   if (m) return `anthropic/claude-${m[2]}-${m[1]}`;
   return slug.replace(/(-\d{8}|-\d{6})$/, "");

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -744,7 +744,7 @@ async function dispatch(
 
     // ─── GitHub write ────────────────────────────────────────────────
     case "github_create_file": {
-      const owner = requireString(input.owner, "owner");
+      const owner = ownerOrDefault(input.owner);
       const repo = requireString(input.repo, "repo");
       const path = requireString(input.path, "path");
       const content = requireString(input.content, "content");
@@ -770,7 +770,7 @@ async function dispatch(
       };
     }
     case "github_update_file": {
-      const owner = requireString(input.owner, "owner");
+      const owner = ownerOrDefault(input.owner);
       const repo = requireString(input.repo, "repo");
       const path = requireString(input.path, "path");
       const content = requireString(input.content, "content");
@@ -797,7 +797,7 @@ async function dispatch(
       };
     }
     case "github_delete_file": {
-      const owner = requireString(input.owner, "owner");
+      const owner = ownerOrDefault(input.owner);
       const repo = requireString(input.repo, "repo");
       const path = requireString(input.path, "path");
       const message = requireString(input.message, "message");
@@ -823,7 +823,7 @@ async function dispatch(
       };
     }
     case "github_create_branch": {
-      const owner = requireString(input.owner, "owner");
+      const owner = ownerOrDefault(input.owner);
       const repo = requireString(input.repo, "repo");
       const branch = requireString(input.branch, "branch");
       const fromBranch =
@@ -841,7 +841,7 @@ async function dispatch(
       };
     }
     case "github_create_pull_request": {
-      const owner = requireString(input.owner, "owner");
+      const owner = ownerOrDefault(input.owner);
       const repo = requireString(input.repo, "repo");
       const title = requireString(input.title, "title");
       const head = requireString(input.head, "head");
@@ -1564,6 +1564,20 @@ function clampNumber(
   const n = typeof v === "number" ? v : parseInt(String(v ?? ""), 10);
   if (Number.isNaN(n)) return def;
   return Math.min(Math.max(n, min), max);
+}
+
+/**
+ * Default GitHub owner when V invokes a write tool without specifying
+ * one. The single-tenant MVP only operates on Luis's own repos under
+ * 'turbillon50', so an empty owner is almost always V failing to fill
+ * the field rather than a real ambiguity. Replace with the Clerk-bound
+ * owner when M11 lands (multi-tenant).
+ */
+const DEFAULT_GITHUB_OWNER = "turbillon50";
+
+function ownerOrDefault(v: unknown): string {
+  if (typeof v === "string" && v.length > 0) return v;
+  return DEFAULT_GITHUB_OWNER;
 }
 
 function requireString(v: unknown, name: string): string {


### PR DESCRIPTION
## Resumen

Los 3 bugs que V identificó en el chat hoy. Sin estos, V no puede escribir sola y el cost report está sesgado en runtimes no-UTC.

## Bugs arreglados

### 1. Legacy slug map — Codex P0
**Archivo**: `lib/forge/models.ts`
**Cambio**: `normalizeSlug()` ahora mapea nombres cortos pre-OpenRouter al slug OR.

```ts
const LEGACY_SLUG_MAP: Record<string, string> = {
  "claude-opus-4-7": "anthropic/claude-opus-4.7",
  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
  "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
};
```

**Por qué importaba**: La seed migration `002_seed.sql` siembra `default_model = 'claude-sonnet-4-6'` (formato Anthropic SDK pre-OR). Sin este mapeo, el cascade arrancaba con un slug inválido para OpenRouter, primera llamada pegaba 4xx (no recoverable, no entra al fallback), chat abortaba. Cualquier deploy nuevo quedaba roto.

### 2. `this_month` UTC consistency — Codex P2
**Archivo**: `app/api/forge/cost/route.ts:43-48`
**Cambio**: `new Date(now.getUTCFullYear(), now.getUTCMonth(), 1)` → `new Date(Date.UTC(...))`.

**Por qué importaba**: El constructor sin `Date.UTC` usa local time. En runtimes con TZ ≠ UTC el periodo arrancaba en local-midnight, varias horas off. Sesgaba el cost report MTD que V consulta para auto-administrar gasto.

### 3. Dispatcher `owner` vacío — V lo reportó hoy
**Archivo**: `lib/forge/tools.ts`
**Cambio**: 5 cases de write tools ahora usan `ownerOrDefault(input.owner)` que cae a `'turbillon50'` si V omite el campo.

```ts
function ownerOrDefault(v: unknown): string {
  if (typeof v === "string" && v.length > 0) return v;
  return DEFAULT_GITHUB_OWNER; // = "turbillon50"
}
```

**Por qué importaba**: Antes `requireString(input.owner, "owner")` tiraba "owner must be a non-empty string" cuando V omitía el campo. Las **read tools no se tocaron** — V puede seguir pasándoles owner explícito sin cambio.

## Lo que NO incluye

- Sin nuevas tools (`github_list_directory` no entra)
- Sin cambio al cap de 5KB en `read_file`
- Sin expandir `inferTaskKind`
- Sin refactor del routing existente
- Sin tocar dynamic env routing del PR #30

## Test plan

- [x] `tsc --noEmit` pasa
- [ ] CI build + lint
- [ ] Vercel preview build
- [ ] Validar producción: V ejecuta `github_create_branch({repo:'vforge', branch:'tmp/...', from_branch:'main'})` sin `owner` → debe pasar.
- [ ] Validar producción: chat normal en cuenta nueva (sin override de `default_model`) → primera llamada debe usar Sonnet via OR sin abortar.

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_