### PR TITLE
feat(forge): V se reconfigura sola — agent_config + 4 tools

### DIFF
--- a/app/api/forge/run/route.ts
+++ b/app/api/forge/run/route.ts
@@ -11,6 +11,7 @@ import { TOOLS, executeTool } from "@/lib/forge/tools";
 import { getOperatorSecret } from "@/lib/vault/get-secret";
 import { routeFor } from "@/lib/forge/routing";
 import { estimateCostForModel, MODELS, normalizeSlug } from "@/lib/forge/models";
+import { getModelForTask } from "@/lib/forge/agent-config";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -67,12 +68,17 @@ export async function POST(req: Request) {
     projectId: body.projectId ?? null,
   });
 
-  // Resolve the model cascade via the routing policy. If the operator
-  // pinned a specific slug in system_config.default_model (and it's in
-  // our registry), we honor it as the primary and let routing.ts supply
-  // its fallback chain. If the slug isn't in the registry, we treat
-  // it as a free-form override and skip cascade.
-  const configuredModel = config.default_model;
+  // Resolve the model cascade.
+  // 1. agent_config DB (V's self-config, migration 007) is the canonical
+  //    answer for chat-main. Luis (or V herself via agent_config_set)
+  //    chooses the model without a code deploy.
+  // 2. system_config.default_model is the legacy override, still respected
+  //    if someone updates it manually.
+  // 3. routeFor falls back to the registry default + cascade.
+  const dbConfiguredModel = await getModelForTask("chat-main").catch(
+    () => null,
+  );
+  const configuredModel = dbConfiguredModel ?? config.default_model;
   const isKnownSlug = !!MODELS[normalizeSlug(configuredModel)];
   const routing = isKnownSlug
     ? routeFor("chat-main", { forceSlug: normalizeSlug(configuredModel) })

