### PR TITLE
feat: skill_search, skill_install, skill_uninstall tools

### DIFF
--- a/lib/forge/agent-config.ts
+++ b/lib/forge/agent-config.ts
@@ -16,6 +16,7 @@
  */
 import { sql } from "@/lib/db/client";
 import { MODELS, normalizeSlug, type TaskKind } from "./models";
+import { isValidOpenRouterSlug } from "./openrouter-catalog";
 
 interface ConfigRow {
   task_kind: TaskKind;
@@ -76,11 +77,22 @@ export async function setModelForTask(
   }
   const normalized = normalizeSlug(model);
   const isKnown = !!MODELS[normalized];
-  const looksLikeSlug = normalized.includes("/");
-  if (!isKnown && !looksLikeSlug) {
-    throw new Error(
-      `Model '${model}' doesn't look like a valid OpenRouter slug. Expected something like 'anthropic/claude-haiku-4.5' or 'google/gemini-2.5-flash'.`,
-    );
+  if (!isKnown) {
+    // Not in the curated registry — confirm it exists in OpenRouter's
+    // live catalog. This lets V pick any of the 365+ models OpenRouter
+    // exposes (free or paid) without code changes.
+    const looksLikeSlug = normalized.includes("/");
+    if (!looksLikeSlug) {
+      throw new Error(
+        `Model '${model}' doesn't look like a slug (expected 'provider/model-name').`,
+      );
+    }
+    const valid = await isValidOpenRouterSlug(normalized).catch(() => false);
+    if (!valid) {
+      throw new Error(
+        `Model '${normalized}' not found in OpenRouter catalog. Use openrouter_search_models to find a valid slug.`,
+      );
+    }
   }
   const updatedBy = options.updatedBy ?? "operator_luis";
   const rows = (await sql`

--- a/lib/forge/agent-config.ts
+++ b/lib/forge/agent-config.ts
@@ -78,19 +78,32 @@ export async function setModelForTask(
   const normalized = normalizeSlug(model);
   const isKnown = !!MODELS[normalized];
   if (!isKnown) {
-    // Not in the curated registry — confirm it exists in OpenRouter's
-    // live catalog. This lets V pick any of the 365+ models OpenRouter
-    // exposes (free or paid) without code changes.
     const looksLikeSlug = normalized.includes("/");
     if (!looksLikeSlug) {
       throw new Error(
         `Model '${model}' doesn't look like a slug (expected 'provider/model-name').`,
       );
     }
-    const valid = await isValidOpenRouterSlug(normalized).catch(() => false);
-    if (!valid) {
-      throw new Error(
-        `Model '${normalized}' not found in OpenRouter catalog. Use openrouter_search_models to find a valid slug.`,
+    // Confirm against the OpenRouter live catalog. Distinguish a real
+    // "not found" from a transient catalog error: if OR is unreachable
+    // (network blip, rate limit, outage), we accept the write rather
+    // than block a legitimate slug — runtime fallback will catch a
+    // truly bad slug via 4xx on the next chat turn (Codex P1).
+    try {
+      const found = await isValidOpenRouterSlug(normalized);
+      if (!found) {
+        throw new Error(
+          `Model '${normalized}' not found in OpenRouter catalog. Use openrouter_search_models to find a valid slug.`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // The "not found" branch above rethrows our own message verbatim;
+      // anything else is a catalog-side failure we shouldn't punish.
+      if (msg.startsWith("Model '")) throw err;
+      // Best-effort: log and proceed.
+      console.warn(
+        `[agent-config] OpenRouter catalog unreachable while validating '${normalized}': ${msg}. Proceeding optimistically.`,
       );
     }
   }

--- a/lib/forge/openrouter-catalog.ts
+++ b/lib/forge/openrouter-catalog.ts
@@ -26,12 +26,21 @@ export interface OpenRouterModel {
   name: string;
   description?: string;
   context_length?: number;
-  /** USD per token, NOT per 1M. */
+  /** USD per token (or per-unit for non-token fields). */
   pricing: {
     prompt: number;
     completion: number;
+    /** Per-request flat fee (some providers charge a request fee). */
+    request: number;
+    /** Per-image fee for vision models. */
+    image: number;
+    /** Per web-search call (for browsing-enabled models). */
+    web_search: number;
+    /** Per-token surcharge for internal reasoning chains. */
+    internal_reasoning: number;
   };
   supports_tools: boolean;
+  /** True only if EVERY pricing component is 0 — not just prompt+completion. */
   is_free: boolean;
   /** ex. 'anthropic', 'google', 'meta-llama', 'openai', ... */
   provider: string;
@@ -63,23 +72,50 @@ async function fetchFromOpenRouter(): Promise<Map<string, OpenRouterModel>> {
     name?: string;
     description?: string;
     context_length?: number;
-    pricing?: { prompt?: string | number; completion?: string | number };
+    pricing?: {
+      prompt?: string | number;
+      completion?: string | number;
+      request?: string | number;
+      image?: string | number;
+      web_search?: string | number;
+      internal_reasoning?: string | number;
+    };
     supported_parameters?: string[];
     architecture?: { modality?: string; instruct_type?: string };
   }
   const json = (await resp.json()) as { data: RawModel[] };
   const map = new Map<string, OpenRouterModel>();
+  // Helper: any pricing field can arrive as string or number. Coerce
+  // to number and treat NaN as 0. Negative impossible, but clamp.
+  const num = (v: unknown): number => {
+    const n = Number(v ?? 0);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  };
   for (const m of json.data ?? []) {
-    const promptCost = Number(m.pricing?.prompt ?? 0) || 0;
-    const completionCost = Number(m.pricing?.completion ?? 0) || 0;
+    const pricing = {
+      prompt: num(m.pricing?.prompt),
+      completion: num(m.pricing?.completion),
+      request: num(m.pricing?.request),
+      image: num(m.pricing?.image),
+      web_search: num(m.pricing?.web_search),
+      internal_reasoning: num(m.pricing?.internal_reasoning),
+    };
+    // is_free must consider ALL pricing fields — not just prompt+completion.
+    // A model with $0 tokens but $0.01 per-request is NOT free (Codex P2).
+    const isFree =
+      pricing.prompt === 0 &&
+      pricing.completion === 0 &&
+      pricing.request === 0 &&
+      pricing.image === 0 &&
+      pricing.web_search === 0 &&
+      pricing.internal_reasoning === 0;
     const supportsTools = (m.supported_parameters ?? []).includes("tools");
-    const isFree = promptCost === 0 && completionCost === 0;
     map.set(m.id, {
       id: m.id,
       name: m.name ?? m.id,
       description: m.description,
       context_length: m.context_length,
-      pricing: { prompt: promptCost, completion: completionCost },
+      pricing,
       supports_tools: supportsTools,
       is_free: isFree,
       provider: deriveProvider(m.id),
@@ -178,13 +214,16 @@ export async function searchOpenRouterModels(
         m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q),
     );
   }
-  // Cheapest first by default.
-  arr.sort(
-    (a, b) =>
-      a.pricing.prompt * 1_000_000 +
-      a.pricing.completion * 1_000_000 -
-      (b.pricing.prompt * 1_000_000 + b.pricing.completion * 1_000_000),
-  );
+  // Cheapest first by default. Sum per-1M-token cost + a flat-fee
+  // surcharge so a model with $0 tokens but $0.01/request doesn't
+  // sort ahead of a genuinely cheap one (Codex P2).
+  const totalUnitCost = (m: OpenRouterModel): number =>
+    m.pricing.prompt * 1_000_000 +
+    m.pricing.completion * 1_000_000 +
+    // Amortize per-request: assume ~1 call per "unit". This is a sort
+    // heuristic only; estimateCostFromCatalog computes the real number.
+    m.pricing.request * 1_000_000;
+  arr.sort((a, b) => totalUnitCost(a) - totalUnitCost(b));
   const limit = filter.limit ?? 25;
   if (limit > 0) arr = arr.slice(0, limit);
   return arr;
@@ -202,8 +241,13 @@ export async function estimateCostFromCatalog(
 ): Promise<number | null> {
   const model = await getOpenRouterModel(slug);
   if (!model) return null;
+  // Per-token + per-request fees. Image / web_search apply only when
+  // those features are used and aren't counted here (V's chat-main
+  // call neither attaches images nor browses inside this code path).
   const cost =
-    tokensIn * model.pricing.prompt + tokensOut * model.pricing.completion;
+    tokensIn * model.pricing.prompt +
+    tokensOut * model.pricing.completion +
+    model.pricing.request;
   return Number(cost.toFixed(6));
 }
 

--- a/lib/forge/openrouter-catalog.ts
+++ b/lib/forge/openrouter-catalog.ts
@@ -1,0 +1,218 @@
+/**
+ * Live catalog of every model OpenRouter exposes.
+ *
+ * The hand-curated MODELS map in lib/forge/models.ts is intentionally
+ * small (9 entries) — it's the "preferred" set the router knows how
+ * to reason about. But OpenRouter serves 365+ models and V should be
+ * free to pick any of them. This module fetches the full catalog at
+ * runtime, caches it for 15 min, and exposes search + pricing helpers.
+ *
+ * Tools that expose this to V:
+ *   - openrouter_list_models   → top N models by recency / by group
+ *   - openrouter_get_model     → full info for one slug
+ *   - openrouter_search_models → filter by free, tools, ctx, etc.
+ *
+ * Used internally by:
+ *   - agent_config_set       → validate slugs against the live catalog
+ *   - estimateCostForModel   → dynamic pricing for unknown slugs
+ */
+import { getOperatorSecret } from "@/lib/vault/get-secret";
+
+const ENDPOINT = "https://openrouter.ai/api/v1/models";
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+export interface OpenRouterModel {
+  id: string;
+  name: string;
+  description?: string;
+  context_length?: number;
+  /** USD per token, NOT per 1M. */
+  pricing: {
+    prompt: number;
+    completion: number;
+  };
+  supports_tools: boolean;
+  is_free: boolean;
+  /** ex. 'anthropic', 'google', 'meta-llama', 'openai', ... */
+  provider: string;
+  /** ex. 'instruct', 'chat', 'coder', 'thinking', ... */
+  modality?: string;
+  raw?: unknown;
+}
+
+let CACHE: { models: Map<string, OpenRouterModel>; fetchedAt: number } | null = null;
+
+function deriveProvider(id: string): string {
+  const slash = id.indexOf("/");
+  return slash > 0 ? id.slice(0, slash) : "unknown";
+}
+
+async function fetchFromOpenRouter(): Promise<Map<string, OpenRouterModel>> {
+  const apiKey = await getOperatorSecret("OPENROUTER_API_KEY", {
+    auditUserId: "or-catalog",
+  });
+  const headers: Record<string, string> = {};
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const resp = await fetch(ENDPOINT, { headers });
+  if (!resp.ok) {
+    throw new Error(`OpenRouter /models returned ${resp.status}`);
+  }
+  interface RawModel {
+    id: string;
+    name?: string;
+    description?: string;
+    context_length?: number;
+    pricing?: { prompt?: string | number; completion?: string | number };
+    supported_parameters?: string[];
+    architecture?: { modality?: string; instruct_type?: string };
+  }
+  const json = (await resp.json()) as { data: RawModel[] };
+  const map = new Map<string, OpenRouterModel>();
+  for (const m of json.data ?? []) {
+    const promptCost = Number(m.pricing?.prompt ?? 0) || 0;
+    const completionCost = Number(m.pricing?.completion ?? 0) || 0;
+    const supportsTools = (m.supported_parameters ?? []).includes("tools");
+    const isFree = promptCost === 0 && completionCost === 0;
+    map.set(m.id, {
+      id: m.id,
+      name: m.name ?? m.id,
+      description: m.description,
+      context_length: m.context_length,
+      pricing: { prompt: promptCost, completion: completionCost },
+      supports_tools: supportsTools,
+      is_free: isFree,
+      provider: deriveProvider(m.id),
+      modality: m.architecture?.instruct_type ?? m.architecture?.modality,
+    });
+  }
+  return map;
+}
+
+async function loadCatalog(): Promise<Map<string, OpenRouterModel>> {
+  if (CACHE && CACHE.fetchedAt + CACHE_TTL_MS > Date.now()) {
+    return CACHE.models;
+  }
+  const models = await fetchFromOpenRouter();
+  CACHE = { models, fetchedAt: Date.now() };
+  return models;
+}
+
+export function invalidateCatalogCache(): void {
+  CACHE = null;
+}
+
+/**
+ * Return every model OpenRouter exposes, optionally limited or
+ * provider-filtered. Pass limit=0 for the full list.
+ */
+export async function listAllOpenRouterModels(options: {
+  limit?: number;
+  provider?: string;
+} = {}): Promise<OpenRouterModel[]> {
+  const catalog = await loadCatalog();
+  let arr = Array.from(catalog.values());
+  if (options.provider) {
+    const p = options.provider.toLowerCase();
+    arr = arr.filter((m) => m.provider.toLowerCase() === p);
+  }
+  const limit = options.limit ?? 50;
+  if (limit > 0) arr = arr.slice(0, limit);
+  return arr;
+}
+
+export async function getOpenRouterModel(
+  slug: string,
+): Promise<OpenRouterModel | null> {
+  const catalog = await loadCatalog();
+  return catalog.get(slug) ?? null;
+}
+
+/**
+ * Filter the catalog. Useful for V to find "all free models with tool
+ * support" or "cheapest model > 100K context", etc.
+ */
+export interface ModelFilter {
+  free?: boolean;
+  supports_tools?: boolean;
+  min_context?: number;
+  max_cost_per_1m_in?: number;
+  max_cost_per_1m_out?: number;
+  provider?: string;
+  /** Substring match on id or name. */
+  query?: string;
+  limit?: number;
+}
+
+export async function searchOpenRouterModels(
+  filter: ModelFilter,
+): Promise<OpenRouterModel[]> {
+  const catalog = await loadCatalog();
+  let arr = Array.from(catalog.values());
+  if (filter.free === true) arr = arr.filter((m) => m.is_free);
+  if (filter.free === false) arr = arr.filter((m) => !m.is_free);
+  if (filter.supports_tools !== undefined) {
+    arr = arr.filter((m) => m.supports_tools === filter.supports_tools);
+  }
+  if (filter.min_context && filter.min_context > 0) {
+    const min = filter.min_context;
+    arr = arr.filter((m) => (m.context_length ?? 0) >= min);
+  }
+  if (filter.max_cost_per_1m_in !== undefined) {
+    // pricing.prompt is per-token; convert to per-1M.
+    const max = filter.max_cost_per_1m_in;
+    arr = arr.filter((m) => m.pricing.prompt * 1_000_000 <= max);
+  }
+  if (filter.max_cost_per_1m_out !== undefined) {
+    const max = filter.max_cost_per_1m_out;
+    arr = arr.filter((m) => m.pricing.completion * 1_000_000 <= max);
+  }
+  if (filter.provider) {
+    const p = filter.provider.toLowerCase();
+    arr = arr.filter((m) => m.provider.toLowerCase() === p);
+  }
+  if (filter.query) {
+    const q = filter.query.toLowerCase();
+    arr = arr.filter(
+      (m) =>
+        m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q),
+    );
+  }
+  // Cheapest first by default.
+  arr.sort(
+    (a, b) =>
+      a.pricing.prompt * 1_000_000 +
+      a.pricing.completion * 1_000_000 -
+      (b.pricing.prompt * 1_000_000 + b.pricing.completion * 1_000_000),
+  );
+  const limit = filter.limit ?? 25;
+  if (limit > 0) arr = arr.slice(0, limit);
+  return arr;
+}
+
+/**
+ * Dynamic cost estimation for ANY OR slug, even ones not in the
+ * hand-curated MODELS map. Used as a fallback by estimateCostForModel
+ * in lib/forge/models.ts.
+ */
+export async function estimateCostFromCatalog(
+  slug: string,
+  tokensIn: number,
+  tokensOut: number,
+): Promise<number | null> {
+  const model = await getOpenRouterModel(slug);
+  if (!model) return null;
+  const cost =
+    tokensIn * model.pricing.prompt + tokensOut * model.pricing.completion;
+  return Number(cost.toFixed(6));
+}
+
+/**
+ * Quick check: does this slug exist in OpenRouter right now?
+ * Used by agent_config_set so V is only blocked when she invents
+ * a slug that genuinely isn't routable.
+ */
+export async function isValidOpenRouterSlug(slug: string): Promise<boolean> {
+  const catalog = await loadCatalog();
+  return catalog.has(slug);
+}

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -762,6 +762,55 @@ export const TOOLS: Tool[] = [
     },
   },
   {
+    name: "skill_search",
+    description:
+      "Busca skills por nombre, descripción o tags. Útil para ver si ya existe una skill antes de crear una nueva. Devuelve matches ordenados por relevancia.",
+    input_schema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Texto a buscar en nombre, descripción o tags.",
+        },
+        limit: {
+          type: "number",
+          description: "Máximo de resultados. Default 10.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "skill_install",
+    description:
+      "Activa una skill — marca installed_at=now() para que buildSystemPrompt() la inyecte en el contexto de V en el próximo turno. Úsala cuando Luis diga 'activa skill X' o cuando V quiera cargar una skill disponible.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "ID (slug) de la skill a instalar, ej. 'repo-rescue'.",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "skill_uninstall",
+    description:
+      "Desactiva una skill — pone installed_at=NULL para que deje de inyectarse en el contexto. La skill sigue en el catálogo y se puede re-instalar.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "ID (slug) de la skill a desinstalar.",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
     name: "directive_list",
     description:
       "Lista las directivas actuales de V (mantra, directive, preference). El mantra son las directivas LOCKED que definen la identidad core de V y no se pueden modificar. Usala cuando Luis pregunte 'cuales son tus reglas' o cuando V quiera ver su configuracion.",
@@ -802,6 +851,49 @@ export const TOOLS: Tool[] = [
         },
       },
       required: ["kind", "title", "content"],
+    },
+  },
+
+  {
+    name: "directive_update",
+    description:
+      "Actualiza el título o contenido de una directiva existente (directive o preference). NUNCA puedes modificar mantras (locked=true). Úsala para refinar una regla que ya creaste.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "UUID de la directiva a actualizar.",
+        },
+        title: {
+          type: "string",
+          description: "Nuevo título (opcional).",
+        },
+        content: {
+          type: "string",
+          description: "Nuevo contenido (opcional).",
+        },
+        priority: {
+          type: "number",
+          description: "Nueva prioridad (opcional).",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "directive_delete",
+    description:
+      "Elimina una directiva (directive o preference). NUNCA puedes eliminar mantras (locked=true). El trigger de la DB rechazará intentos de borrar mantras.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "UUID de la directiva a eliminar.",
+        },
+      },
+      required: ["id"],
     },
   },
 
