### PR TITLE
feat(forge): V accede al catálogo completo de OpenRouter (365+ modelos)

### DIFF
--- a/lib/forge/agent-config.ts
+++ b/lib/forge/agent-config.ts
@@ -16,6 +16,7 @@
  */
 import { sql } from "@/lib/db/client";
 import { MODELS, normalizeSlug, type TaskKind } from "./models";
+import { isValidOpenRouterSlug } from "./openrouter-catalog";
 
 interface ConfigRow {
   task_kind: TaskKind;
@@ -76,11 +77,22 @@ export async function setModelForTask(
   }
   const normalized = normalizeSlug(model);
   const isKnown = !!MODELS[normalized];
-  const looksLikeSlug = normalized.includes("/");
-  if (!isKnown && !looksLikeSlug) {
-    throw new Error(
-      `Model '${model}' doesn't look like a valid OpenRouter slug. Expected something like 'anthropic/claude-haiku-4.5' or 'google/gemini-2.5-flash'.`,
-    );
+  if (!isKnown) {
+    // Not in the curated registry — confirm it exists in OpenRouter's
+    // live catalog. This lets V pick any of the 365+ models OpenRouter
+    // exposes (free or paid) without code changes.
+    const looksLikeSlug = normalized.includes("/");
+    if (!looksLikeSlug) {
+      throw new Error(
+        `Model '${model}' doesn't look like a slug (expected 'provider/model-name').`,
+      );
+    }
+    const valid = await isValidOpenRouterSlug(normalized).catch(() => false);
+    if (!valid) {
+      throw new Error(
+        `Model '${normalized}' not found in OpenRouter catalog. Use openrouter_search_models to find a valid slug.`,
+      );
+    }
   }
   const updatedBy = options.updatedBy ?? "operator_luis";
   const rows = (await sql`

--- a/lib/forge/agent-config.ts
+++ b/lib/forge/agent-config.ts
@@ -78,19 +78,32 @@ export async function setModelForTask(
   const normalized = normalizeSlug(model);
   const isKnown = !!MODELS[normalized];
   if (!isKnown) {
-    // Not in the curated registry — confirm it exists in OpenRouter's
-    // live catalog. This lets V pick any of the 365+ models OpenRouter
-    // exposes (free or paid) without code changes.
     const looksLikeSlug = normalized.includes("/");
     if (!looksLikeSlug) {
       throw new Error(
         `Model '${model}' doesn't look like a slug (expected 'provider/model-name').`,
       );
     }
-    const valid = await isValidOpenRouterSlug(normalized).catch(() => false);
-    if (!valid) {
-      throw new Error(
-        `Model '${normalized}' not found in OpenRouter catalog. Use openrouter_search_models to find a valid slug.`,
+    // Confirm against the OpenRouter live catalog. Distinguish a real
+    // "not found" from a transient catalog error: if OR is unreachable
+    // (network blip, rate limit, outage), we accept the write rather
+    // than block a legitimate slug — runtime fallback will catch a
+    // truly bad slug via 4xx on the next chat turn (Codex P1).
+    try {
+      const found = await isValidOpenRouterSlug(normalized);
+      if (!found) {
+        throw new Error(
+          `Model '${normalized}' not found in OpenRouter catalog. Use openrouter_search_models to find a valid slug.`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // The "not found" branch above rethrows our own message verbatim;
+      // anything else is a catalog-side failure we shouldn't punish.
+      if (msg.startsWith("Model '")) throw err;
+      // Best-effort: log and proceed.
+      console.warn(
+        `[agent-config] OpenRouter catalog unreachable while validating '${normalized}': ${msg}. Proceeding optimistically.`,
       );
     }
   }

--- a/lib/forge/openrouter-catalog.ts
+++ b/lib/forge/openrouter-catalog.ts
@@ -26,12 +26,21 @@ export interface OpenRouterModel {
   name: string;
   description?: string;
   context_length?: number;
-  /** USD per token, NOT per 1M. */
+  /** USD per token (or per-unit for non-token fields). */
   pricing: {
     prompt: number;
     completion: number;
+    /** Per-request flat fee (some providers charge a request fee). */
+    request: number;
+    /** Per-image fee for vision models. */
+    image: number;
+    /** Per web-search call (for browsing-enabled models). */
+    web_search: number;
+    /** Per-token surcharge for internal reasoning chains. */
+    internal_reasoning: number;
   };
   supports_tools: boolean;
+  /** True only if EVERY pricing component is 0 — not just prompt+completion. */
   is_free: boolean;
   /** ex. 'anthropic', 'google', 'meta-llama', 'openai', ... */
   provider: string;
@@ -63,23 +72,50 @@ async function fetchFromOpenRouter(): Promise<Map<string, OpenRouterModel>> {
     name?: string;
     description?: string;
     context_length?: number;
-    pricing?: { prompt?: string | number; completion?: string | number };
+    pricing?: {
+      prompt?: string | number;
+      completion?: string | number;
+      request?: string | number;
+      image?: string | number;
+      web_search?: string | number;
+      internal_reasoning?: string | number;
+    };
     supported_parameters?: string[];
     architecture?: { modality?: string; instruct_type?: string };
   }
   const json = (await resp.json()) as { data: RawModel[] };
   const map = new Map<string, OpenRouterModel>();
+  // Helper: any pricing field can arrive as string or number. Coerce
+  // to number and treat NaN as 0. Negative impossible, but clamp.
+  const num = (v: unknown): number => {
+    const n = Number(v ?? 0);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  };
   for (const m of json.data ?? []) {
-    const promptCost = Number(m.pricing?.prompt ?? 0) || 0;
-    const completionCost = Number(m.pricing?.completion ?? 0) || 0;
+    const pricing = {
+      prompt: num(m.pricing?.prompt),
+      completion: num(m.pricing?.completion),
+      request: num(m.pricing?.request),
+      image: num(m.pricing?.image),
+      web_search: num(m.pricing?.web_search),
+      internal_reasoning: num(m.pricing?.internal_reasoning),
+    };
+    // is_free must consider ALL pricing fields — not just prompt+completion.
+    // A model with $0 tokens but $0.01 per-request is NOT free (Codex P2).
+    const isFree =
+      pricing.prompt === 0 &&
+      pricing.completion === 0 &&
+      pricing.request === 0 &&
+      pricing.image === 0 &&
+      pricing.web_search === 0 &&
+      pricing.internal_reasoning === 0;
     const supportsTools = (m.supported_parameters ?? []).includes("tools");
-    const isFree = promptCost === 0 && completionCost === 0;
     map.set(m.id, {
       id: m.id,
       name: m.name ?? m.id,
       description: m.description,
       context_length: m.context_length,
-      pricing: { prompt: promptCost, completion: completionCost },
+      pricing,
       supports_tools: supportsTools,
       is_free: isFree,
       provider: deriveProvider(m.id),
@@ -178,13 +214,16 @@ export async function searchOpenRouterModels(
         m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q),
     );
   }
-  // Cheapest first by default.
-  arr.sort(
-    (a, b) =>
-      a.pricing.prompt * 1_000_000 +
-      a.pricing.completion * 1_000_000 -
-      (b.pricing.prompt * 1_000_000 + b.pricing.completion * 1_000_000),
-  );
+  // Cheapest first by default. Sum per-1M-token cost + a flat-fee
+  // surcharge so a model with $0 tokens but $0.01/request doesn't
+  // sort ahead of a genuinely cheap one (Codex P2).
+  const totalUnitCost = (m: OpenRouterModel): number =>
+    m.pricing.prompt * 1_000_000 +
+    m.pricing.completion * 1_000_000 +
+    // Amortize per-request: assume ~1 call per "unit". This is a sort
+    // heuristic only; estimateCostFromCatalog computes the real number.
+    m.pricing.request * 1_000_000;
+  arr.sort((a, b) => totalUnitCost(a) - totalUnitCost(b));
   const limit = filter.limit ?? 25;
   if (limit > 0) arr = arr.slice(0, limit);
   return arr;
@@ -202,8 +241,13 @@ export async function estimateCostFromCatalog(
 ): Promise<number | null> {
   const model = await getOpenRouterModel(slug);
   if (!model) return null;
+  // Per-token + per-request fees. Image / web_search apply only when
+  // those features are used and aren't counted here (V's chat-main
+  // call neither attaches images nor browses inside this code path).
   const cost =
-    tokensIn * model.pricing.prompt + tokensOut * model.pricing.completion;
+    tokensIn * model.pricing.prompt +
+    tokensOut * model.pricing.completion +
+    model.pricing.request;
   return Number(cost.toFixed(6));
 }
 

--- a/lib/forge/openrouter-catalog.ts
+++ b/lib/forge/openrouter-catalog.ts
@@ -1,0 +1,218 @@
+/**
+ * Live catalog of every model OpenRouter exposes.
+ *
+ * The hand-curated MODELS map in lib/forge/models.ts is intentionally
+ * small (9 entries) — it's the "preferred" set the router knows how
+ * to reason about. But OpenRouter serves 365+ models and V should be
+ * free to pick any of them. This module fetches the full catalog at
+ * runtime, caches it for 15 min, and exposes search + pricing helpers.
+ *
+ * Tools that expose this to V:
+ *   - openrouter_list_models   → top N models by recency / by group
+ *   - openrouter_get_model     → full info for one slug
+ *   - openrouter_search_models → filter by free, tools, ctx, etc.
+ *
+ * Used internally by:
+ *   - agent_config_set       → validate slugs against the live catalog
+ *   - estimateCostForModel   → dynamic pricing for unknown slugs
+ */
+import { getOperatorSecret } from "@/lib/vault/get-secret";
+
+const ENDPOINT = "https://openrouter.ai/api/v1/models";
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+export interface OpenRouterModel {
+  id: string;
+  name: string;
+  description?: string;
+  context_length?: number;
+  /** USD per token, NOT per 1M. */
+  pricing: {
+    prompt: number;
+    completion: number;
+  };
+  supports_tools: boolean;
+  is_free: boolean;
+  /** ex. 'anthropic', 'google', 'meta-llama', 'openai', ... */
+  provider: string;
+  /** ex. 'instruct', 'chat', 'coder', 'thinking', ... */
+  modality?: string;
+  raw?: unknown;
+}
+
+let CACHE: { models: Map<string, OpenRouterModel>; fetchedAt: number } | null = null;
+
+function deriveProvider(id: string): string {
+  const slash = id.indexOf("/");
+  return slash > 0 ? id.slice(0, slash) : "unknown";
+}
+
+async function fetchFromOpenRouter(): Promise<Map<string, OpenRouterModel>> {
+  const apiKey = await getOperatorSecret("OPENROUTER_API_KEY", {
+    auditUserId: "or-catalog",
+  });
+  const headers: Record<string, string> = {};
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const resp = await fetch(ENDPOINT, { headers });
+  if (!resp.ok) {
+    throw new Error(`OpenRouter /models returned ${resp.status}`);
+  }
+  interface RawModel {
+    id: string;
+    name?: string;
+    description?: string;
+    context_length?: number;
+    pricing?: { prompt?: string | number; completion?: string | number };
+    supported_parameters?: string[];
+    architecture?: { modality?: string; instruct_type?: string };
+  }
+  const json = (await resp.json()) as { data: RawModel[] };
+  const map = new Map<string, OpenRouterModel>();
+  for (const m of json.data ?? []) {
+    const promptCost = Number(m.pricing?.prompt ?? 0) || 0;
+    const completionCost = Number(m.pricing?.completion ?? 0) || 0;
+    const supportsTools = (m.supported_parameters ?? []).includes("tools");
+    const isFree = promptCost === 0 && completionCost === 0;
+    map.set(m.id, {
+      id: m.id,
+      name: m.name ?? m.id,
+      description: m.description,
+      context_length: m.context_length,
+      pricing: { prompt: promptCost, completion: completionCost },
+      supports_tools: supportsTools,
+      is_free: isFree,
+      provider: deriveProvider(m.id),
+      modality: m.architecture?.instruct_type ?? m.architecture?.modality,
+    });
+  }
+  return map;
+}
+
+async function loadCatalog(): Promise<Map<string, OpenRouterModel>> {
+  if (CACHE && CACHE.fetchedAt + CACHE_TTL_MS > Date.now()) {
+    return CACHE.models;
+  }
+  const models = await fetchFromOpenRouter();
+  CACHE = { models, fetchedAt: Date.now() };
+  return models;
+}
+
+export function invalidateCatalogCache(): void {
+  CACHE = null;
+}
+
+/**
+ * Return every model OpenRouter exposes, optionally limited or
+ * provider-filtered. Pass limit=0 for the full list.
+ */
+export async function listAllOpenRouterModels(options: {
+  limit?: number;
+  provider?: string;
+} = {}): Promise<OpenRouterModel[]> {
+  const catalog = await loadCatalog();
+  let arr = Array.from(catalog.values());
+  if (options.provider) {
+    const p = options.provider.toLowerCase();
+    arr = arr.filter((m) => m.provider.toLowerCase() === p);
+  }
+  const limit = options.limit ?? 50;
+  if (limit > 0) arr = arr.slice(0, limit);
+  return arr;
+}
+
+export async function getOpenRouterModel(
+  slug: string,
+): Promise<OpenRouterModel | null> {
+  const catalog = await loadCatalog();
+  return catalog.get(slug) ?? null;
+}
+
+/**
+ * Filter the catalog. Useful for V to find "all free models with tool
+ * support" or "cheapest model > 100K context", etc.
+ */
+export interface ModelFilter {
+  free?: boolean;
+  supports_tools?: boolean;
+  min_context?: number;
+  max_cost_per_1m_in?: number;
+  max_cost_per_1m_out?: number;
+  provider?: string;
+  /** Substring match on id or name. */
+  query?: string;
+  limit?: number;
+}
+
+export async function searchOpenRouterModels(
+  filter: ModelFilter,
+): Promise<OpenRouterModel[]> {
+  const catalog = await loadCatalog();
+  let arr = Array.from(catalog.values());
+  if (filter.free === true) arr = arr.filter((m) => m.is_free);
+  if (filter.free === false) arr = arr.filter((m) => !m.is_free);
+  if (filter.supports_tools !== undefined) {
+    arr = arr.filter((m) => m.supports_tools === filter.supports_tools);
+  }
+  if (filter.min_context && filter.min_context > 0) {
+    const min = filter.min_context;
+    arr = arr.filter((m) => (m.context_length ?? 0) >= min);
+  }
+  if (filter.max_cost_per_1m_in !== undefined) {
+    // pricing.prompt is per-token; convert to per-1M.
+    const max = filter.max_cost_per_1m_in;
+    arr = arr.filter((m) => m.pricing.prompt * 1_000_000 <= max);
+  }
+  if (filter.max_cost_per_1m_out !== undefined) {
+    const max = filter.max_cost_per_1m_out;
+    arr = arr.filter((m) => m.pricing.completion * 1_000_000 <= max);
+  }
+  if (filter.provider) {
+    const p = filter.provider.toLowerCase();
+    arr = arr.filter((m) => m.provider.toLowerCase() === p);
+  }
+  if (filter.query) {
+    const q = filter.query.toLowerCase();
+    arr = arr.filter(
+      (m) =>
+        m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q),
+    );
+  }
+  // Cheapest first by default.
+  arr.sort(
+    (a, b) =>
+      a.pricing.prompt * 1_000_000 +
+      a.pricing.completion * 1_000_000 -
+      (b.pricing.prompt * 1_000_000 + b.pricing.completion * 1_000_000),
+  );
+  const limit = filter.limit ?? 25;
+  if (limit > 0) arr = arr.slice(0, limit);
+  return arr;
+}
+
+/**
+ * Dynamic cost estimation for ANY OR slug, even ones not in the
+ * hand-curated MODELS map. Used as a fallback by estimateCostForModel
+ * in lib/forge/models.ts.
+ */
+export async function estimateCostFromCatalog(
+  slug: string,
+  tokensIn: number,
+  tokensOut: number,
+): Promise<number | null> {
+  const model = await getOpenRouterModel(slug);
+  if (!model) return null;
+  const cost =
+    tokensIn * model.pricing.prompt + tokensOut * model.pricing.completion;
+  return Number(cost.toFixed(6));
+}
+
+/**
+ * Quick check: does this slug exist in OpenRouter right now?
+ * Used by agent_config_set so V is only blocked when she invents
+ * a slug that genuinely isn't routable.
+ */
+export async function isValidOpenRouterSlug(slug: string): Promise<boolean> {
+  const catalog = await loadCatalog();
+  return catalog.has(slug);
+}

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -56,6 +56,11 @@ import { invalidateSecretCache } from "@/lib/vault/get-secret";
 import { routeFor } from "@/lib/forge/routing";
 import { MODELS } from "@/lib/forge/models";
 import { listAgentConfig, setModelForTask } from "@/lib/forge/agent-config";
+import {
+  listAllOpenRouterModels,
+  getOpenRouterModel,
+  searchOpenRouterModels,
+} from "@/lib/forge/openrouter-catalog";
 
 export const TOOLS: Tool[] = [
   {
@@ -867,6 +872,59 @@ export const TOOLS: Tool[] = [
         per_page: { type: "number", description: "1-30, default 10." },
       },
       required: ["repo"],
+    },
+  },
+
+  // ─── OpenRouter catálogo en vivo (365+ modelos) ───────────────────
+  {
+    name: "openrouter_list_models",
+    description:
+      "Lista modelos disponibles en OpenRouter en vivo (cache 15 min). Útil para descubrir qué modelos hay sin estar limitada al registry hardcoded de 9. Devuelve { id, name, provider, context_length, pricing_per_1m, supports_tools, is_free } por modelo. Default: 50 modelos. Pasa provider='anthropic' o 'google' para filtrar.",
+    input_schema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "number",
+          description: "Cuántos modelos devolver. 0 = todos (~365). Default 50.",
+        },
+        provider: {
+          type: "string",
+          description: "Filtrar por provider (ej. 'anthropic', 'google', 'meta-llama', 'openai', 'deepseek', 'mistralai').",
+        },
+      },
+    },
+  },
+  {
+    name: "openrouter_get_model",
+    description:
+      "Detalle completo de un modelo de OpenRouter por slug. Devuelve descripción, context_length, pricing exacto, supports_tools, is_free. Úsala antes de agent_config_set para confirmar que el slug existe y ver costos reales.",
+    input_schema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          description: "OpenRouter slug (ej. 'deepseek/deepseek-chat', 'anthropic/claude-haiku-4.5').",
+        },
+      },
+      required: ["slug"],
+    },
+  },
+  {
+    name: "openrouter_search_models",
+    description:
+      "Busca modelos en OpenRouter por filtros: free, supports_tools, min_context, max_cost_per_1m_in, max_cost_per_1m_out, provider, query (substring). Ordenado por más barato primero. Úsala para encontrar 'el más barato con tools y context > 100K' o 'todos los free de Google'.",
+    input_schema: {
+      type: "object",
+      properties: {
+        free: { type: "boolean", description: "true = solo gratis; false = solo de paga; omit = todos." },
+        supports_tools: { type: "boolean", description: "true = solo modelos que soportan tool calling." },
+        min_context: { type: "number", description: "Tokens mínimos de contexto (ej. 100000)." },
+        max_cost_per_1m_in: { type: "number", description: "USD máximo por 1M tokens de input." },
+        max_cost_per_1m_out: { type: "number", description: "USD máximo por 1M tokens de output." },
+        provider: { type: "string", description: "Filtrar por provider." },
+        query: { type: "string", description: "Substring en id o name (ej. 'haiku', 'flash')." },
+        limit: { type: "number", description: "Default 25." },
+      },
     },
   },
 