--- a/lib/forge/agent-config.ts
+++ b/lib/forge/agent-config.ts
@@ -1,0 +1,141 @@
+/**
+ * V's self-config layer.
+ *
+ * Lets V change its own model per task kind via the `agent_config` table
+ * in Neon (migration 007). The router in /api/forge/run reads from this
+ * table first, then falls back to env vars, then to the registry defaults
+ * in lib/forge/models.ts.
+ *
+ * Exposed to V through 3 tools (lib/forge/tools.ts):
+ *   - agent_config_get()          → current config + which model maps to which task
+ *   - agent_config_set(task, mdl) → V changes its own model for that task
+ *   - model_set_default(slug)     → alias for "use this model for chat-main"
+ *
+ * Cache: 60s in-memory per Lambda invocation to keep the hot path fast.
+ * Cache busts on any write via clearAgentConfigCache().
+ */
+import { sql } from "@/lib/db/client";
+import { MODELS, normalizeSlug, type TaskKind } from "./models";
+
+interface ConfigRow {
+  task_kind: TaskKind;
+  model: string;
+}
+
+let CACHE: { entries: Map<string, string>; expiresAt: number } | null = null;
+const CACHE_TTL_MS = 60 * 1000;
+
+export function clearAgentConfigCache(): void {
+  CACHE = null;
+}
+
+/**
+ * Returns the model slug V should use for a given task kind, with this
+ * cascade:
+ *   1. agent_config row in Neon (if exists)
+ *   2. env var fallback (e.g. MODEL_CHAT_MAIN)
+ *   3. registry default in lib/forge/models.ts
+ */
+export async function getModelForTask(task: TaskKind): Promise<string> {
+  const cfg = await loadConfig();
+  const fromDb = cfg.get(task);
+  if (fromDb) return fromDb;
+
+  const envVar = ENV_BY_TASK[task];
+  const fromEnv = envVar ? process.env[envVar] : undefined;
+  if (fromEnv) return fromEnv;
+
+  // Registry default — first slug in TASK_PREFERENCES for that kind.
+  return DEFAULT_BY_TASK[task];
+}
+
+/** Bulk-load all agent_config rows. Used by agent_config_get tool. */
+export async function listAgentConfig(): Promise<ConfigRow[]> {
+  const rows = (await sql`
+    SELECT task_kind, model
+    FROM agent_config
+    ORDER BY task_kind
+  `) as ConfigRow[];
+  return rows;
+}
+
+/**
+ * Persist a new model for a task kind. Validates that the slug
+ * normalizes to something we know about (registry hit OR a free-form
+ * passthrough that includes a '/'). Throws on garbage input.
+ */
+export async function setModelForTask(
+  task: TaskKind,
+  model: string,
+  options: { updatedBy?: string } = {},
+): Promise<{ task_kind: TaskKind; model: string }> {
+  if (!ALLOWED_TASKS.has(task)) {
+    throw new Error(
+      `Unknown task_kind '${task}'. Allowed: ${[...ALLOWED_TASKS].join(", ")}`,
+    );
+  }
+  const normalized = normalizeSlug(model);
+  const isKnown = !!MODELS[normalized];
+  const looksLikeSlug = normalized.includes("/");
+  if (!isKnown && !looksLikeSlug) {
+    throw new Error(
+      `Model '${model}' doesn't look like a valid OpenRouter slug. Expected something like 'anthropic/claude-haiku-4.5' or 'google/gemini-2.5-flash'.`,
+    );
+  }
+  const updatedBy = options.updatedBy ?? "operator_luis";
+  const rows = (await sql`
+    INSERT INTO agent_config (task_kind, model, updated_by, updated_at)
+    VALUES (${task}, ${normalized}, ${updatedBy}, now())
+    ON CONFLICT (task_kind) DO UPDATE SET
+      model = EXCLUDED.model,
+      updated_by = EXCLUDED.updated_by,
+      updated_at = now()
+    RETURNING task_kind, model
+  `) as ConfigRow[];
+  clearAgentConfigCache();
+  return rows[0];
+}
+
+async function loadConfig(): Promise<Map<string, string>> {
+  if (CACHE && CACHE.expiresAt > Date.now()) return CACHE.entries;
+  const entries = new Map<string, string>();
+  try {
+    const rows = (await sql`
+      SELECT task_kind, model FROM agent_config
+    `) as ConfigRow[];
+    for (const r of rows) entries.set(r.task_kind, r.model);
+  } catch {
+    // If the table doesn't exist yet (pre-migration), fall back to env/registry.
+  }
+  CACHE = { entries, expiresAt: Date.now() + CACHE_TTL_MS };
+  return entries;
+}
+
+const ALLOWED_TASKS = new Set<TaskKind>([
+  "chat-main",
+  "reasoning",
+  "code-edit",
+  "classification",
+  "summarization",
+  "extraction",
+  // The registry also has 'web-search' and 'embedding' but those don't
+  // currently route through this code path — V doesn't pick a model for
+  // them, the adapter is fixed.
+]);
+
+const ENV_BY_TASK: Partial<Record<TaskKind, string>> = {
+  "chat-main": "MODEL_CHAT_MAIN",
+  "code-edit": "MODEL_CODE",
+  classification: "MODEL_CLASSIFY",
+};
+
+const DEFAULT_BY_TASK: Record<TaskKind, string> = {
+  "chat-main": "anthropic/claude-sonnet-4.6",
+  reasoning: "anthropic/claude-sonnet-4.6",
+  "code-edit": "anthropic/claude-sonnet-4.6",
+  classification: "google/gemini-2.5-flash",
+  summarization: "anthropic/claude-haiku-4.5",
+  extraction: "anthropic/claude-haiku-4.5",
+  "web-search": "anthropic/claude-haiku-4.5",
+  embedding: "google/gemini-2.5-flash",
+};

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -51,6 +51,7 @@ import { encryptOperatorSecret } from "@/lib/vault/operator-crypto";
 import { invalidateSecretCache } from "@/lib/vault/get-secret";
 import { routeFor } from "@/lib/forge/routing";
 import { MODELS } from "@/lib/forge/models";
