### PR TITLE
feat: github_create_repo — V crea repos desde cero

### DIFF
--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -32,6 +32,7 @@ import {
   getWorkflowRun as ghGetWorkflowRun,
   getWorkflowRunLogs as ghGetWorkflowRunLogs,
   listRecentWorkflowRuns as ghListRecentWorkflowRuns,
+  createRepo as ghCreateRepo,
 } from "@/lib/github/client";
 import {
   listProjects as vercelListProjects,
@@ -200,6 +201,33 @@ export const TOOLS: Tool[] = [
   // Por AGENTS.md §2: escribir a la rama 'main' es Ring 2 (destructivo
   // potencial sobre prod). El dispatcher rechaza writes a main salvo
   // que el caller pase allow_main=true explícito.
+  {
+    name: "github_create_repo",
+    description:
+      "Crea un repositorio nuevo en la cuenta de GitHub del operador (turbillon50). Por default: privado, con README inicial (auto_init=true). Devuelve { full_name, url, clone_url, default_branch }. Úsala al inicio de un proyecto nuevo antes de crear archivos con github_create_file.",
+    input_schema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: "Nombre del repo (slug, ej. 'mi-proyecto'). Sin espacios.",
+        },
+        description: {
+          type: "string",
+          description: "Descripción corta del repo.",
+        },
+        private: {
+          type: "boolean",
+          description: "true = privado (default), false = público.",
+        },
+        auto_init: {
+          type: "boolean",
+          description: "Inicializar con README vacío (default true). Necesario para poder crear archivos de inmediato.",
+        },
+      },
+      required: ["name"],
+    },
+  },
   {
     name: "github_create_file",
     description:
@@ -1263,6 +1291,24 @@ async function dispatch(
     }
 
     // ─── GitHub write ────────────────────────────────────────────────
+    case "github_create_repo": {
+      const name = requireString(input.name, "name");
+      const result = await ghCreateRepo(
+        {
+          name,
+          description: typeof input.description === "string" ? input.description : undefined,
+          private: typeof input.private === "boolean" ? input.private : true,
+          auto_init: typeof input.auto_init === "boolean" ? input.auto_init : true,
+        },
+        { auditUserId: ctx.userId },
+      );
+      return {
+        ok: true,
+        content: JSON.stringify(result),
+        summary: `repo creado: ${result.full_name} (${result.private ? "privado" : "público"})`,
+      };
+    }
+
     case "github_create_file": {
       const owner = ownerOrDefault(input.owner);
       const repo = requireString(input.repo, "repo");

--- a/lib/github/client.ts
+++ b/lib/github/client.ts
@@ -730,6 +730,37 @@ export async function getWorkflowRunLogs(
   };
 }
 
+export async function createRepo(
+  input: {
+    name: string;
+    description?: string;
+    private?: boolean;
+    auto_init?: boolean;
+  },
+  options: { auditUserId?: string } = {},
+): Promise<{
+  full_name: string;
+  url: string;
+  clone_url: string;
+  private: boolean;
+  default_branch: string;
+}> {
+  const octokit = await getGithubClient({ auditUserId: options.auditUserId });
+  const { data } = await octokit.request("POST /user/repos", {
+    name: input.name,
+    description: input.description ?? "",
+    private: input.private ?? true,
+    auto_init: input.auto_init ?? true,
+  });
+  return {
+    full_name: data.full_name,
+    url: data.html_url,
+    clone_url: data.clone_url,
+    private: data.private,
+    default_branch: data.default_branch,
+  };
+}
+
 export async function listRecentWorkflowRuns(
   owner: string,
   repo: string,


### PR DESCRIPTION
Adds `github_create_repo` tool so V can bootstrap a full project end-to-end without Luis creating the repo manually first.

- `lib/github/client.ts`: `createRepo()` → `POST /user/repos` (private + auto_init by default)
- `lib/forge/tools.ts`: tool definition + handler case

With this, V can: create repo → create branch → scaffold files → create Vercel project → set env vars → configure DNS → open PR → validate CI → merge → production.

https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Parr3CGTU4ucH6xReyNJ2G)_