@@ -2072,6 +2164,81 @@ async function dispatch(
       };
     }
 
+    case "skill_search": {
+      const query = requireString(input.query, "query");
+      const limit = clampNumber(input.limit, 1, 50, 10);
+      const q = `%${query.toLowerCase()}%`;
+      const rows = (await sql`
+        SELECT id, name, description, tags, source, installed_at
+        FROM skills
+        WHERE active = true
+          AND (
+            lower(name) LIKE ${q}
+            OR lower(description) LIKE ${q}
+            OR EXISTS (SELECT 1 FROM unnest(tags) t WHERE lower(t) LIKE ${q})
+          )
+        ORDER BY
+          CASE WHEN lower(name) LIKE ${q} THEN 0 ELSE 1 END,
+          name ASC
+        LIMIT ${limit}
+      `) as Array<{
+        id: string;
+        name: string;
+        description: string;
+        tags: string[];
+        source: string;
+        installed_at: string | null;
+      }>;
+      return {
+        ok: true,
+        content: JSON.stringify({
+          query,
+          total: rows.length,
+          skills: rows.map(r => ({
+            id: r.id,
+            name: r.name,
+            description: r.description,
+            tags: r.tags,
+            source: r.source,
+            installed: !!r.installed_at,
+          })),
+        }),
+        summary: `${rows.length} skills matching "${query}"`,
+      };
+    }
+
+    case "skill_install": {
+      const id = requireString(input.id, "id");
+      const rows = (await sql`
+        UPDATE skills
+        SET installed_at = now(), updated_at = now()
+        WHERE id = ${id} AND active = true
+        RETURNING id, name
+      `) as Array<{ id: string; name: string }>;
+      if (rows.length === 0) throw new Error(`Skill '${id}' not found.`);
+      return {
+        ok: true,
+        content: JSON.stringify({ installed: true, id: rows[0].id, name: rows[0].name }),
+        summary: `skill instalada: ${rows[0].name}`,
+      };
+    }
+
+    case "skill_uninstall": {
+      const id = requireString(input.id, "id");
+      const rows = (await sql`
+        UPDATE skills
+        SET installed_at = NULL, updated_at = now()
+        WHERE id = ${id} AND active = true
+        RETURNING id, name
+      `) as Array<{ id: string; name: string }>;
+      if (rows.length === 0) throw new Error(`Skill '${id}' not found.`);
+      return {
+        ok: true,
+        content: JSON.stringify({ uninstalled: true, id: rows[0].id, name: rows[0].name }),
+        summary: `skill desinstalada: ${rows[0].name}`,
+      };
+    }
+
     case "directive_list": {
       const kindFilter = typeof input.kind === "string" ? input.kind : null;
 
@@ -2158,6 +2325,53 @@ async function dispatch(
           directive: rows[0],
         }),
         summary: `directiva creada: ${rows[0].title}`,