+import { listAgentConfig, setModelForTask } from "@/lib/forge/agent-config";
 
 export const TOOLS: Tool[] = [
   {
@@ -637,6 +638,104 @@ export const TOOLS: Tool[] = [
           enum: ["today", "24h", "this_month", "last_7d", "last_30d"],
         },
       },
+    },
+  },
+
+  // ─── Self-config (V reconfigura sus propios modelos) ─────────────
+  {
+    name: "agent_config_get",
+    description:
+      "Devuelve la configuración actual de modelos por tipo de tarea. Lo que V está usando ahora mismo para chat-main, code-edit, classification, etc. Úsala cuando Luis pregunte 'qué modelo estás usando' o antes de proponer un cambio para saber el estado actual.",
+    input_schema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "agent_config_set",
+    description:
+      "Cambia el modelo que V usará para un tipo de tarea específico. Aplica al siguiente turno SIN redeploy. Úsala cuando Luis te diga 'usa Haiku para chat', 'cambia clasificación a Gemini Flash', 'para código usa Sonnet'. task_kind debe ser uno de: chat-main, reasoning, code-edit, classification, summarization, extraction. model debe ser un slug válido de OpenRouter (ej. 'anthropic/claude-haiku-4.5', 'google/gemini-2.5-flash').",
+    input_schema: {
+      type: "object",
+      properties: {
+        task_kind: {
+          type: "string",
+          enum: [
+            "chat-main",
+            "reasoning",
+            "code-edit",
+            "classification",
+            "summarization",
+            "extraction",
+          ],
+          description: "Tipo de tarea para la cual cambiar el modelo.",
+        },
+        model: {
+          type: "string",
+          description:
+            "Slug de OpenRouter (ej. 'anthropic/claude-haiku-4.5', 'google/gemini-2.5-flash', 'anthropic/claude-sonnet-4.6').",
+        },
+      },
+      required: ["task_kind", "model"],
+    },
+  },
+  {
+    name: "model_set_default",
+    description:
+      "Atajo para cambiar el modelo principal del chat (task_kind='chat-main'). Equivalente a agent_config_set({task_kind:'chat-main', model: <slug>}). Úsala cuando Luis dice 'V, a partir de ahora usa X para todo'.",
+    input_schema: {
+      type: "object",
+      properties: {
+        model: {
+          type: "string",
+          description:
+            "Slug de OpenRouter del nuevo modelo principal.",
+        },
+      },
+      required: ["model"],
+    },
+  },
+  {
+    name: "skill_create",
+    description:
+      "Crea una nueva habilidad reusable en el catálogo de skills. Úsala cuando Luis te describe un flujo que vale la pena recordar como skill ('cuando te pida X, sigue Y, Z, W') o cuando V identifica un patrón frecuente que merece skill propia. Después de crear, skill_search la encontrará y skill_install la cargará.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "Slug único kebab-case (ej. 'deploy-monorepo-vercel').",
+        },
+        name: {
+          type: "string",
+          description: "Nombre corto descriptivo (ej. 'Deploy de monorepo a Vercel').",
+        },
+        description: {
+          type: "string",
+          description: "1-2 líneas de para qué sirve y cuándo activarla.",
+        },
+        system_prompt: {
+          type: "string",
+          description:
+            "Fragment de instrucciones que V leerá al instalar la skill. Debe incluir el flujo paso a paso y reglas.",
+        },
+        required_tools: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Tools que la skill típicamente usa (ej. ['github_create_branch','github_create_file']).",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Tags para búsqueda (ej. ['deploy', 'vercel', 'monorepo']).",
+        },
+        ring_max: {
+          type: "number",
+          description: "Anillo máximo de privilegio. Default 1.",
+        },
+      },
+      required: ["id", "name", "description", "system_prompt"],
     },
   },
 
@@ -1623,6 +1722,110 @@ async function dispatch(
           fallback_events: fallbackRows[0].n,
         }),
         summary: `${period}: $${Number(totals[0].total_usd).toFixed(4)} / ${totals[0].turns} turns / ${fallbackRows[0].n} fallbacks`,
