### PR TITLE
feat(forge): M5-alt — GitHub Actions como sandbox (gratis, sin E2B)

### DIFF
--- a/.github/workflows/v-sandbox.yml
+++ b/.github/workflows/v-sandbox.yml
@@ -1,0 +1,81 @@
+name: V Sandbox
+
+# On-demand validation sandbox triggered by V (the Forge brain) before
+# opening a PR or after committing to a feature branch. Mirrors the CI
+# checks (type-check + lint + build) but runs explicitly via
+# workflow_dispatch so V can poll for its outcome.
+#
+# How V uses it (lib/forge/tools.ts):
+#   github_run_check(repo, branch, command?)
+#     → POST /repos/{owner}/{repo}/actions/workflows/v-sandbox.yml/dispatches
+#   github_get_check_status(run_id)
+#     → GET /repos/{owner}/{repo}/actions/runs/{run_id}
+#   github_get_check_logs(run_id)
+#     → GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs
+#
+# Default command runs all three checks. V can override with a custom
+# npm script for targeted validation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "Comando a ejecutar (npm script). Default: tc+lint+build."
+        required: false
+        default: "default"
+      reason:
+        description: "Por qué V está validando (audit trail)."
+        required: false
+        default: "v-on-demand"
+
+# Each branch's sandbox can run in parallel — we don't cancel previous
+# runs because V might dispatch multiple to compare branches.
+concurrency:
+  group: v-sandbox-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: V validate (${{ github.event.inputs.reason }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout the branch V is testing
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Run validation
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+        run: |
+          CMD="${{ github.event.inputs.command }}"
+          if [ "$CMD" = "default" ] || [ -z "$CMD" ]; then
+            echo "→ default: type-check + lint + build"
+            npx tsc --noEmit
+            npm run lint
+            npm run build
+          else
+            echo "→ custom command: $CMD"
+            # Whitelist: only npm scripts and npx tsc are allowed
+            case "$CMD" in
+              "npm run "*|"npx tsc"*|"npm test"*)
+                eval "$CMD"
+                ;;
+              *)
+                echo "ERROR: command not allowed. Only 'npm run X', 'npm test', or 'npx tsc' permitted."
+                exit 1
+                ;;
+            esac
+          fi

--- a/.github/workflows/v-sandbox.yml
+++ b/.github/workflows/v-sandbox.yml
@@ -59,23 +59,29 @@ jobs:
       - name: Run validation
         env:
           NEXT_TELEMETRY_DISABLED: "1"
+          # Pass the command via env, not interpolation, so it can't
+          # break out of the literal string. The case below matches
+          # EXACT values from a closed whitelist — no eval, no globbing.
+          # (Codex P1 — eval-injection fix.)
+          CMD: ${{ github.event.inputs.command }}
         run: |
-          CMD="${{ github.event.inputs.command }}"
           if [ "$CMD" = "default" ] || [ -z "$CMD" ]; then
             echo "→ default: type-check + lint + build"
             npx tsc --noEmit
             npm run lint
             npm run build
-          else
-            echo "→ custom command: $CMD"
-            # Whitelist: only npm scripts and npx tsc are allowed
-            case "$CMD" in
-              "npm run "*|"npx tsc"*|"npm test"*)
-                eval "$CMD"
-                ;;
-              *)
-                echo "ERROR: command not allowed. Only 'npm run X', 'npm test', or 'npx tsc' permitted."
-                exit 1
-                ;;
-            esac
+            exit 0
           fi
+          case "$CMD" in
+            "npm run lint")        npm run lint ;;
+            "npm run build")       npm run build ;;
+            "npm run test"|"npm test") npm test ;;
+            "npm run dev")         echo "ERROR: 'npm run dev' is interactive; not allowed here." ; exit 1 ;;
+            "npx tsc --noEmit")    npx tsc --noEmit ;;
+            "npx tsc")             npx tsc --noEmit ;;
+            *)
+              echo "ERROR: command '$CMD' not in whitelist."
+              echo "Allowed: npm run lint | npm run build | npm run test | npx tsc --noEmit | default"
+              exit 1
+              ;;
+          esac

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -28,6 +28,10 @@ import {
   listDirectory as ghListDirectory,
   searchCode as ghSearchCode,
   listPullRequests as ghListPullRequests,
+  dispatchWorkflow as ghDispatchWorkflow,
+  getWorkflowRun as ghGetWorkflowRun,
+  getWorkflowRunLogs as ghGetWorkflowRunLogs,
+  listRecentWorkflowRuns as ghListRecentWorkflowRuns,
 } from "@/lib/github/client";
 import {
   listProjects as vercelListProjects,
@@ -793,6 +797,76 @@ export const TOOLS: Tool[] = [
         },
       },
       required: ["kind", "title", "content"],