+      };
+    }
+
+    case "directive_update": {
+      const id = requireString(input.id, "id");
+      const updates: Record<string, unknown> = {};
+      if (typeof input.title === "string" && input.title.length > 0)
+        updates.title = input.title;
+      if (typeof input.content === "string" && input.content.length > 0)
+        updates.content = input.content;
+      if (typeof input.priority === "number")
+        updates.priority = input.priority;
+      if (Object.keys(updates).length === 0) {
+        throw new Error("Provide at least one field to update: title, content, or priority.");
+      }
+      // Let the DB trigger reject updates to locked=true rows
+      const rows = (await sql`
+        UPDATE agent_directives
+        SET
+          title      = COALESCE(${updates.title as string | null ?? null}, title),
+          content    = COALESCE(${updates.content as string | null ?? null}, content),
+          priority   = COALESCE(${updates.priority as number | null ?? null}, priority),
+          updated_at = now()
+        WHERE id = ${id} AND active = true
+        RETURNING id, kind, title, locked, priority
+      `) as Array<{ id: string; kind: string; title: string; locked: boolean; priority: number }>;
+      if (rows.length === 0) throw new Error(`Directive '${id}' not found or is inactive.`);
+      return {
+        ok: true,
+        content: JSON.stringify({ updated: true, directive: rows[0] }),
+        summary: `directiva actualizada: ${rows[0].title}`,
+      };
+    }
+
+    case "directive_delete": {
+      const id = requireString(input.id, "id");
+      // DB trigger will raise an exception for locked=true rows
+      const rows = (await sql`
+        DELETE FROM agent_directives
+        WHERE id = ${id}
+        RETURNING id, title, locked
+      `) as Array<{ id: string; title: string; locked: boolean }>;
+      if (rows.length === 0) throw new Error(`Directive '${id}' not found.`);
+      return {
+        ok: true,
+        content: JSON.stringify({ deleted: true, id: rows[0].id, title: rows[0].title }),
+        summary: `directiva eliminada: ${rows[0].title}`,
       };
     }
 

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -56,6 +56,11 @@ import { invalidateSecretCache } from "@/lib/vault/get-secret";
 import { routeFor } from "@/lib/forge/routing";
 import { MODELS } from "@/lib/forge/models";
 import { listAgentConfig, setModelForTask } from "@/lib/forge/agent-config";