+      };
+    }
+
+    // ─── Self-config (V reconfigura sus propios modelos / skills) ────
+    case "agent_config_get": {
+      const rows = await listAgentConfig();
+      return {
+        ok: true,
+        content: JSON.stringify({
+          total: rows.length,
+          config: rows,
+        }),
+        summary: `${rows.length} task kinds configurados`,
+      };
+    }
+    case "agent_config_set": {
+      const task = requireString(input.task_kind, "task_kind") as
+        | "chat-main"
+        | "reasoning"
+        | "code-edit"
+        | "classification"
+        | "summarization"
+        | "extraction";
+      const model = requireString(input.model, "model");
+      const result = await setModelForTask(task, model, {
+        updatedBy: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify({
+          updated: true,
+          task_kind: result.task_kind,
+          model: result.model,
+          note: "Aplica al siguiente turno (cache 60s). No requiere redeploy.",
+        }),
+        summary: `${result.task_kind} → ${result.model}`,
+      };
+    }
+    case "model_set_default": {
+      const model = requireString(input.model, "model");
+      const result = await setModelForTask("chat-main", model, {
+        updatedBy: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify({
+          updated: true,
+          task_kind: "chat-main",
+          model: result.model,
+        }),
+        summary: `chat-main → ${result.model}`,
+      };
+    }
+    case "skill_create": {
+      const id = requireString(input.id, "id");
+      if (!/^[a-z][a-z0-9-]{2,60}$/.test(id)) {
+        throw new Error(
+          "id must be kebab-case (a-z, 0-9, dash; 3-60 chars; start with letter)",
+        );
+      }
+      const name = requireString(input.name, "name");
+      const description = requireString(input.description, "description");
+      const systemPrompt = requireString(input.system_prompt, "system_prompt");
+      const requiredTools = Array.isArray(input.required_tools)
+        ? (input.required_tools as string[]).filter(
+            (t) => typeof t === "string" && t.length > 0,
+          )
+        : [];
+      const tags = Array.isArray(input.tags)
+        ? (input.tags as string[]).filter(
+            (t) => typeof t === "string" && t.length > 0,
+          )
+        : [];
+      const ringMax =
+        typeof input.ring_max === "number" &&
+        input.ring_max >= 0 &&
+        input.ring_max <= 3
+          ? input.ring_max
+          : 1;
+      const rows = (await sql`
+        INSERT INTO skills (
+          id, name, description, system_prompt, required_tools,
+          ring_max, source, tags, created_by
+        ) VALUES (
+          ${id}, ${name}, ${description}, ${systemPrompt}, ${requiredTools},
+          ${ringMax}, 'user', ${tags}, ${ctx.userId}
+        )
+        ON CONFLICT (id) DO UPDATE SET
+          name = EXCLUDED.name,
+          description = EXCLUDED.description,
+          system_prompt = EXCLUDED.system_prompt,
+          required_tools = EXCLUDED.required_tools,
+          ring_max = EXCLUDED.ring_max,
+          tags = EXCLUDED.tags,
+          updated_at = now()
+        RETURNING id, name, ring_max
+      `) as Array<{ id: string; name: string; ring_max: number }>;
+      return {
+        ok: true,
+        content: JSON.stringify({
+          created: true,
+          skill: rows[0],
+        }),
+        summary: `skill: ${rows[0].id}`,
       };
     }
 

--- a/migrations/007_agent_config.sql
+++ b/migrations/007_agent_config.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- vForge M-self-config — Agent config table (V can reconfigure herself)
+-- ============================================================================
+-- Lets V pick which OpenRouter model gets used per task kind without
+-- a code deploy. The router in /api/forge/run reads from this table
+-- first, then falls back to env vars (PR #30), then to the registry
+-- defaults in lib/forge/models.ts.
+--
+-- V exposes two tools (lib/forge/tools.ts):
+--   agent_config_set(task_kind, model)
+--   agent_config_get()
+--
+-- So Luis can say "V, usa Haiku para chat" and V actually changes
+-- its own behaviour for the next turn.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS agent_config (
+  task_kind   text PRIMARY KEY
+              CHECK (task_kind IN (
+                'chat-main', 'reasoning', 'code-edit',
+                'classification', 'summarization', 'extraction',
+                'translation', 'brainstorm', 'scout'
+              )),
+  model       text NOT NULL,
+  updated_by  text REFERENCES users(id) ON DELETE SET NULL,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Sensible defaults: balance cost vs quality.
+-- chat-main = Sonnet (Luis talking to V); everything else as cheap
+-- as possible while still supporting tools when needed.
+INSERT INTO agent_config (task_kind, model, updated_by) VALUES
+  ('chat-main',      'anthropic/claude-sonnet-4.6',  'operator_luis'),
+  ('reasoning',      'anthropic/claude-sonnet-4.6',  'operator_luis'),
+  ('code-edit',      'anthropic/claude-sonnet-4.6',  'operator_luis'),
+  ('classification', 'google/gemini-2.5-flash',      'operator_luis'),
+  ('summarization',  'anthropic/claude-haiku-4.5',   'operator_luis'),
+  ('extraction',     'anthropic/claude-haiku-4.5',   'operator_luis'),
+  ('translation',    'google/gemini-2.5-flash',      'operator_luis'),
+  ('brainstorm',     'minimax/minimax-m2.5:free',    'operator_luis'),
+  ('scout',          'minimax/minimax-m2.5:free',    'operator_luis')
+ON CONFLICT (task_kind) DO NOTHING;
+
+INSERT INTO schema_migrations (version) VALUES ('007_agent_config')
+  ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Qué hace

V puede ahora **elegir su propio modelo** por task kind sin redeploy y **crear sus propias skills**. Si le dices *"usa Haiku para chat"* o *"para clasificación usa Gemini Flash"*, V ejecuta `agent_config_set` y el siguiente turno aplica el cambio.

## Cambios (4 archivos, +401 / -6)

| Archivo | Qué |
|---|---|
| `migrations/007_agent_config.sql` | Tabla `agent_config (task_kind PK, model, updated_by, updated_at)` + 9 seeds. **Aplicada a Neon production.** |
| `lib/forge/agent-config.ts` | `getModelForTask`, `setModelForTask`, `listAgentConfig`. Cascade: DB → env var → registry. Cache 60s. |
| `app/api/forge/run/route.ts` | El primary del chat lee de DB primero. `system_config.default_model` queda como legacy fallback. |
| `lib/forge/tools.ts` | 4 tools nuevas (defs + dispatcher cases): `agent_config_get`, `agent_config_set`, `model_set_default`, `skill_create`. |

## Cómo se usa

| Cosa que dices a V | Lo que V hace |
|---|---|
| "qué modelo estás usando" | `agent_config_get` → tabla de 9 task kinds con su modelo |
| "usa Haiku para chat" | `model_set_default("anthropic/claude-haiku-4.5")` → DB updated, próximo turno usa Haiku |
| "para clasificación usa Gemini Flash" | `agent_config_set("classification","google/gemini-2.5-flash")` |
| "recuerda este flujo como skill 'deploy-monorepo'" + describe pasos | `skill_create({id:"deploy-monorepo", ...})` → quedará buscable con `skill_search` |

## Validaciones

- `setModelForTask` rechaza slugs garbage (debe normalizar a algo en `MODELS` o tener `/`).
- `skill_create` exige kebab-case strict (3-60 chars, `[a-z][a-z0-9-]*`).
- Cache busta en cada write.
- `task_kind` con `CHECK` constraint en SQL — V no puede inventar tipos.

## Lo que NO incluye

- Sin UI en Settings (puedes hacerla después o no, el backend ya funciona).
- Sin cambio al routing fallback automático del PR #28.
- Sin cambio a env vars (siguen siendo fallback secundario).
- Sin tools para que V cambie su personality / system_prompt — `system_config.ai_personality` sigue siendo SQL manual por ahora.

## Test plan

- [x] `tsc --noEmit` pasa
- [x] Migration 007 aplicada en Neon prod (9 seeds verificados)
- [ ] CI build + lint
- [ ] Vercel preview build
- [ ] Validación end-to-end: pedirle a V *"qué modelo estás usando ahorita"* → debe llamar `agent_config_get` y reportar 9 rows reales. Luego *"cambia el chat a Haiku"* → debe llamar `model_set_default` y confirmar.

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_