+    },
+  },
+
+  // ─── Sandbox vía GitHub Actions (M5 alt) ────────────────────────
+  {
+    name: "github_run_check",
+    description:
+      "Dispara una validación on-demand (type-check + lint + build) en GitHub Actions contra la rama indicada. Úsala DESPUÉS de hacer cambios en un repo y ANTES de abrir un PR, para validar que el código compila. Devuelve { run_id, url } — guarda el run_id y consulta el estado con github_get_check_status. El workflow es .github/workflows/v-sandbox.yml (debe existir en el repo). Si Luis no especifica owner, asume 'turbillon50'.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string", description: "Default 'turbillon50'." },
+        repo: { type: "string" },
+        branch: {
+          type: "string",
+          description: "Rama a validar (ej. 'claude/fix-X').",
+        },
+        command: {
+          type: "string",
+          description: "Comando npm opcional (ej. 'npm run test'). Default: tc+lint+build.",
+        },
+        reason: {
+          type: "string",
+          description: "Una línea explicando por qué validas (queda en audit).",
+        },
+      },
+      required: ["repo", "branch"],
+    },
+  },
+  {
+    name: "github_get_check_status",
+    description:
+      "Devuelve el estado de una corrida de GitHub Actions. status: queued|in_progress|completed. conclusion (solo si completed): success|failure|cancelled|skipped|timed_out. Úsala en loop con un pequeño delay para esperar el resultado de github_run_check.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string", description: "Default 'turbillon50'." },
+        repo: { type: "string" },
+        run_id: { type: "number" },
+      },
+      required: ["repo", "run_id"],
+    },
+  },
+  {
+    name: "github_get_check_logs",
+    description:
+      "Devuelve los logs de una corrida fallida de GitHub Actions (truncados a 100KB). Úsala SOLO cuando github_get_check_status devuelve conclusion=failure para entender qué falló. Para corridas exitosas no es necesario.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string", description: "Default 'turbillon50'." },
+        repo: { type: "string" },
+        run_id: { type: "number" },
+      },
+      required: ["repo", "run_id"],
+    },
+  },
+  {
+    name: "github_list_check_runs",
+    description:
+      "Lista las últimas corridas del workflow v-sandbox en un repo, opcionalmente filtradas por rama. Útil para ver historia de validaciones o encontrar el último run de una rama.",
+    input_schema: {
+      type: "object",
+      properties: {
+        owner: { type: "string", description: "Default 'turbillon50'." },
+        repo: { type: "string" },
+        branch: { type: "string", description: "Filtrar por rama (opcional)." },
+        per_page: { type: "number", description: "1-30, default 10." },
+      },
+      required: ["repo"],
     },
   },
 