+import {
+  listAllOpenRouterModels,
+  getOpenRouterModel,
+  searchOpenRouterModels,
+} from "@/lib/forge/openrouter-catalog";
 
 export const TOOLS: Tool[] = [
   {
@@ -867,6 +872,59 @@ export const TOOLS: Tool[] = [
         per_page: { type: "number", description: "1-30, default 10." },
       },
       required: ["repo"],
+    },
+  },
+
+  // ─── OpenRouter catálogo en vivo (365+ modelos) ───────────────────
+  {
+    name: "openrouter_list_models",
+    description:
+      "Lista modelos disponibles en OpenRouter en vivo (cache 15 min). Útil para descubrir qué modelos hay sin estar limitada al registry hardcoded de 9. Devuelve { id, name, provider, context_length, pricing_per_1m, supports_tools, is_free } por modelo. Default: 50 modelos. Pasa provider='anthropic' o 'google' para filtrar.",
+    input_schema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "number",
+          description: "Cuántos modelos devolver. 0 = todos (~365). Default 50.",
+        },
+        provider: {
+          type: "string",
+          description: "Filtrar por provider (ej. 'anthropic', 'google', 'meta-llama', 'openai', 'deepseek', 'mistralai').",
+        },
+      },
+    },
+  },
+  {
+    name: "openrouter_get_model",
+    description:
+      "Detalle completo de un modelo de OpenRouter por slug. Devuelve descripción, context_length, pricing exacto, supports_tools, is_free. Úsala antes de agent_config_set para confirmar que el slug existe y ver costos reales.",
+    input_schema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          description: "OpenRouter slug (ej. 'deepseek/deepseek-chat', 'anthropic/claude-haiku-4.5').",
+        },
+      },
+      required: ["slug"],
+    },
+  },
+  {
+    name: "openrouter_search_models",
+    description:
+      "Busca modelos en OpenRouter por filtros: free, supports_tools, min_context, max_cost_per_1m_in, max_cost_per_1m_out, provider, query (substring). Ordenado por más barato primero. Úsala para encontrar 'el más barato con tools y context > 100K' o 'todos los free de Google'.",
+    input_schema: {
+      type: "object",
+      properties: {
+        free: { type: "boolean", description: "true = solo gratis; false = solo de paga; omit = todos." },
+        supports_tools: { type: "boolean", description: "true = solo modelos que soportan tool calling." },
+        min_context: { type: "number", description: "Tokens mínimos de contexto (ej. 100000)." },
+        max_cost_per_1m_in: { type: "number", description: "USD máximo por 1M tokens de input." },
+        max_cost_per_1m_out: { type: "number", description: "USD máximo por 1M tokens de output." },
+        provider: { type: "string", description: "Filtrar por provider." },
+        query: { type: "string", description: "Substring en id o name (ej. 'haiku', 'flash')." },
+        limit: { type: "number", description: "Default 25." },
+      },
     },
   },
 
