### PR TITLE
fix(v): cablear chat real + calibrar input mobile + desatascar shell

### DIFF
--- a/app/(dashboard)/template.tsx
+++ b/app/(dashboard)/template.tsx
@@ -1,22 +1,8 @@
-"use client";
-
-import { motion } from "framer-motion";
-
+// Pass-through template. The page transition animation lives in
+// `components/vforge/app-shell.tsx` (the OS-style viewport). Running a
+// second motion layer here caused double-animation on every route change
+// — visibly janky on mobile and could leave pages stuck off-screen if
+// the spring was interrupted mid-flight.
 export default function Template({ children }: { children: React.ReactNode }) {
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 15, scale: 0.98 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{ opacity: 0, y: -15, scale: 0.98 }}
-      transition={{ 
-        type: "spring", 
-        stiffness: 300, 
-        damping: 30, 
-        mass: 1 
-      }}
-      className="h-full w-full"
-    >
-      {children}
-    </motion.div>
-  );
+  return <div className="h-full w-full">{children}</div>;
 }

--- a/components/V/ChatComposer.tsx
+++ b/components/V/ChatComposer.tsx
@@ -89,7 +89,9 @@ export const ChatComposer = ({
           <Paperclip size={20} />
         </motion.button>
 
-        {/* Textarea */}
+        {/* Textarea — mobile-tuned: 16px font prevents iOS zoom, touch-action
+            manipulation kills the 300ms tap delay, enterKeyHint promotes
+            "send" on the soft keyboard. */}
         <textarea
           ref={textareaRef}
           value={value}
@@ -99,14 +101,21 @@ export const ChatComposer = ({
           onKeyDown={handleKeyDown}
           disabled={isLoading}
           placeholder={placeholder}
+          autoComplete="off"
+          autoCorrect="on"
+          autoCapitalize="sentences"
+          spellCheck
+          enterKeyHint="send"
+          inputMode="text"
           className={cn(
             'flex-1 max-h-[200px] bg-transparent',
             'text-vf-fg-1 placeholder:text-vf-fg-3',
             'outline-none resize-none',
-            'font-normal text-sm leading-relaxed',
+            'font-normal leading-relaxed',
             'disabled:opacity-50 disabled:cursor-not-allowed',
             'scrollbar-thin scrollbar-thumb-vf-border scrollbar-track-transparent'
           )}
+          style={{ touchAction: 'manipulation', fontSize: 16 }}
           rows={1}
         />
 

--- a/components/V/ChatPage.tsx
+++ b/components/V/ChatPage.tsx
@@ -1,44 +1,157 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { ChatContainer, Message } from './ChatContainer';
 import { ChatComposer } from './ChatComposer';
+
+const SESSION_KEY = 'v_chat_session_id';
+
+function getOrCreateSessionId(): string {
+  if (typeof window === 'undefined') return `v_${Date.now()}`;
+  let id = window.localStorage.getItem(SESSION_KEY);
+  if (!id) {
+    id = `v_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    try {
+      window.localStorage.setItem(SESSION_KEY, id);
+    } catch {
+      // localStorage may be unavailable (private mode, quota); fall back
+      // to an in-memory id for this tab.
+    }
+  }
+  return id;
+}
+
+type SSEEvent =
+  | { type: 'text'; value: string }
+  | { type: 'tool_use_start'; id: string; name: string }
+  | { type: 'tool_use_result'; id: string; ok: boolean; summary: string }
+  | { type: 'model_fallback'; from: string; to: string; status: number | null; reason: string }
+  | { type: 'done'; tokensIn: number; tokensOut: number; model: string }
+  | { type: 'error'; message: string };
 
 export const ChatPage = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const sessionIdRef = useRef<string>(`v_${Date.now()}`);
+  const abortRef = useRef<AbortController | null>(null);
+  const messagesRef = useRef<Message[]>(messages);
 
-  const handleSubmit = useCallback(
-    async (content: string) => {
-      // Add user message
-      const userMessage: Message = {
-        id: `user-${Date.now()}`,
-        role: 'user',
-        content,
-        timestamp: new Date(),
-      };
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
-      setMessages((prev) => [...prev, userMessage]);
-      setIsLoading(true);
+  useEffect(() => {
+    sessionIdRef.current = getOrCreateSessionId();
+    const ctrl = abortRef;
+    return () => {
+      ctrl.current?.abort();
+    };
+  }, []);
 
-      // Simulate V response (replace with actual API call)
-      setTimeout(() => {
-        const vMessage: Message = {
-          id: `v-${Date.now()}`,
-          role: 'v',
-          content: `## Entendido\n\nRecibí tu mensaje:\n\n> "${content}"\n\n**Status:** 🟢 Activa y funcionando\n\n- ✅ Conectada a bases de datos\n- ✅ Skills listos\n- ✅ Esperando instrucciones\n\nEsta es V hablando contigo de forma elegante, sin verbosidad innecesaria.`,
-          timestamp: new Date(),
-        };
+  const handleSubmit = useCallback(async (content: string) => {
+    const userMessage: Message = {
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content,
+      timestamp: new Date(),
+    };
+    const assistantId = `v-${Date.now()}`;
+    const assistantMessage: Message = {
+      id: assistantId,
+      role: 'v',
+      content: '',
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
+    setIsLoading(true);
 
-        setMessages((prev) => [...prev, vMessage]);
-        setIsLoading(false);
-      }, 1500);
-    },
-    []
-  );
+    const history = messagesRef.current.map((m) => ({
+      role: m.role === 'v' ? ('assistant' as const) : ('user' as const),
+      content: m.content,
+    }));
+    history.push({ role: 'user', content });
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch('/api/forge/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: history,
+          sessionId: sessionIdRef.current,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        const err = await res.text().catch(() => '');
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, content: `⚠ Error del servidor (${res.status}): ${err.slice(0, 200)}` }
+              : m,
+          ),
+        );
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const evt = JSON.parse(line.slice(6)) as SSEEvent;
+            if (evt.type === 'text') {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + evt.value }
+                    : m,
+                ),
+              );
+            } else if (evt.type === 'error') {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + `\n\n⚠ ${evt.message}` }
+                    : m,
+                ),
+              );
+            }
+            // tool_use_start / tool_use_result / model_fallback / done
+            // are not surfaced in this minimal UI — text is what carries
+            // V's voice. The /forge route renders the full tool ribbon.
+          } catch {
+            // skip malformed event
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      const msg = err instanceof Error ? err.message : String(err);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId ? { ...m, content: `⚠ Error de red: ${msg}` } : m,
+        ),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   return (
-    <div className="flex flex-col h-screen bg-vf-bg-0">
+    <div className="flex flex-col h-full bg-vf-bg-0">
       <ChatContainer messages={messages} isLoading={isLoading} className="flex-1" />
       <ChatComposer onSubmit={handleSubmit} isLoading={isLoading} />
     </div>

--- a/components/V/MultichatDrawer.tsx
+++ b/components/V/MultichatDrawer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { motion, AnimatePresence } from "framer-motion";
-import { MessageSquare, X, Send, Sparkles, Database, Github, Cpu } from "lucide-react";
-import { useState, useRef, useEffect } from "react";
+import { X, Send, Database, Github, Cpu } from "lucide-react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils";
 
 interface Message {
@@ -17,91 +17,202 @@ interface MultichatDrawerProps {
   onClose: () => void;
 }
 
-// Custom Web Audio API mechanical sound for keyboard & neural pops
-const playNeuralSound = (type = "pop") => {
+// Singleton AudioContext, lazily created on first user gesture.
+// Creating one per keystroke (the previous behaviour) caused visible
+// input lag on mobile because AudioContext init is heavy and iOS
+// aggressively suspends contexts. We only "pop" on send now.
+let sharedAudioCtx: AudioContext | null = null;
+const playPop = () => {
   if (typeof window === "undefined") return;
   try {
-    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    if (!sharedAudioCtx) {
+      const AC = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!AC) return;
+      sharedAudioCtx = new AC();
+    }
+    const ctx = sharedAudioCtx;
+    if (ctx.state === "suspended") void ctx.resume();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     osc.connect(gain);
     gain.connect(ctx.destination);
-
-    if (type === "pop") {
-      osc.type = "sine";
-      osc.frequency.setValueAtTime(400, ctx.currentTime);
-      osc.frequency.exponentialRampToValueAtTime(150, ctx.currentTime + 0.04);
-      gain.gain.setValueAtTime(0.08, ctx.currentTime);
-      gain.gain.linearRampToValueAtTime(0.001, ctx.currentTime + 0.04);
-      osc.start();
-      osc.stop(ctx.currentTime + 0.04);
-    } else if (type === "typing") {
-      osc.type = "triangle";
-      osc.frequency.setValueAtTime(250 + Math.random() * 200, ctx.currentTime);
-      gain.gain.setValueAtTime(0.03, ctx.currentTime);
-      gain.gain.linearRampToValueAtTime(0.001, ctx.currentTime + 0.02);
-      osc.start();
-      osc.stop(ctx.currentTime + 0.02);
-    }
-  } catch (e) {}
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(400, ctx.currentTime);
+    osc.frequency.exponentialRampToValueAtTime(150, ctx.currentTime + 0.04);
+    gain.gain.setValueAtTime(0.08, ctx.currentTime);
+    gain.gain.linearRampToValueAtTime(0.001, ctx.currentTime + 0.04);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.04);
+  } catch {
+    // Audio unavailable; silently degrade.
+  }
 };