@@ -1888,7 +1962,7 @@ async function dispatch(
 
     case "skill_list": {
       const installedOnly = input.installed_only === true;
-      
+
       let rows;
       if (installedOnly) {
         rows = (await sql`
@@ -1921,7 +1995,7 @@ async function dispatch(
           ring_max: number;
         }>;
       }
-      
+
       return {
         ok: true,
         content: JSON.stringify({
@@ -1942,7 +2016,7 @@ async function dispatch(
 
     case "directive_list": {
       const kindFilter = typeof input.kind === "string" ? input.kind : null;
-      
+
       let rows;
       if (kindFilter) {
         rows = (await sql`
@@ -1975,13 +2049,13 @@ async function dispatch(
           active: boolean;
         }>;
       }
-      
+
       const byKind = {
         mantra: rows.filter(r => r.kind === 'mantra'),
         directive: rows.filter(r => r.kind === 'directive'),
         preference: rows.filter(r => r.kind === 'preference'),
       };
-      
+
       return {
         ok: true,
         content: JSON.stringify({
@@ -2012,13 +2086,13 @@ async function dispatch(
       const title = requireString(input.title, "title");
       const content = requireString(input.content, "content");
       const priority = typeof input.priority === "number" ? input.priority : 100;
-      
+
       const rows = (await sql`
         INSERT INTO agent_directives (kind, title, content, locked, priority, created_by)
         VALUES (${kind}, ${title}, ${content}, false, ${priority}, ${ctx.userId})
         RETURNING id, kind, title, priority
       `) as Array<{ id: string; kind: string; title: string; priority: number }>;
-      
+
       return {
         ok: true,
         content: JSON.stringify({
@@ -2026,6 +2100,100 @@ async function dispatch(
           directive: rows[0],
         }),
         summary: `directiva creada: ${rows[0].title}`,
+      };
+    }
+
+    // ─── Sandbox vía GitHub Actions (M5 alt) ───────────────────────
+    case "github_run_check": {
+      const owner = ownerOrDefault(input.owner);
+      const repo = requireString(input.repo, "repo");
+      const branch = requireString(input.branch, "branch");
+      const command =
+        typeof input.command === "string" && input.command.length > 0
+          ? input.command
+          : "default";
+      const reason =
+        typeof input.reason === "string" && input.reason.length > 0
+          ? input.reason
+          : "v-on-demand";
+      const result = await ghDispatchWorkflow(
+        owner,
+        repo,
+        "v-sandbox.yml",
+        branch,
+        { command, reason },
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify({
+          run_id: result.run_id,
+          ref: result.ref,
+          workflow: result.workflow,
+          note: result.run_id
+            ? "Validación disparada. Usa github_get_check_status para seguir el estado."
+            : "Workflow disparado pero la corrida aún no aparece en la lista. Reintenta github_list_check_runs en unos segundos.",
+        }),
+        summary: `dispatched v-sandbox on ${owner}/${repo}#${branch}${result.run_id ? ` → run ${result.run_id}` : ""}`,
+      };
+    }
+    case "github_get_check_status": {
+      const owner = ownerOrDefault(input.owner);
+      const repo = requireString(input.repo, "repo");
+      const runId = Number(input.run_id);
+      if (!Number.isFinite(runId)) throw new Error("run_id must be a number");
+      const run = await ghGetWorkflowRun(owner, repo, runId, {
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify(run),
+        summary: `run ${runId}: ${run.status}${run.conclusion ? ` / ${run.conclusion}` : ""}`,
+      };
+    }
+    case "github_get_check_logs": {
+      const owner = ownerOrDefault(input.owner);
+      const repo = requireString(input.repo, "repo");
+      const runId = Number(input.run_id);
+      if (!Number.isFinite(runId)) throw new Error("run_id must be a number");
+      const logs = await ghGetWorkflowRunLogs(owner, repo, runId, {
+        auditUserId: ctx.userId,
+      });
+      return {
+        ok: true,
+        content: JSON.stringify({
+          run_id: runId,
+          size: logs.size,
+          truncated: logs.truncated,
+          text: logs.text,
+        }),
+        summary: `logs for run ${runId} (${logs.size}B${logs.truncated ? ", truncado a 100KB" : ""})`,
+      };
+    }
+    case "github_list_check_runs": {
+      const owner = ownerOrDefault(input.owner);
+      const repo = requireString(input.repo, "repo");
+      const branch =
+        typeof input.branch === "string" && input.branch.length > 0
+          ? input.branch
+          : undefined;
+      const perPage = clampNumber(input.per_page, 1, 30, 10);
+      const runs = await ghListRecentWorkflowRuns(
+        owner,
+        repo,
+        "v-sandbox.yml",
+        { branch, perPage, auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify({
+          owner,
+          repo,
+          branch,
+          total: runs.length,
+          runs,
+        }),
+        summary: `${runs.length} runs de v-sandbox en ${owner}/${repo}${branch ? "#" + branch : ""}`,
       };
     }
 

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -2163,11 +2163,12 @@ async function dispatch(
         ok: true,
         content: JSON.stringify({
           run_id: runId,
+          jobs: logs.jobs,
           size: logs.size,
           truncated: logs.truncated,
           text: logs.text,
         }),
-        summary: `logs for run ${runId} (${logs.size}B${logs.truncated ? ", truncado a 100KB" : ""})`,
+        summary: `logs run ${runId}: ${logs.jobs} job(s), ${logs.size}B${logs.truncated ? " (truncado 100KB)" : ""}`,
       };
     }
     case "github_list_check_runs": {

--- a/lib/github/client.ts
+++ b/lib/github/client.ts
@@ -608,6 +608,13 @@ export async function dispatchWorkflow(
   options: { auditUserId?: string } = {},
 ): Promise<{ run_id: number | null; ref: string; workflow: string }> {
   const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+
+  // Capture a high-water-mark BEFORE the dispatch so we only accept
+  // runs created strictly after our request. Without this, a previous
+  // workflow_dispatch on the same branch within the last 30s could be
+  // mis-correlated as ours (Codex P1).
+  const dispatchedAfter = Date.now();
+
   await octokit.request(
     "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
     {
@@ -619,8 +626,8 @@ export async function dispatchWorkflow(
     },
   );
 
-  // Poll for the freshly-created run. GitHub assigns IDs eagerly but
-  // the listing has a small lag.
+  // Poll for the freshly-created run. GitHub assigns the ID eagerly
+  // but the listing has a small lag; 5s is enough in practice.
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     const { data } = await octokit.request(
@@ -630,7 +637,7 @@ export async function dispatchWorkflow(
     const fresh = data.workflow_runs.find(
       (r) =>
         r.event === "workflow_dispatch" &&
-        new Date(r.created_at).getTime() > Date.now() - 30_000,
+        new Date(r.created_at).getTime() >= dispatchedAfter,
     );
     if (fresh) {
       return { run_id: fresh.id, ref, workflow: workflowFile };
@@ -667,40 +674,60 @@ export async function getWorkflowRun(
 }
 
 /**
- * Fetch workflow run logs as plain text. GitHub returns a zip; we
- * extract just the merged log payload by reading the response as
- * text. Truncates to 100KB to fit V's context budget.
+ * Fetch workflow run logs as readable plain text.
+ *
+ * The run-level `/actions/runs/{id}/logs` endpoint returns a ZIP that
+ * we'd need to decompress (extra dep + buffer mgmt). Instead we use
+ * the per-job endpoint `/actions/jobs/{job_id}/logs` which returns
+ * plain text directly. We concatenate all jobs of the run, prefix
+ * each with a header, and truncate to maxBytes.
+ * (Codex P2 — was returning ZIP-as-utf8 garbage.)
  */
 export async function getWorkflowRunLogs(
   owner: string,
   repo: string,
   runId: number,
   options: { auditUserId?: string; maxBytes?: number } = {},
-): Promise<{ text: string; truncated: boolean; size: number }> {
+): Promise<{ text: string; truncated: boolean; size: number; jobs: number }> {
   const octokit = await getGithubClient({ auditUserId: options.auditUserId });
-  // The /logs endpoint redirects to a signed S3 URL with the zip.
-  // octokit handles the redirect and returns the binary as arraybuffer.
-  const { data } = await octokit.request(
-    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
-    {
-      owner,
-      repo,
-      run_id: runId,
-      // Tell octokit to NOT auto-parse; we'll read as binary.
-      request: { redirect: "follow" },
-    },
+  const maxBytes = options.maxBytes ?? 100_000;
+
+  // List jobs of this run.
+  const { data: jobsData } = await octokit.request(
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+    { owner, repo, run_id: runId, per_page: 30 },
   );
-  // data is an ArrayBuffer from octokit for binary responses.
-  const buf = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
-  // The zip is a binary blob — V doesn't need to parse it; we just
-  // hand back the readable text portions if any. Most callers will
-  // prefer the URL to look at the logs in GitHub UI.
-  const max = options.maxBytes ?? 100_000;
-  const truncated = buf.length > max;
-  const slice = truncated ? buf.subarray(0, max) : buf;
-  // Try to extract readable ASCII; fallback to a hint about size.
-  const ascii = slice.toString("utf8").replace(/[\x00-\x08\x0e-\x1f]/g, "");
-  return { text: ascii, truncated, size: buf.length };
+
+  const parts: string[] = [];
+  let totalSize = 0;
+  for (const job of jobsData.jobs ?? []) {
+    if (totalSize >= maxBytes) break;
+    try {
+      // octokit returns the body as string for this text endpoint.
+      const { data: logBody } = (await octokit.request(
+        "GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
+        { owner, repo, job_id: job.id, request: { redirect: "follow" } },
+      )) as unknown as { data: string };
+      const body = typeof logBody === "string" ? logBody : String(logBody);
+      const header = `\n══════ job ${job.id} · ${job.name} · ${job.conclusion ?? job.status} ══════\n`;
+      parts.push(header);
+      parts.push(body);
+      totalSize += header.length + body.length;
+    } catch {
+      // A job may not have logs yet (still queued); skip.
+      parts.push(`\n══════ job ${job.id} · ${job.name} · (logs unavailable) ══════\n`);
+    }
+  }
+
+  const combined = parts.join("");
+  const truncated = combined.length > maxBytes;
+  const text = truncated ? combined.slice(0, maxBytes) : combined;
+  return {
+    text,
+    truncated,
+    size: combined.length,
+    jobs: (jobsData.jobs ?? []).length,
+  };
 }
 
 export async function listRecentWorkflowRuns(

--- a/lib/github/client.ts
+++ b/lib/github/client.ts
@@ -576,3 +576,161 @@ export async function listPullRequests(
     url: pr.html_url,
   }));
 }
+
+// ─── Workflow / Actions ops (M5 alt — GitHub Actions as sandbox) ──────
+
+export interface WorkflowRunSummary {
+  id: number;
+  name: string | null;
+  status: string | null; // queued | in_progress | completed
+  conclusion: string | null; // success | failure | cancelled | skipped | timed_out | null
+  head_branch: string | null;
+  head_sha: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  run_started_at: string | null;
+  run_attempt: number;
+}
+
+/**
+ * Dispatch a workflow_dispatch event. The GitHub API doesn't return
+ * the resulting run_id, so we poll the list of recent runs and pick
+ * the newest one for that workflow + branch. Pollable for ~5s before
+ * giving up — the run usually shows up within 2s.
+ */
+export async function dispatchWorkflow(
+  owner: string,
+  repo: string,
+  workflowFile: string,
+  ref: string,
+  inputs: Record<string, string>,
+  options: { auditUserId?: string } = {},
+): Promise<{ run_id: number | null; ref: string; workflow: string }> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  await octokit.request(
+    "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+    {
+      owner,
+      repo,
+      workflow_id: workflowFile,
+      ref,
+      inputs,
+    },
+  );
+
+  // Poll for the freshly-created run. GitHub assigns IDs eagerly but
+  // the listing has a small lag.
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const { data } = await octokit.request(
+      "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+      { owner, repo, workflow_id: workflowFile, branch: ref, per_page: 5 },
+    );
+    const fresh = data.workflow_runs.find(
+      (r) =>
+        r.event === "workflow_dispatch" &&
+        new Date(r.created_at).getTime() > Date.now() - 30_000,
+    );
+    if (fresh) {
+      return { run_id: fresh.id, ref, workflow: workflowFile };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 800));
+  }
+  return { run_id: null, ref, workflow: workflowFile };
+}
+
+export async function getWorkflowRun(
+  owner: string,
+  repo: string,
+  runId: number,
+  options: { auditUserId?: string } = {},
+): Promise<WorkflowRunSummary> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  const { data } = await octokit.request(
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}",
+    { owner, repo, run_id: runId },
+  );
+  return {
+    id: data.id,
+    name: data.name ?? null,
+    status: data.status,
+    conclusion: data.conclusion,
+    head_branch: data.head_branch,
+    head_sha: data.head_sha,
+    url: data.html_url,
+    created_at: data.created_at,
+    updated_at: data.updated_at,
+    run_started_at: data.run_started_at ?? null,
+    run_attempt: data.run_attempt ?? 1,
+  };
+}
+
+/**
+ * Fetch workflow run logs as plain text. GitHub returns a zip; we
+ * extract just the merged log payload by reading the response as
+ * text. Truncates to 100KB to fit V's context budget.
+ */
+export async function getWorkflowRunLogs(
+  owner: string,
+  repo: string,
+  runId: number,
+  options: { auditUserId?: string; maxBytes?: number } = {},
+): Promise<{ text: string; truncated: boolean; size: number }> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  // The /logs endpoint redirects to a signed S3 URL with the zip.
+  // octokit handles the redirect and returns the binary as arraybuffer.
+  const { data } = await octokit.request(
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+    {
+      owner,
+      repo,
+      run_id: runId,
+      // Tell octokit to NOT auto-parse; we'll read as binary.
+      request: { redirect: "follow" },
+    },
+  );
+  // data is an ArrayBuffer from octokit for binary responses.
+  const buf = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
+  // The zip is a binary blob — V doesn't need to parse it; we just
+  // hand back the readable text portions if any. Most callers will
+  // prefer the URL to look at the logs in GitHub UI.
+  const max = options.maxBytes ?? 100_000;
+  const truncated = buf.length > max;
+  const slice = truncated ? buf.subarray(0, max) : buf;
+  // Try to extract readable ASCII; fallback to a hint about size.
+  const ascii = slice.toString("utf8").replace(/[\x00-\x08\x0e-\x1f]/g, "");
+  return { text: ascii, truncated, size: buf.length };
+}
+
+export async function listRecentWorkflowRuns(
+  owner: string,
+  repo: string,
+  workflowFile: string,
+  options: { branch?: string; perPage?: number; auditUserId?: string } = {},
+): Promise<WorkflowRunSummary[]> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  const { data } = await octokit.request(
+    "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+    {
+      owner,
+      repo,
+      workflow_id: workflowFile,
+      branch: options.branch,
+      per_page: options.perPage ?? 10,
+    },
+  );
+  return data.workflow_runs.map((r) => ({
+    id: r.id,
+    name: r.name ?? null,
+    status: r.status,
+    conclusion: r.conclusion,
+    head_branch: r.head_branch,
+    head_sha: r.head_sha,
+    url: r.html_url,
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+    run_started_at: r.run_started_at ?? null,
+    run_attempt: r.run_attempt ?? 1,
+  }));
+}


### PR DESCRIPTION
## Qué hace

V puede ahora **validar código en sandbox antes de abrir PR**: dispara un workflow GitHub Actions on-demand, espera resultado, lee logs si falla. **Costo: $0** (free tier de Actions cubre uso personal). Alternativa pragmática a E2B/Modal mientras no tengas necesidad de sandbox de baja latencia (<5s).

## Flujo típico

```
1. V hace cambios via github_create_branch + github_update_file
2. V invoca github_run_check(repo, branch)
3. V hace polling con github_get_check_status hasta completed
4. Si conclusion=success → V abre PR con github_create_pull_request
5. Si conclusion=failure → V lee logs con github_get_check_logs
   y propone fix concreto con file:line
```

## Cambios (3 archivos, +407)

| Archivo | Qué |
|---|---|
| `.github/workflows/v-sandbox.yml` | `workflow_dispatch` con inputs (command, reason). Default: tc + lint + build. Whitelist de comandos custom (solo `npm run X`, `npm test`, `npx tsc`). |
| `lib/github/client.ts` | 4 helpers: `dispatchWorkflow` (con polling de 5s para resolver el run_id), `getWorkflowRun`, `getWorkflowRunLogs`, `listRecentWorkflowRuns`. |
| `lib/forge/tools.ts` | 4 tools nuevas: `github_run_check`, `github_get_check_status`, `github_get_check_logs`, `github_list_check_runs`. |

## Trade-offs honestos

| | GitHub Actions (este PR) | E2B (original) |
|---|---|---|
| Costo | $0 (free tier 2,000 min/mes) | ~$0.001/seg |
| Setup | 1-2 horas (este PR) | 1 día |
| Cold start | 30-60s | 1-2s |
| Logs en V | Sí, vía API | Sí, en proceso |
| Interactive | No (batch) | Sí (REPL-like) |
| Multi-repo | Sí, V instala el workflow donde quiera | Sí |

## Para que funcione en otros repos

vForge ya trae el workflow. Para que V valide en otro repo (ej. rivones, breack), V puede crearlo ahí con `github_create_file` apuntando a `.github/workflows/v-sandbox.yml` con el contenido de este PR. Una sola vez por repo.

## Lo que NO incluye

- Sin nuevas migrations
- Sin cambios al routing / agent_config / skills / subagents
- Sin tools de Actions write (re-run, cancel) — solo dispatch + read
- Sin auto-retry inteligente — V decide qué hacer si falla

## Test plan

- [x] `tsc --noEmit` pasa
- [x] Workflow file válido (sintaxis YAML simple)
- [ ] CI build + lint
- [ ] Vercel preview build
- [ ] Smoke E2E: pedirle a V en producción *"V, dispara una validación contra la rama main de vforge"* → debe llamar `github_run_check`, poll `github_get_check_status`, reportar conclusion=success.

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_