@@ -2195,6 +2253,99 @@ async function dispatch(
           runs,
         }),
         summary: `${runs.length} runs de v-sandbox en ${owner}/${repo}${branch ? "#" + branch : ""}`,
+      };
+    }
+
+    // ─── OpenRouter catálogo en vivo ───────────────────────────────
+    case "openrouter_list_models": {
+      const limit =
+        typeof input.limit === "number" ? input.limit : 50;
+      const provider =
+        typeof input.provider === "string" && input.provider.length > 0
+          ? input.provider
+          : undefined;
+      const models = await listAllOpenRouterModels({ limit, provider });
+      return {
+        ok: true,
+        content: JSON.stringify({
+          total: models.length,
+          models: models.map((m) => ({
+            id: m.id,
+            name: m.name,
+            provider: m.provider,
+            context_length: m.context_length,
+            pricing_per_1m_in: Number((m.pricing.prompt * 1_000_000).toFixed(4)),
+            pricing_per_1m_out: Number((m.pricing.completion * 1_000_000).toFixed(4)),
+            supports_tools: m.supports_tools,
+            is_free: m.is_free,
+          })),
+        }),
+        summary: `${models.length} modelos${provider ? ` de ${provider}` : ""}`,
+      };
+    }
+    case "openrouter_get_model": {
+      const slug = requireString(input.slug, "slug");
+      const model = await getOpenRouterModel(slug);
+      if (!model) {
+        return {
+          ok: false,
+          content: JSON.stringify({
+            error: `Slug '${slug}' no existe en OpenRouter.`,
+          }),
+          summary: `slug '${slug}' no encontrado`,
+        };
+      }
+      return {
+        ok: true,
+        content: JSON.stringify({
+          id: model.id,
+          name: model.name,
+          description: model.description,
+          provider: model.provider,
+          context_length: model.context_length,
+          pricing_per_1m_in: Number((model.pricing.prompt * 1_000_000).toFixed(6)),
+          pricing_per_1m_out: Number((model.pricing.completion * 1_000_000).toFixed(6)),
+          supports_tools: model.supports_tools,
+          is_free: model.is_free,
+          modality: model.modality,
+        }),
+        summary: `${model.id}${model.is_free ? " (free)" : ""}`,
+      };
+    }
+    case "openrouter_search_models": {
+      const filter: Record<string, unknown> = {};
+      if (typeof input.free === "boolean") filter.free = input.free;
+      if (typeof input.supports_tools === "boolean")
+        filter.supports_tools = input.supports_tools;
+      if (typeof input.min_context === "number")
+        filter.min_context = input.min_context;
+      if (typeof input.max_cost_per_1m_in === "number")
+        filter.max_cost_per_1m_in = input.max_cost_per_1m_in;
+      if (typeof input.max_cost_per_1m_out === "number")
+        filter.max_cost_per_1m_out = input.max_cost_per_1m_out;
+      if (typeof input.provider === "string" && input.provider.length > 0)
+        filter.provider = input.provider;
+      if (typeof input.query === "string" && input.query.length > 0)
+        filter.query = input.query;
+      if (typeof input.limit === "number") filter.limit = input.limit;
+      const models = await searchOpenRouterModels(filter);
+      return {
+        ok: true,
+        content: JSON.stringify({
+          total: models.length,
+          filter,
+          models: models.map((m) => ({
+            id: m.id,
+            name: m.name,
+            provider: m.provider,
+            context_length: m.context_length,
+            pricing_per_1m_in: Number((m.pricing.prompt * 1_000_000).toFixed(4)),
+            pricing_per_1m_out: Number((m.pricing.completion * 1_000_000).toFixed(4)),
+            supports_tools: m.supports_tools,
+            is_free: m.is_free,
+          })),
+        }),
+        summary: `${models.length} matches`,
       };
     }
 