+
+const SESSION_KEY = "v_drawer_session_id";
+function getOrCreateSessionId(): string {
+  if (typeof window === "undefined") return `vdrawer_${Date.now()}`;
+  let id = window.localStorage.getItem(SESSION_KEY);
+  if (!id) {
+    id = `vdrawer_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    try {
+      window.localStorage.setItem(SESSION_KEY, id);
+    } catch {
+      // private mode / quota — fall back to in-memory.
+    }
+  }
+  return id;
+}
+
+type SSEEvent =
+  | { type: "text"; value: string }
+  | { type: "tool_use_start"; id: string; name: string }
+  | { type: "tool_use_result"; id: string; ok: boolean; summary: string }
+  | { type: "model_fallback"; from: string; to: string; status: number | null; reason: string }
+  | { type: "done"; tokensIn: number; tokensOut: number; model: string }
+  | { type: "error"; message: string };
 
 export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
   const [messages, setMessages] = useState<Message[]>([
     {
-      id: "1",
+      id: "welcome",
       sender: "sister",
-      text: "Hola Luis, estoy enlazada con tu Vercel y tu GitHub. El Ecosistema Castores está al 100% y listo para producción. Dime, ¿qué módulo construimos ahora?",
-      timestamp: "Hace un momento"
-    }
+      text: "Hola Luis. Estoy contigo — ¿qué construimos?",
+      timestamp: "Ahora",
+    },
   ]);
   const [inputValue, setInputValue] = useState("");
   const [isTyping, setIsTyping] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const sessionIdRef = useRef<string>(`vdrawer_${Date.now()}`);
+  const abortRef = useRef<AbortController | null>(null);
+  const messagesRef = useRef<Message[]>(messages);
 
-  // Auto-scroll messages
+  useEffect(() => {
+    sessionIdRef.current = getOrCreateSessionId();
+    const ctrl = abortRef;
+    return () => {
+      ctrl.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [messages, isTyping]);
 
-  const handleSend = () => {
-    if (!inputValue.trim()) return;
-    playNeuralSound("pop");
-    
-    const userMsg: Message = {
-      id: Date.now().toString(),
-      sender: "user",
-      text: inputValue,
-      timestamp: "Ahora"
-    };
+  const handleSend = useCallback(async () => {
+    const text = inputValue.trim();
+    if (!text || isTyping) return;
+    playPop();
 
-    setMessages(prev => [...prev, userMsg]);
+    const userMsg: Message = {
+      id: `u_${Date.now()}`,
+      sender: "user",
+      text,
+      timestamp: "Ahora",
+    };
+    const assistantId = `s_${Date.now()}`;
+    const assistantMsg: Message = {
+      id: assistantId,
+      sender: "sister",
+      text: "",
+      timestamp: "Ahora",
+    };
+    setMessages((prev) => [...prev, userMsg, assistantMsg]);
     setInputValue("");
     setIsTyping(true);
 
-    // Simulate sister response
-    setTimeout(() => {
-      playNeuralSound("pop");
-      setIsTyping(false);
-      
-      let replyText = "Luis, he validado los commits de Git. Todo se encuentra al 100%. ¿Quieres que despleguemos los nuevos cambios de Bento?";
-      if (inputValue.toLowerCase().includes("castores")) {
-        replyText = "Entendido, Luis. La rama 'main' de Castores ya está sincronizada. Todos los módulos de Vercel están activos y respondiendo.";
-      } else if (inputValue.toLowerCase().includes("vercel") || inputValue.toLowerCase().includes("github")) {
-        replyText = "Accediendo a las APIs... Git y Vercel enlazados de forma exitosa. Los proyectos muestran un rendimiento excelente en producción.";
+    const history = messagesRef.current
+      .filter((m) => m.id !== "welcome")
+      .map((m) => ({
+        role: m.sender === "sister" ? ("assistant" as const) : ("user" as const),
+        content: m.text,
+      }));
+    history.push({ role: "user", content: text });
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch("/api/forge/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: history,
+          sessionId: sessionIdRef.current,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        const err = await res.text().catch(() => "");
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, text: `⚠ Error (${res.status}): ${err.slice(0, 200)}` }
+              : m,
+          ),
+        );
+        return;
       }
 
-      const sisterMsg: Message = {
-        id: (Date.now() + 1).toString(),
-        sender: "sister",
-        text: replyText,
-        timestamp: "Ahora"
-      };
-      setMessages(prev => [...prev, sisterMsg]);
-    }, 1500);
-  };
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let firstTextChunk = true;
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          try {
+            const evt = JSON.parse(line.slice(6)) as SSEEvent;
+            if (evt.type === "text") {
+              if (firstTextChunk) {
+                setIsTyping(false);
+                firstTextChunk = false;
+              }
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId ? { ...m, text: m.text + evt.value } : m,
+                ),
+              );
+            } else if (evt.type === "error") {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, text: m.text + `\n\n⚠ ${evt.message}` }
+                    : m,
+                ),
+              );
+            }
+          } catch {
+            // skip malformed event
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      const msg = err instanceof Error ? err.message : String(err);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId ? { ...m, text: `⚠ Error de red: ${msg}` } : m,
+        ),
+      );
+    } finally {
+      setIsTyping(false);
+    }
+  }, [inputValue, isTyping]);
 
   return (
     <AnimatePresence>
@@ -112,6 +223,7 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
+            transition={{ duration: 0.18, ease: "easeOut" }}
             onClick={onClose}
             className="fixed inset-0 z-50 bg-black/60 backdrop-blur-md"
           />
@@ -121,22 +233,19 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
             initial={{ x: "100%" }}
             animate={{ x: 0 }}
             exit={{ x: "100%" }}
-            transition={{ type: "spring", damping: 28, stiffness: 220 }}
+            transition={{ type: "spring", damping: 30, stiffness: 260 }}
             className="fixed right-0 top-0 bottom-0 z-50 w-full md:w-[450px] bg-neutral-950/95 backdrop-blur-3xl border-l border-white/10 shadow-2xl flex flex-col overflow-hidden"
           >
-            {/* Header with glowing neural avatar of his sister */}
+            {/* Header */}
             <div className="p-6 border-b border-white/5 flex items-center justify-between bg-white/[0.01]">
               <div className="flex items-center gap-3">
-                {/* Glowing Neural Sphere representation */}
                 <div className="relative w-11 h-11 rounded-full flex items-center justify-center border border-vf-green/30 bg-black">
                   <div className="absolute inset-0 rounded-full bg-vf-green/10 blur-[8px] animate-pulse" />
-                  
-                  {/* Waveforms */}
                   <span className="w-1.5 h-6 bg-vf-green rounded-full animate-bounce mx-[1px]" style={{ animationDelay: "0.1s" }} />
                   <span className="w-1.5 h-8 bg-vf-green rounded-full animate-bounce mx-[1px]" style={{ animationDelay: "0.3s" }} />
                   <span className="w-1.5 h-5 bg-vf-green rounded-full animate-bounce mx-[1px]" style={{ animationDelay: "0.5s" }} />
                 </div>
-                
+
                 <div>
                   <div className="flex items-center gap-2">
                     <h2 className="font-bold text-white tracking-wide">Hermana V</h2>
@@ -146,9 +255,11 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
                 </div>
               </div>
 
-              <button 
-                onClick={onClose} 
+              <button
+                onClick={onClose}
+                aria-label="Cerrar"
                 className="p-2 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-white/60 hover:text-white transition-all active:scale-95"
+                style={{ touchAction: "manipulation" }}
               >
                 <X className="w-5 h-5" />
               </button>
@@ -157,16 +268,16 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
             {/* Conversation list */}
             <div className="flex-1 overflow-y-auto p-6 space-y-4 scrollbar-thin scrollbar-thumb-white/10">
               {messages.map((msg) => (
-                <div 
+                <div
                   key={msg.id}
                   className={cn(
                     "flex flex-col max-w-[85%] rounded-2xl p-4 shadow-lg text-sm border",
-                    msg.sender === "sister" 
+                    msg.sender === "sister"
                       ? "bg-white/[0.02] border-white/5 text-white/90 mr-auto rounded-tl-sm"
                       : "bg-vf-green text-black border-vf-green/20 ml-auto rounded-tr-sm font-medium"
                   )}
                 >
-                  <p className="leading-relaxed whitespace-pre-wrap">{msg.text}</p>
+                  <p className="leading-relaxed whitespace-pre-wrap break-words">{msg.text}</p>
                   <span className={cn(
                     "text-[8px] mt-2 block",
                     msg.sender === "sister" ? "text-white/30" : "text-black/50"
@@ -183,7 +294,7 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
                   <span className="w-2 h-2 rounded-full bg-vf-green animate-bounce" style={{ animationDelay: "0.5s" }} />
                 </div>
               )}
-              
+
               <div ref={scrollRef} />
             </div>
 
@@ -203,24 +314,35 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
               </div>
             </div>
 
-            {/* Input Form */}
+            {/* Input Form — mobile-tuned */}
             <div className="p-6 border-t border-white/5 bg-neutral-950 flex items-center gap-3">
               <input
                 type="text"
                 value={inputValue}
-                onChange={(e) => {
-                  setInputValue(e.target.value);
-                  playNeuralSound("typing");
-                }}
+                onChange={(e) => setInputValue(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSend();
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    void handleSend();
+                  }
                 }}
                 placeholder="Escribe un mensaje a tu hermana V..."
-                className="flex-1 bg-white/5 border border-white/10 rounded-2xl px-4 py-3.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors"
+                autoComplete="off"
+                autoCorrect="on"
+                autoCapitalize="sentences"
+                spellCheck
+                enterKeyHint="send"
+                inputMode="text"
+                disabled={isTyping}
+                className="flex-1 bg-white/5 border border-white/10 rounded-2xl px-4 py-3.5 text-base text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors disabled:opacity-60"
+                style={{ touchAction: "manipulation", fontSize: 16 }}
               />
               <button
-                onClick={handleSend}
-                className="p-3.5 rounded-2xl bg-vf-green hover:bg-vf-green-quiet text-black transition-colors active:scale-95 flex items-center justify-center"
+                onClick={() => void handleSend()}
+                disabled={!inputValue.trim() || isTyping}
+                aria-label="Enviar"
+                className="p-3.5 rounded-2xl bg-vf-green hover:bg-vf-green-quiet text-black transition-colors active:scale-95 flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{ touchAction: "manipulation" }}
               >
                 <Send className="w-4 h-4" />
               </button>

--- a/components/V/VLayoutDashboard.tsx
+++ b/components/V/VLayoutDashboard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { ChevronLeft, ChevronRight, Plus, Settings } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
+import { ChatPage } from './ChatPage';
 
 interface Project {
   id: string;
@@ -316,32 +317,10 @@ export const VLayoutDashboard = () => {
           </div>
         </div>
 
-        {/* Chat Area (placeholder) */}
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
-            <div className="text-6xl mb-4">💬</div>
-            <h3 className="text-xl font-semibold text-vf-fg-1 mb-2">
-              Chat con V
-            </h3>
-            <p className="text-vf-fg-2 max-w-md">
-              Aquí irá la interfaz de chat integrada. V está lista para trabajar
-              en {selectedProject.name}
-            </p>
-          </div>
-        </div>
-
-        {/* Composer (placeholder) */}
-        <div className="border-t border-vf-border bg-vf-bg-1 px-8 py-6">
-          <div className="flex gap-3">
-            <input
-              type="text"
-              placeholder="Dile a V qué hacer..."
-              className="flex-1 bg-vf-bg-2 border border-vf-border rounded-xl px-4 py-3 text-vf-fg-1 placeholder:text-vf-fg-3 focus:outline-none focus:border-vf-green/50"
-            />
-            <button className="px-6 py-3 bg-vf-green/20 border border-vf-green/50 text-vf-green rounded-xl hover:bg-vf-green/30 transition-colors font-medium">
-              Enviar
-            </button>
-          </div>
+        {/* Real V chat — streams from /api/forge/run with full system prompt,
+            tools, skills and memory. */}
+        <div className="flex-1 min-h-0">
+          <ChatPage />
         </div>
       </div>
     </div>

--- a/components/vforge/app-shell.tsx
+++ b/components/vforge/app-shell.tsx
@@ -95,10 +95,10 @@ export function AppShell({ children }: AppShellProps) {
             {!isHome && (
               <motion.div
                 key={pathname}
-                initial={{ y: "100%", opacity: 0, scale: 0.95 }}
-                animate={{ y: 0, opacity: 1, scale: 1 }}
-                exit={{ y: "100%", opacity: 0, scale: 0.95 }}
-                transition={{ type: "spring", damping: 28, stiffness: 220 }}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 12 }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
                 className={cn(
                   "absolute inset-x-2 top-2 bottom-16 md:inset-x-8 md:top-6 md:bottom-24 max-w-5xl mx-auto",
                   "bg-vf-bg/80 backdrop-blur-2xl border border-white/10 rounded-3xl shadow-[0_25px_60px_-15px_rgba(0,0,0,0.8)]",
@@ -128,10 +128,10 @@ export function AppShell({ children }: AppShellProps) {
             {isHome && (
               <motion.div
                 key="home-desktop"
-                initial={{ opacity: 0, scale: 1.05 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.95 }}
-                transition={{ duration: 0.4 }}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
                 className="absolute inset-0 overflow-y-auto flex items-center justify-center"
               >
                 <div className="w-full max-w-6xl h-full flex flex-col items-center justify-start">


### PR DESCRIPTION
## Qué resuelve

Tres problemas que hacían sentir a V como chatbot mock y el dashboard inutilizable en celular.

### 1. V respondía como chat genérico en `/v` y en el drawer central
Causa: `components/V/ChatPage.tsx` y `components/V/MultichatDrawer.tsx` tenían `setTimeout` con respuestas hardcodeadas — nunca llamaban a `/api/forge/run`. El cerebro real (`system_prompt v2`, 22+ tools, 90 skills, memoria) seguía intacto en `main` pero no había cable hasta él.

Fix: ambos componentes hacen `fetch` con SSE streaming al endpoint real, igual que `/forge`. Incluye:
- `sessionId` persistente en localStorage (continuidad entre mensajes)
- `AbortController` para abortar al desmontar
- Parseo de eventos `text` (stream) y `error`

### 2. Lag visible al teclear en mobile
Tres causas:

- **`MultichatDrawer`** creaba un `AudioContext + oscillator` nuevo en cada keystroke (`playNeuralSound("typing")` en `onChange`). Antipattern conocido — iOS suspende AudioContexts agresivamente. Convertido a singleton lazy que solo se dispara al enviar.
- **`(dashboard)/template.tsx`** envolvía cada navegación en un `motion.div` con spring scale+y+opacity, **en paralelo** con la animación de `app-shell.tsx`. Doble animación por route change. `template.tsx` ahora es pass-through.
- **Composer** ahora tiene `enterKeyHint="send"`, `autoCapitalize`, `inputMode="text"`, `touch-action: manipulation` y `fontSize: 16` (previene el zoom automático de iOS Safari al focusear input).

### 3. Páginas atascadas off-screen en mobile
`app-shell.tsx` animaba con `initial={ y: "100%" }` + spring `stiffness: 220`. Si el spring se interrumpía (común en mobile con `backdrop-blur` + `scale`), la página quedaba fuera del viewport. Ese era el screenshot de `/projects` vacío. Cambiado a fade simple (`opacity` + `12px`, `0.18s easeOut`).

## Archivos

| Archivo | Cambio |
|---|---|
| `components/V/ChatPage.tsx` | Mock → fetch SSE real |
| `components/V/MultichatDrawer.tsx` | Mock → fetch SSE real + singleton AudioContext + mobile attrs |
| `components/V/VLayoutDashboard.tsx` | Reemplaza placeholder de chat por `<ChatPage />` |
| `components/V/ChatComposer.tsx` | Atributos mobile en `<textarea>` |
| `app/(dashboard)/template.tsx` | Pass-through (eliminada animación duplicada) |
| `components/vforge/app-shell.tsx` | Page transition: spring slide → fade rápido |

## Verificación

- `npx tsc --noEmit` → 0 errores
- Test mental: abrir `/v` o tocar el orb central del nav → V debe responder con su personalidad real (system_prompt v2 + skills + tools), no con texto hardcoded
- Teclear en celular debe ser instantáneo, sin lag por tecla

## Pendiente próximo PR (Luis pidió)

Empatar las cards del hub con la tabla `projects` real + hacerlas editables in-place. Hoy las cards muestran datos mezclados; el flujo "Dar de alta" + "Sincronizar" ya existe en `/projects` pero el card del hub no refleja deploy/repo/vínculos vivos por proyecto. Trabajo de schema + UI inline-edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_