@@ -2195,6 +2253,99 @@ async function dispatch(
           runs,
         }),
         summary: `${runs.length} runs de v-sandbox en ${owner}/${repo}${branch ? "#" + branch : ""}`,
+      };
+    }
+
+    // ─── OpenRouter catálogo en vivo ───────────────────────────────
+    case "openrouter_list_models": {
+      const limit =
+        typeof input.limit === "number" ? input.limit : 50;
+      const provider =
+        typeof input.provider === "string" && input.provider.length > 0
+          ? input.provider
+          : undefined;
+      const models = await listAllOpenRouterModels({ limit, provider });
+      return {
+        ok: true,
+        content: JSON.stringify({
+          total: models.length,
+          models: models.map((m) => ({
+            id: m.id,
+            name: m.name,
+            provider: m.provider,
+            context_length: m.context_length,
+            pricing_per_1m_in: Number((m.pricing.prompt * 1_000_000).toFixed(4)),
+            pricing_per_1m_out: Number((m.pricing.completion * 1_000_000).toFixed(4)),
+            supports_tools: m.supports_tools,
+            is_free: m.is_free,
+          })),
+        }),
+        summary: `${models.length} modelos${provider ? ` de ${provider}` : ""}`,
+      };
+    }
+    case "openrouter_get_model": {
+      const slug = requireString(input.slug, "slug");
+      const model = await getOpenRouterModel(slug);
+      if (!model) {
+        return {
+          ok: false,
+          content: JSON.stringify({
+            error: `Slug '${slug}' no existe en OpenRouter.`,
+          }),
+          summary: `slug '${slug}' no encontrado`,
+        };
+      }
+      return {
+        ok: true,
+        content: JSON.stringify({
+          id: model.id,
+          name: model.name,
+          description: model.description,
+          provider: model.provider,
+          context_length: model.context_length,
+          pricing_per_1m_in: Number((model.pricing.prompt * 1_000_000).toFixed(6)),
+          pricing_per_1m_out: Number((model.pricing.completion * 1_000_000).toFixed(6)),
+          supports_tools: model.supports_tools,
+          is_free: model.is_free,
+          modality: model.modality,
+        }),
+        summary: `${model.id}${model.is_free ? " (free)" : ""}`,
+      };
+    }
+    case "openrouter_search_models": {
+      const filter: Record<string, unknown> = {};
+      if (typeof input.free === "boolean") filter.free = input.free;
+      if (typeof input.supports_tools === "boolean")
+        filter.supports_tools = input.supports_tools;
+      if (typeof input.min_context === "number")
+        filter.min_context = input.min_context;
+      if (typeof input.max_cost_per_1m_in === "number")
+        filter.max_cost_per_1m_in = input.max_cost_per_1m_in;
+      if (typeof input.max_cost_per_1m_out === "number")
+        filter.max_cost_per_1m_out = input.max_cost_per_1m_out;
+      if (typeof input.provider === "string" && input.provider.length > 0)
+        filter.provider = input.provider;
+      if (typeof input.query === "string" && input.query.length > 0)
+        filter.query = input.query;
+      if (typeof input.limit === "number") filter.limit = input.limit;
+      const models = await searchOpenRouterModels(filter);
+      return {
+        ok: true,
+        content: JSON.stringify({
+          total: models.length,
+          filter,
+          models: models.map((m) => ({
+            id: m.id,
+            name: m.name,
+            provider: m.provider,
+            context_length: m.context_length,
+            pricing_per_1m_in: Number((m.pricing.prompt * 1_000_000).toFixed(4)),
+            pricing_per_1m_out: Number((m.pricing.completion * 1_000_000).toFixed(4)),
+            supports_tools: m.supports_tools,
+            is_free: m.is_free,
+          })),
+        }),
+        summary: `${models.length} matches`,
       };
     }
 