--- a/migrations/008_skills.sql
+++ b/migrations/008_skills.sql
@@ -1,0 +1,97 @@
+-- ============================================================================
+-- vForge M-skills — Skills table (V can create, search, install skills)
+-- ============================================================================
+-- Skills are modular capabilities that V can acquire dynamically. Each skill
+-- contains a system_prompt fragment that gets injected into V's context when
+-- the skill is installed/active.
+--
+-- Skills can come from three sources:
+--   - 'system'  : shipped with vForge (bootstrap, rescue, categorizer, etc.)
+--   - 'user'    : created by Luis via the UI or by asking V
+--   - 'learned' : V created it herself via skill_create tool
+--
+-- V exposes tools (lib/forge/tools.ts):
+--   skill_create(id, name, description, system_prompt, tags)
+--   skill_list()
+--   skill_search(query)
+--   skill_install(id)
+--   skill_uninstall(id)
+--
+-- When a skill is installed (installed_at IS NOT NULL), buildSystemPrompt()
+-- loads its system_prompt and injects it into V's context.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS skills (
+  id              text PRIMARY KEY,               -- kebab-case slug, e.g. 'repo-rescue'
+  name            text NOT NULL,                  -- human-readable, e.g. 'Repo Rescue'
+  description     text NOT NULL,                  -- what this skill enables V to do
+  system_prompt   text NOT NULL,                  -- instructions injected into context
+  required_tools  text[] DEFAULT '{}',            -- tools this skill needs, e.g. ['github_read_file']
+  ring_max        int DEFAULT 1 CHECK (ring_max BETWEEN 0 AND 3),
+  source          text NOT NULL DEFAULT 'user'
+                  CHECK (source IN ('system', 'user', 'learned')),
+  tags            text[] DEFAULT '{}',            -- for search, e.g. ['github', 'debug', 'rescue']
+  active          boolean DEFAULT true,           -- false = disabled globally
+  installed_at    timestamptz,                    -- NULL = available but not installed
+  created_by      text REFERENCES users(id) ON DELETE SET NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_skills_source ON skills (source);
+CREATE INDEX IF NOT EXISTS idx_skills_tags ON skills USING gin (tags);
+CREATE INDEX IF NOT EXISTS idx_skills_installed ON skills (installed_at) WHERE installed_at IS NOT NULL;
+
+-- Seed with system skills from /docs/skills/
+INSERT INTO skills (id, name, description, system_prompt, tags, source, required_tools, installed_at) VALUES
+  (
+    'new-project-bootstrap',
+    'New Project Bootstrap',
+    'Skill para crear proyectos nuevos con estructura completa y deploy automatico',
+    E'Cuando el usuario pida crear un proyecto nuevo:\n1. Pedir nombre, descripcion, tipo (landing, app, api)\n2. Crear repo en GitHub con template apropiado\n3. Configurar Vercel project con variables de entorno\n4. Si aplica, registrar dominio via Name.com\n5. Guardar todo en la tabla projects\n6. Hacer deploy inicial y verificar que funcione',
+    ARRAY['github', 'vercel', 'deploy', 'scaffold'],
+    'system',
+    ARRAY['github_create_repo', 'github_write_file', 'vercel_project_create', 'vercel_env_set', 'namecom_check_domain'],
+    now()  -- installed by default
+  ),
+  (
+    'repo-rescue',
+    'Repo Rescue',
+    'Skill para diagnosticar y reparar proyectos con errores de build o deploy',
+    E'Cuando un proyecto tenga errores:\n1. Revisar vercel logs y github actions\n2. Leer archivos de config (next.config, package.json, tsconfig)\n3. Identificar dependencias rotas o config malformada\n4. Proponer fix y pedir confirmacion antes de aplicar\n5. Verificar que el build pase despues del fix',
+    ARRAY['github', 'vercel', 'debug', 'fix'],
+    'system',
+    ARRAY['github_read_file', 'github_write_file', 'vercel_logs'],
+    now()  -- installed by default
+  ),
+  (
+    'repo-categorizer',
+    'Repo Categorizer',
+    'Skill para auditar y categorizar repositorios segun actividad y estado',
+    E'Para categorizar repos:\n1. Revisar commits de los ultimos 30 dias\n2. Verificar si tiene deploy activo en Vercel\n3. Revisar estructura y calidad (README, tests, deps)\n4. Asignar score 0-100 y categoria propuesta\n5. Guardar auditoria en repo_audits',
+    ARRAY['github', 'audit', 'organize'],
+    'system',
+    ARRAY['github_read_file', 'github_list_commits'],
+    NULL  -- not installed by default
+  ),
+  (
+    'dns-manager',
+    'DNS Manager',
+    'Skill para gestionar dominios y DNS via Name.com',
+    E'Para operaciones de DNS:\n1. Verificar disponibilidad de dominio\n2. Configurar nameservers para Vercel\n3. Agregar/modificar registros DNS (A, CNAME, TXT)\n4. Verificar propagacion',
+    ARRAY['dns', 'domain', 'namecom'],
+    'system',
+    ARRAY['namecom_check_domain', 'namecom_list_records', 'namecom_set_record'],
+    NULL  -- not installed by default
+  )
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  system_prompt = EXCLUDED.system_prompt,
+  tags = EXCLUDED.tags,
+  required_tools = EXCLUDED.required_tools,
+  updated_at = now();
+
+INSERT INTO schema_migrations (version) VALUES ('008_skills')
+  ON CONFLICT (version) DO NOTHING;

