### PR TITLE
fix: P1 — block ALL field updates on locked directives

### DIFF
--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -2216,7 +2216,9 @@ async function dispatch(
       if (Object.keys(updates).length === 0) {
         throw new Error("Provide at least one field to update: title, content, or priority.");
       }
-      // Let the DB trigger reject updates to locked=true rows
+      // Reject locked mantras at the application layer (belt) AND rely on the
+      // DB trigger (suspenders). The WHERE locked = false means 0 rows returned
+      // for a locked row, which we detect and turn into a clear error message.
       const rows = (await sql`
         UPDATE agent_directives
         SET
@@ -2224,10 +2226,19 @@ async function dispatch(
           content    = COALESCE(${updates.content as string | null ?? null}, content),
           priority   = COALESCE(${updates.priority as number | null ?? null}, priority),
           updated_at = now()
-        WHERE id = ${id} AND active = true
+        WHERE id = ${id} AND active = true AND locked = false
         RETURNING id, kind, title, locked, priority
       `) as Array<{ id: string; kind: string; title: string; locked: boolean; priority: number }>;
-      if (rows.length === 0) throw new Error(`Directive '${id}' not found or is inactive.`);
+      if (rows.length === 0) {
+        // Distinguish "not found" from "locked"
+        const check = (await sql`
+          SELECT id, locked FROM agent_directives WHERE id = ${id}
+        `) as Array<{ id: string; locked: boolean }>;
+        if (check.length > 0 && check[0].locked) {
+          throw new Error(`Cannot modify locked mantra '${id}'. Mantras are immutable.`);
+        }
+        throw new Error(`Directive '${id}' not found or is inactive.`);
+      }
       return {
         ok: true,
         content: JSON.stringify({ updated: true, directive: rows[0] }),

--- a/migrations/010_fix_locked_directive_trigger.sql
+++ b/migrations/010_fix_locked_directive_trigger.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- vForge fix: strengthen protect_locked_directives trigger
+--
+-- The original trigger in 009_agent_directives.sql only blocked changes to
+-- content/title/locked/active. A priority-only update could silently mutate
+-- a locked mantra's ordering. This migration replaces both triggers so that
+-- ANY field change on a locked=true row raises an exception.
+-- ============================================================================
+
+-- Drop the old triggers first (function stays, we replace the triggers)
+DROP TRIGGER IF EXISTS prevent_locked_directive_update ON agent_directives;
+DROP TRIGGER IF EXISTS prevent_locked_directive_delete ON agent_directives;
+DROP FUNCTION IF EXISTS protect_locked_directives();
+
+-- Recreate function — now fires on ANY update to a locked row
+CREATE OR REPLACE FUNCTION protect_locked_directives()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.locked = true THEN
+      RAISE EXCEPTION 'Cannot delete locked directive (mantra): %', OLD.title;
+    END IF;
+    RETURN OLD;
+  END IF;
+  -- UPDATE: block if the row was locked before the change
+  IF OLD.locked = true THEN
+    RAISE EXCEPTION 'Cannot modify locked directive (mantra): %', OLD.title;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate DELETE trigger
+CREATE TRIGGER prevent_locked_directive_delete
+  BEFORE DELETE ON agent_directives
+  FOR EACH ROW
+  EXECUTE FUNCTION protect_locked_directives();
+
+-- Recreate UPDATE trigger — no WHEN clause so it fires for every field change
+CREATE TRIGGER prevent_locked_directive_update
+  BEFORE UPDATE ON agent_directives
+  FOR EACH ROW
+  EXECUTE FUNCTION protect_locked_directives();
+
+INSERT INTO schema_migrations (version) VALUES ('010_fix_locked_directive_trigger')
+  ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
Fixes the trigger gap reported by Codex on PR #38: priority-only updates could silently mutate locked mantras. Belt+suspenders fix: migration 010 drops/recreates trigger without WHEN clause, directive_update adds AND locked=false to WHERE.

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_