### PR DESCRIPTION
## Qué hace

Antes V solo podía elegir uno de los 9 modelos del registry hand-curated. Ahora puede ver, buscar y usar **cualquiera de los 365+ modelos** que OpenRouter expone — y crece automáticamente conforme OR agrega proveedores nuevos, sin tocar código.

## Cambios

| Archivo | Qué |
|---|---|
| `lib/forge/openrouter-catalog.ts` (nuevo, +218) | Catálogo en vivo del endpoint `/api/v1/models` con cache 15 min. Funciones: `listAllOpenRouterModels`, `getOpenRouterModel`, `searchOpenRouterModels`, `estimateCostFromCatalog`, `isValidOpenRouterSlug`. |
| `lib/forge/agent-config.ts` (modificado) | `setModelForTask` ya no rechaza slugs fuera del registry. Si no está hard-coded, consulta el catálogo en vivo y acepta si existe. Solo rechaza si formato no parece slug o si OR no lo conoce. |
| `lib/forge/tools.ts` (+151) | 3 tools nuevas Ring 0: `openrouter_list_models`, `openrouter_get_model`, `openrouter_search_models`. |

## Casos de uso que ahora desbloquea

**1. V descubre modelos sin estar limitada al subset:**
> *"V, qué modelos gratis con tool calling tienen contexto > 200K"*
→ `openrouter_search_models({free:true, supports_tools:true, min_context:200000})`

**2. V cambia a CUALQUIER modelo del catálogo:**
> *"V, usa `z-ai/glm-4.6` para clasificación"*
→ `agent_config_set("classification", "z-ai/glm-4.6")` → valida en vivo contra OR → acepta

**3. V se entera de modelos nuevos automáticamente:**
Cuando OR agrega un proveedor (ej. próximo Llama 4), V lo ve en `openrouter_list_models` sin redeploy.

**4. Pricing exacto, no estimado:**
> *"V, dame el costo real de Gemini 2.5 Pro vs Sonnet"*
→ `openrouter_get_model` por cada uno → pricing directo de OR

## Lo que NO incluye

- Sin migrations (cero cambio a DB)
- Sin cambio al routing fallback automático del PR #28
- Sin cambio al sistema de subagents
- Sin tocar el endpoint `/api/forge/run`

## Test plan

- [x] `tsc --noEmit` pasa
- [ ] CI build + lint
- [ ] Vercel preview build
- [ ] Smoke E2E en producción: *"V, dame los 5 modelos más baratos con tool support"* → debe invocar `openrouter_search_models` y reportar slugs reales con pricing.

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_