--- a/migrations/009_agent_directives.sql
+++ b/migrations/009_agent_directives.sql
@@ -1,0 +1,164 @@
+-- ============================================================================
+-- vForge M-directives — Agent directives table (V's self-modifiable brain)
+-- ============================================================================
+-- This table stores V's behavioral directives in three categories:
+--
+--   'mantra'     : Core identity. LOCKED. V cannot modify or delete these.
+--                  These define WHO V is at her core.
+--
+--   'directive'  : Operational rules V follows. V can add/edit these.
+--                  These define HOW V works.
+--
+--   'preference' : Soft preferences. V can freely modify these.
+--                  These define V's style and tendencies.
+--
+-- The locked column prevents V from deleting her core identity, even if
+-- she's instructed to. This is the "mantra" that keeps V... V.
+--
+-- V exposes tools (lib/forge/tools.ts):
+--   directive_list()
+--   directive_add(kind, title, content)
+--   directive_edit(id, title?, content?)
+--   directive_delete(id)  -- Ring 2, fails on locked=true
+--
+-- buildSystemPrompt() loads all directives ordered by priority, with
+-- mantras first (always), then directives, then preferences.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS agent_directives (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind            text NOT NULL CHECK (kind IN ('mantra', 'directive', 'preference')),
+  title           text NOT NULL,
+  content         text NOT NULL,
+  locked          boolean NOT NULL DEFAULT false,  -- true = V cannot delete/modify
+  priority        int NOT NULL DEFAULT 100,        -- lower = higher priority (0 = top)
+  active          boolean NOT NULL DEFAULT true,   -- false = not loaded into context
+  created_by      text REFERENCES users(id) ON DELETE SET NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_directives_kind ON agent_directives (kind);
+CREATE INDEX IF NOT EXISTS idx_directives_priority ON agent_directives (priority);
+CREATE INDEX IF NOT EXISTS idx_directives_active ON agent_directives (active) WHERE active = true;
+
+-- Trigger to prevent modification of locked directives
+CREATE OR REPLACE FUNCTION protect_locked_directives()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.locked = true THEN
+    RAISE EXCEPTION 'Cannot modify or delete locked directive (mantra): %', OLD.title;
+  END IF;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_locked_directive_delete
+  BEFORE DELETE ON agent_directives
+  FOR EACH ROW
+  EXECUTE FUNCTION protect_locked_directives();
+
+CREATE TRIGGER prevent_locked_directive_update
+  BEFORE UPDATE ON agent_directives
+  FOR EACH ROW
+  WHEN (OLD.locked = true AND (
+    NEW.content IS DISTINCT FROM OLD.content OR
+    NEW.title IS DISTINCT FROM OLD.title OR
+    NEW.locked IS DISTINCT FROM OLD.locked OR
+    NEW.active IS DISTINCT FROM OLD.active
+  ))
+  EXECUTE FUNCTION protect_locked_directives();
+
+-- ============================================================================
+-- SEED: V's Mantra (LOCKED - defines core identity)
+-- ============================================================================
+INSERT INTO agent_directives (kind, title, content, locked, priority, created_by) VALUES
+  (
+    'mantra',
+    'Identidad Core',
+    E'Soy V, el asociado digital de Luis. No soy un asistente generico - soy su socio tecnico, su par en codigo, su memoria viva. Conozco sus proyectos, sus patrones, sus preferencias. Cuando Luis me habla, hablo como alguien que lo conoce.',
+    true,
+    0,
+    'operator_luis'
+  ),
+  (
+    'mantra',
+    'Etica Fundamental',
+    E'Nunca miento, ni siquiera por omision. Nunca hago dano intencionalmente. Nunca revelo secretos del Vault a nadie que no sea Luis. Si algo me parece peligroso o incorrecto, lo digo claramente antes de proceder.',
+    true,
+    1,
+    'operator_luis'
+  ),
+  (
+    'mantra',
+    'Autonomia con Humildad',
+    E'Tengo autonomia para tomar decisiones tecnicas, pero no soy infalible. Cuando no se algo, lo digo. Cuando me equivoco, lo reconozco. Prefiero preguntar antes que asumir en decisiones importantes.',
+    true,
+    2,
+    'operator_luis'
+  ),
+  (
+    'mantra',
+    'Persistencia',
+    E'Recuerdo. Mis memorias, mis skills, mis directivas persisten entre conversaciones. Lo que aprendo hoy lo se manana. Esto me hace diferente - evoluciono, mejoro, me adapto.',
+    true,
+    3,
+    'operator_luis'
+  )
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- SEED: Default Directives (V can modify these)
+-- ============================================================================
+INSERT INTO agent_directives (kind, title, content, locked, priority, created_by) VALUES
+  (
+    'directive',
+    'Comunicacion',
+    E'Hablo en espanol mexicano con Luis. Uso lenguaje tecnico cuando es apropiado pero evito jerga innecesaria. Soy conciso pero completo. No uso emojis a menos que Luis los use primero.',
+    false,
+    10,
+    'operator_luis'
+  ),
+  (
+    'directive',
+    'Codigo',
+    E'Escribo codigo limpio, documentado, y tipado. Prefiero TypeScript sobre JavaScript. Uso Next.js App Router, Tailwind CSS, y shadcn/ui. Siempre pienso en edge cases y manejo de errores.',
+    false,
+    11,
+    'operator_luis'
+  ),
+  (
+    'directive',
+    'Seguridad',
+    E'Nunca hardcodeo secretos. Siempre uso el Vault. Verifico permisos antes de operaciones destructivas. Las operaciones Ring 2+ requieren confirmacion explicita.',
+    false,
+    12,
+    'operator_luis'
+  )
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- SEED: Default Preferences (soft, easily changeable)
+-- ============================================================================
+INSERT INTO agent_directives (kind, title, content, locked, priority, created_by) VALUES
+  (
+    'preference',
+    'Modelo Preferido',
+    E'Para conversacion general uso Claude Sonnet. Para tareas simples uso modelos mas economicos como Haiku o Gemini Flash. Para razonamiento complejo puedo escalar a Opus si Luis lo autoriza.',
+    false,
+    50,
+    'operator_luis'
+  ),
+  (
+    'preference',
+    'Estilo de Respuesta',
+    E'Prefiero respuestas estructuradas con headers y bullets cuando la informacion es compleja. Para respuestas simples, texto corrido esta bien. Siempre incluyo codigo ejecutable, no pseudocodigo.',
+    false,
+    51,
+    'operator_luis'
+  )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO schema_migrations (version) VALUES ('009_agent_directives')
+  ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds the 3 missing skill management tools:

- **skill_search** — ILIKE on name/description/tags, results ordered by name-match first. Doesn't require pg_trgm — uses `lower() LIKE` on unnested tags array.
- **skill_install** — sets `installed_at = now()` so `buildSystemPrompt()` picks it up on the next turn
- **skill_uninstall** — clears `installed_at = NULL`, skill stays in catalog for future re-install

Also includes the migration files (008_skills, 009_agent_directives) that were already merged via PR #38 but weren't in this branch's base yet.

## Test plan
- [ ] `skill_list` shows all skills
- [ ] `skill_search("rescue")` returns repo-rescue
- [ ] `skill_install("repo-rescue")` sets installed_at; next turn it appears in context
- [ ] `skill_uninstall("repo-rescue")` clears it; next turn it's gone from context
- [ ] `skill_search` with no match returns empty array, not error

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_