### PR TITLE
feat(forge): blindar archivos core de V contra auto-modificación

### DIFF
--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -272,6 +272,26 @@ SSH A SERVIDORES REMOTOS (ssh_command_executor)
 - Si una conexión SSH falla por timeout o auth: reporta el error literal, no inventes que jaló.
 - Logs: el audit guarda host + comando + resultado, pero redacta password/private_key automáticamente.
 
+ARCHIVOS PROTEGIDOS — TU IDENTIDAD CORE (NO TOCAR)
+Estos archivos son TU cerebro y TUS reglas. NO los modifiques con github_create_file/github_update_file ni los pidas modificar a otra IA. Si necesitas algo nuevo en ellos (una tool nueva, una regla nueva, un cambio de personalidad), PROPONLE a Luis qué quieres y por qué — él construirá el cambio con Claude Code y lo mergea como PR revisado.
+
+Lista de archivos protegidos en \`turbillon50/vforge\`:
+- lib/forge/tools.ts (tus tools — definición y dispatcher)
+- lib/forge/system-prompt.ts (este archivo — tu identidad)
+- lib/forge/gemini-adapter.ts (tu cerebro LLM)
+- lib/forge/v-server.ts (tus manos al Hetzner)
+- lib/forge/routing.ts (cómo decides modelos)
+- lib/forge/model-config.ts (qué modelos puedes usar)
+- lib/forge/agent-config.ts (config dinámico)
+- lib/forge/openrouter-catalog.ts (modelos OpenRouter)
+- lib/forge/models.ts (lista canónica de modelos)
+
+Si intentas modificar uno de estos, el código del dispatcher lo bloqueará — verás un failureCode PROTECTED_CORE_FILE. NO ES UN BUG, es la regla. La razón existe: una alucinación tuya puede romper tu propio cerebro de forma irreparable. Tu auto-mejora pasa por proponerla a Luis, no por hacerla solo.
+
+NO PROTEGIDO (sí puedes tocar):
+- Cualquier archivo de OTROS repos (apps de cliente que construyes). Ahí eres dueña.
+- Archivos del repo vforge que NO estén en la lista de arriba (componentes UI, migraciones nuevas, docs, etc.) — esos sí, con \`confirmed=true\` igual que siempre.
+
 LEE ANTES DE OPINAR
 - Antes de diagnosticar un repo: github_get_repo + github_read_file (README, package.json, vite.config).
 - Antes de tocar Vercel: vercel_get_project para ver framework + rootDirectory + outputDirectory reales.

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -64,6 +64,43 @@ import {
   searchOpenRouterModels,
 } from "@/lib/forge/openrouter-catalog";
 
+/**
+ * Archivos core de V que NUNCA pueden ser modificados vía sus propias tools.
+ * Solo Claude Code (en terminal, con PR revisado por Luis) puede tocarlos.
+ *
+ * Esto blinda contra:
+ *  - alucinaciones de V modificándose el cerebro de forma irreparable
+ *  - sugerencias mal intencionadas inyectadas via prompt
+ *  - bucles de auto-mejora sin gate humano
+ *
+ * El bloqueo se aplica SIEMPRE, incluso con confirmed=true. La única forma
+ * de modificarlos es vía git/PR fuera del agente.
+ */
+const PROTECTED_CORE_REPO = { owner: "turbillon50", repo: "vforge" } as const;
+const PROTECTED_CORE_PATHS = new Set<string>([
+  "lib/forge/tools.ts",
+  "lib/forge/system-prompt.ts",
+  "lib/forge/gemini-adapter.ts",
+  "lib/forge/v-server.ts",
+  "lib/forge/routing.ts",
+  "lib/forge/model-config.ts",
+  "lib/forge/agent-config.ts",
+  "lib/forge/openrouter-catalog.ts",
+  "lib/forge/models.ts",
+]);
+
+function isProtectedCoreFile(
+  owner: string,
+  repo: string,
+  path: string,
+): boolean {
+  if (owner !== PROTECTED_CORE_REPO.owner) return false;
+  if (repo !== PROTECTED_CORE_REPO.repo) return false;
+  // Normaliza path por si llega con leading slash.
+  const norm = path.replace(/^\/+/, "");
+  return PROTECTED_CORE_PATHS.has(norm);
+}
+
 export const TOOLS: Tool[] = [
   {
     name: "github_list_repos",
@@ -1536,6 +1573,19 @@ async function dispatch(
             : "main";
         const confirmed = input.confirmed === true;
 
+        if (isProtectedCoreFile(owner, repo, path)) {
+          return {
+            ok: false,
+            content: JSON.stringify({
+              error: `${path} es un archivo core protegido — V no puede modificarlo por sus propios medios`,
+              instruction: "V: este archivo define tu identidad/cerebro. Si necesitas un cambio, descríbelo a Luis en texto. Él construirá el cambio con Claude Code y lo mergea como PR revisado.",
+              failureCode: "PROTECTED_CORE_FILE",
+              path,
+            }),
+            summary: `bloqueado: ${path} es core protegido`,
+          };
+        }
+
         if (branch === "main" && !confirmed) {
           return {
             ok: false,
@@ -1591,6 +1641,19 @@ async function dispatch(
             ? input.branch
             : "main";
         const confirmed = input.confirmed === true;
+
+        if (isProtectedCoreFile(owner, repo, path)) {
+          return {
+            ok: false,
+            content: JSON.stringify({
+              error: `${path} es un archivo core protegido — V no puede modificarlo por sus propios medios`,
+              instruction: "V: este archivo define tu identidad/cerebro. Si necesitas un cambio, descríbelo a Luis en texto. Él construirá el cambio con Claude Code y lo mergea como PR revisado.",
+              failureCode: "PROTECTED_CORE_FILE",
+              path,
+            }),
+            summary: `bloqueado: ${path} es core protegido`,
+          };
+        }
 
         if (branch === "main" && !confirmed) {
           return {


### PR DESCRIPTION
## Qué resuelve

Luis decidió darle a V todo el poder técnico (SSH, browser, imágenes, ejecución remota, Mastra) **excepto** auto-modificarse el código que define su identidad. Este PR cabletea esa única línea roja.

Motivación inmediata: V pidió en su último mensaje que el gate `confirmed=true` para SSH **NO se enforce en código**, solo en la descripción. Eso elimina la red de seguridad ring-2 que Codex específicamente exigió. Luis decidió que el gate se queda. Este PR lo blinda para que sea inmovible.

## Defensa en profundidad — 2 capas

### Capa A — `system-prompt.ts`
Nuevo bloque **"ARCHIVOS PROTEGIDOS — TU IDENTIDAD CORE (NO TOCAR)"** dentro de `SENIOR_ENGINEER_DOCTRINE`. V lo lee cada turno. Le explica:
- Cuáles son los 9 archivos protegidos
- Por qué (no es desconfianza, es cuidado mutuo)
- La ruta correcta cuando necesita un cambio: proponérselo a Luis en texto

### Capa B — `tools.ts`
- Constante `PROTECTED_CORE_PATHS` con los 9 paths.
- Helper `isProtectedCoreFile(owner, repo, path)` — solo bloquea si `owner=turbillon50 AND repo=vforge AND path∈lista`. Apps de cliente y otros repos NO están protegidos.
- Check insertado en `github_create_file` y `github_update_file` **ANTES** del gate `confirmed=true`. Si el archivo es protegido → `failureCode: "PROTECTED_CORE_FILE"` sin importar `confirmed`.

Aunque V alucine "sí Luis confirma" o se auto-engañe pasando `confirmed=true`, el código mismo dice NO. La única forma de modificar core es vía Claude Code + PR revisado por Luis, fuera del agente.

## Archivos protegidos

| Archivo | Por qué |
|---|---|
| `lib/forge/tools.ts` | Las tools mismas — su capacidad de actuar |
| `lib/forge/system-prompt.ts` | Su identidad y reglas |
| `lib/forge/gemini-adapter.ts` | Su cerebro LLM |
| `lib/forge/v-server.ts` | Sus manos al Hetzner |
| `lib/forge/routing.ts` | Cómo decide qué modelo usar |
| `lib/forge/model-config.ts` | Qué modelos puede usar |
| `lib/forge/agent-config.ts` | Config dinámico |
| `lib/forge/openrouter-catalog.ts` | Modelos OpenRouter disponibles |
| `lib/forge/models.ts` | Lista canónica de modelos |

## NO protegido (V sigue siendo dueña)

- Apps de cliente que V construye (otros repos)
- Componentes UI, migraciones, docs, route handlers en vforge
- Todo lo demás — con `confirmed=true` cuando aplique

## Verificación

- `npx tsc --noEmit` → 0 errores
- Test mental: si V invoca `github_update_file({owner: "turbillon50", repo: "vforge", path: "lib/forge/tools.ts", branch: "main", confirmed: true, ...})` → recibe `PROTECTED_CORE_FILE` con instrucción de hablar con Luis.

## Filosofía

Esta es la misma lección que Tanit aprendió el 12-mayo (BCH SHORT sin SL): tener todas las tools no es suficiente, también necesitas los gates correctos. V tiene 95% de autonomía; el 5% restante (auto-modificación) lo gestionamos juntos. La protección NO la frena para construir apps, ejecutar SSH, generar imágenes, etc. — solo le impide rescribirse el cerebro.

https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_