### PR TITLE
refactor(ui): rediseño Vercel/Linear-style con V central permanente

### DIFF
--- a/app/(dashboard)/hub/page.tsx
+++ b/app/(dashboard)/hub/page.tsx
@@ -1,773 +1,285 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
-import { 
-  FolderKanban, Sparkles, Lock, Boxes, Eye, Search, Plus, X, 
-  Settings, Link as LinkIcon, Github, Globe, RefreshCw, CheckCircle2, 
-  AlertCircle, FileText, Image as ImageIcon, Trash2, HeartHandshake,
-  MessageSquare
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Plus,
+  ExternalLink,
+  GitBranch,
+  Lock,
+  Sparkles,
+  RefreshCw,
+  CircleDot,
 } from "lucide-react";
-import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import { openV } from "@/components/V/VDock";
 
-// Custom Web Audio API Haptic Sound Generator
-const playHapticSound = (type = "click") => {
-  if (typeof window === "undefined") return;
-  try {
-    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
-    
-    if (type === "click") {
-      // Apple-style high-end mechanical click
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      
-      osc.type = "sine";
-      osc.frequency.setValueAtTime(160, ctx.currentTime);
-      osc.frequency.exponentialRampToValueAtTime(10, ctx.currentTime + 0.05);
-      
-      gain.gain.setValueAtTime(0.15, ctx.currentTime);
-      gain.gain.linearRampToValueAtTime(0.01, ctx.currentTime + 0.05);
-      
-      osc.start();
-      osc.stop(ctx.currentTime + 0.05);
-    } else if (type === "success") {
-      // Double clean chime
-      const osc1 = ctx.createOscillator();
-      const osc2 = ctx.createOscillator();
-      const gain = ctx.createGain();
-      
-      osc1.connect(gain);
-      osc2.connect(gain);
-      gain.connect(ctx.destination);
-      
-      osc1.type = "sine";
-      osc1.frequency.setValueAtTime(523.25, ctx.currentTime); // C5
-      osc1.frequency.setValueAtTime(659.25, ctx.currentTime + 0.08); // E5
-      
-      osc2.type = "sine";
-      osc2.frequency.setValueAtTime(783.99, ctx.currentTime); // G5
-      
-      gain.gain.setValueAtTime(0.1, ctx.currentTime);
-      gain.gain.linearRampToValueAtTime(0.001, ctx.currentTime + 0.25);
-      
-      osc1.start();
-      osc2.start();
-      osc1.stop(ctx.currentTime + 0.25);
-      osc2.stop(ctx.currentTime + 0.25);
-    }
-  } catch (e) {
-    // AudioContext blocked
-  }
-};
-
-interface BentoCard {
+interface Project {
   id: string;
-  title: string;
-  description: string;
-  bgImage: string;
-  color: string;
-  vercelUrl?: string;
-  vercelStatus: "active" | "building" | "offline";
-  gitRepo?: string;
-  gitBranch?: string;
-  sisterConnected: boolean;
-  assets: Array<{ id: string; name: string; type: "image" | "file" | "link"; url: string }>;
+  name: string;
+  category: string;
+  status: string;
+  github_repo: string | null;
+  github_private?: boolean;
+  github_language?: string | null;
+  vercel_url: string | null;
+  domain?: string | null;
 }
 
-const defaultCards: BentoCard[] = [
-  {
-    id: "c1",
-    title: "Ecosistema Castores",
-    description: "Plataforma de ventas y logística integral para materiales de construcción.",
-    bgImage: "https://images.unsplash.com/photo-1590069261209-f8e9b8642343?auto=format&fit=crop&q=80&w=800",
-    color: "from-blue-600 to-indigo-700",
-    vercelUrl: "https://castores.vforge.site",
-    vercelStatus: "active",
-    gitRepo: "turbillon50/castores-production",
-    gitBranch: "main",
-    sisterConnected: true,
-    assets: [
-      { id: "a1", name: "Catálogo PDF.pdf", type: "file", url: "#" },
-      { id: "a2", name: "Diseño Bento.png", type: "image", url: "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?auto=format&fit=crop&q=80&w=400" }
-    ]
-  },
-  {
-    id: "c2",
-    title: "RideMe Portal",
-    description: "Aplicación premium de transporte y rastreo de flotilla en tiempo real.",
-    bgImage: "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?auto=format&fit=crop&q=80&w=800",
-    color: "from-purple-600 to-pink-700",
-    vercelUrl: "https://rideme-v1.vercel.app",
-    vercelStatus: "building",
-    gitRepo: "turbillon50/rideme-portal",
-    gitBranch: "dev",
-    sisterConnected: true,
-    assets: []
-  },
-  {
-    id: "c3",
-    title: "Fractal Core OS",
-    description: "Núcleo de procesamiento geométrico y analítica avanzada.",
-    bgImage: "https://images.unsplash.com/photo-1634017839464-5c339ebe3cb4?auto=format&fit=crop&q=80&w=800",
-    color: "from-emerald-600 to-teal-700",
-    vercelUrl: "https://fractal-core.vercel.app",
-    vercelStatus: "active",
-    gitRepo: "turbillon50/fractal-core",
-    gitBranch: "main",
-    sisterConnected: false,
-    assets: []
-  }
-];
+const STATUS_TONE: Record<string, { dot: string; label: string }> = {
+  produccion: { dot: "bg-vf-green", label: "Producción" },
+  activo: { dot: "bg-blue-400", label: "Activo" },
+  en_revision: { dot: "bg-amber-400", label: "En revisión" },
+  en_pausa: { dot: "bg-vf-fg-2", label: "En pausa" },
+  archivo: { dot: "bg-vf-fg-3", label: "Archivo" },
+  pendiente_borrado: { dot: "bg-red-400", label: "Pendiente borrado" },
+};
 
 export default function HubPage() {
-  const [cards, setCards] = useState<BentoCard[]>([]);
-  const [activeCard, setActiveCard] = useState<BentoCard | null>(null);
-  const [isEditing, setIsEditing] = useState(false);
-  const [editedCard, setEditedCard] = useState<BentoCard | null>(null);
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
-  
-  // Creation States
-  const [newTitle, setNewTitle] = useState("");
-  const [newDesc, setNewDesc] = useState("");
-  const [newBg, setNewBg] = useState("");
-  const [newVercel, setNewVercel] = useState("");
-  const [newGit, setNewGit] = useState("");
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  // Load from localStorage
-  useEffect(() => {
-    const saved = localStorage.getItem("vforge_bento_cards");
-    if (saved) {
-      setCards(JSON.parse(saved));
-    } else {
-      setCards(defaultCards);
-      localStorage.setItem("vforge_bento_cards", JSON.stringify(defaultCards));
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/projects", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { projects: Project[] };
+      setProjects(data.projects ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error cargando proyectos");
+      setProjects([]);
+    } finally {
+      setLoading(false);
     }
+  }
+
+  useEffect(() => {
+    void load();
   }, []);
 
-  const saveToStorage = (updated: BentoCard[]) => {
-    setCards(updated);
-    localStorage.setItem("vforge_bento_cards", JSON.stringify(updated));
-  };
+  // Open V with prompt + context pre-loaded about this project.
+  function askVAboutProject(p: Project) {
+    openV();
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("vforge:v-context", {
+          detail: {
+            label: "PROYECTO",
+            value: `${p.name} · ${p.github_repo ?? "sin repo"}`,
+            prompt: `Cuéntame el estado actual de ${p.name} (repo ${p.github_repo ?? "n/a"}, deploy ${p.vercel_url ?? "n/a"}). ¿Algo que necesite atención?`,
+          },
+        }),
+      );
+    }
+  }
 
-  const handleCreate = () => {
-    playHapticSound("success");
-    const newCard: BentoCard = {
-      id: Date.now().toString(),
-      title: newTitle || "Nuevo Espacio",
-      description: newDesc || "Baúl de trabajo personalizado.",
-      bgImage: newBg || "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?auto=format&fit=crop&q=80&w=800",
-      color: "from-neutral-800 to-neutral-900",
-      vercelUrl: newVercel,
-      vercelStatus: "active",
-      gitRepo: newGit,
-      gitBranch: "main",
-      sisterConnected: true,
-      assets: []
-    };
-
-    const updated = [...cards, newCard];
-    saveToStorage(updated);
-    setIsCreateOpen(false);
-    
-    // Reset states
-    setNewTitle("");
-    setNewDesc("");
-    setNewBg("");
-    setNewVercel("");
-    setNewGit("");
-  };
-
-  const handleUpdate = () => {
-    if (!editedCard) return;
-    playHapticSound("success");
-    const updated = cards.map(c => c.id === editedCard.id ? editedCard : c);
-    saveToStorage(updated);
-    setIsEditing(false);
-    setActiveCard(editedCard);
-  };
-
-  const handleDelete = (id: string) => {
-    playHapticSound("click");
-    const updated = cards.filter(c => c.id !== id);
-    saveToStorage(updated);
-    setActiveCard(null);
-    setIsEditing(false);
-  };
+  const liveProjects = projects.filter(
+    (p) => p.category === "produccion" || p.category === "activo",
+  );
 
   return (
-    <div className="w-full h-full min-h-[calc(100vh-80px)] flex flex-col items-center justify-start pt-6 pb-24 px-4 md:px-8 relative select-none">
-      
-      {/* Top Professional Banner */}
-      <header className="w-full max-w-5xl mb-10 flex justify-between items-center bg-white/[0.01] border border-white/5 backdrop-blur-xl px-6 py-4 rounded-3xl shadow-[0_8px_32px_rgba(0,0,0,0.3)]">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-2xl bg-gradient-to-tr from-vf-green to-emerald-400 flex items-center justify-center shadow-lg shadow-vf-green/10">
-            <Boxes className="w-5 h-5 text-black" />
-          </div>
-          <div>
-            <h1 className="text-lg font-bold tracking-tight bg-gradient-to-r from-white via-white/80 to-white/40 bg-clip-text text-transparent">vForge Workspaces</h1>
-            <p className="text-[9px] uppercase tracking-widest text-white/40 font-semibold">Bento Operations Console</p>
-          </div>
+    <div className="space-y-8">
+      {/* Header */}
+      <header className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <p className="font-mono text-[11px] uppercase tracking-widest text-vf-fg-2 mb-1">
+            Hub
+          </p>
+          <h1 className="text-2xl md:text-3xl font-semibold text-vf-fg tracking-tight">
+            {loading
+              ? "Cargando…"
+              : projects.length === 0
+                ? "Sin proyectos todavía"
+                : `${projects.length} proyecto${projects.length === 1 ? "" : "s"}`}
+          </h1>
+          {!loading && liveProjects.length > 0 && (
+            <p className="text-sm text-vf-fg-1 mt-1">
+              {liveProjects.length} en producción · gestionados por V
+            </p>
+          )}
         </div>
-        
-        {/* Connection status */}
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2 bg-neutral-900 border border-white/10 px-3 py-1 rounded-xl">
-            <span className="w-1.5 h-1.5 rounded-full bg-vf-green animate-pulse shadow-[0_0_8px_#7cff3c]" />
-            <span className="text-[10px] font-semibold text-white/70 font-mono">Live Sync</span>
-          </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 h-9 px-3 rounded-md border border-vf-border bg-vf-bg-1 text-vf-fg-1 text-xs font-medium hover:text-vf-fg hover:bg-vf-bg-2 transition-colors disabled:opacity-50"
+            style={{ touchAction: "manipulation" }}
+          >
+            <RefreshCw className={cn("w-3.5 h-3.5", loading && "animate-spin")} />
+            Refrescar
+          </button>
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-1.5 h-9 px-3 rounded-md bg-vf-green text-black text-xs font-semibold hover:bg-vf-green/90 transition-colors"
+            style={{ touchAction: "manipulation" }}
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Dar de alta
+          </Link>
         </div>
       </header>
 
-      {/* Bento Grid layout */}
-      <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        
-        {/* Render Workspace Cards */}
-        {cards.map((card, index) => (
-          <motion.div
-            key={card.id}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: index * 0.05, type: "spring", stiffness: 260, damping: 22 }}
-            onClick={() => {
-              playHapticSound("click");
-              setActiveCard(card);
-            }}
-            className={cn(
-              "relative group overflow-hidden rounded-[28px] border border-white/10 flex flex-col justify-between p-6 cursor-pointer",
-              "bg-neutral-900 hover:border-white/20 transition-all duration-300 min-h-[220px]",
-              "hover:-translate-y-1.5 shadow-[0_15px_35px_rgba(0,0,0,0.3)] active:scale-[0.98]"
-            )}
-          >
-            {/* Card Background image with smooth blur hover */}
-            <div 
-              className="absolute inset-0 bg-cover bg-center opacity-[0.15] group-hover:opacity-[0.25] transition-opacity duration-500 z-0 pointer-events-none"
-              style={{ backgroundImage: `url(${card.bgImage})` }}
+      {error && (
+        <div className="rounded-md border border-red-500/30 bg-red-500/5 px-4 py-3 text-sm text-red-300">
+          ⚠ {error}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && projects.length === 0 && <EmptyState />}
+
+      {/* Project list — Vercel/GitHub style rows */}
+      {!loading && projects.length > 0 && (
+        <section className="space-y-3">
+          {projects.map((p) => (
+            <ProjectRow
+              key={p.id}
+              project={p}
+              onAskV={() => askVAboutProject(p)}
             />
-            
-            {/* Ambient Background Gradient Glow */}
-            <div className={cn(
-              "absolute -right-16 -top-16 w-36 h-36 rounded-full bg-gradient-to-br opacity-20 blur-2xl group-hover:opacity-40 transition-opacity",
-              card.color
-            )} />
+          ))}
+        </section>
+      )}
 
-            {/* Workspace Header */}
-            <div className="flex justify-between items-start z-10 w-full mb-4">
-              <div className="flex flex-col gap-1">
-                <h3 className="text-md font-bold text-white tracking-wide group-hover:text-vf-green transition-colors">
-                  {card.title}
-                </h3>
-                <p className="text-[11px] text-white/50 line-clamp-2 max-w-[90%] font-medium">
-                  {card.description}
-                </p>
-              </div>
+      {/* Loading skeleton */}
+      {loading && (
+        <section className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-[88px] rounded-lg border border-vf-border bg-vf-bg-1/40 animate-pulse"
+            />
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}
 
-              {/* V connection icon */}
-              {card.sisterConnected && (
-                <div 
-                  title="Conectado con V Core"
-                  className="w-8 h-8 rounded-xl bg-vf-green/10 border border-vf-green/20 flex items-center justify-center text-vf-green shadow-[0_0_15px_rgba(124,255,60,0.1)]"
-                >
-                  <Sparkles className="w-4 h-4 animate-pulse" />
-                </div>
+function ProjectRow({
+  project,
+  onAskV,
+}: {
+  project: Project;
+  onAskV: () => void;
+}) {
+  const tone = STATUS_TONE[project.category] ?? {
+    dot: "bg-vf-fg-2",
+    label: project.category,
+  };
+
+  return (
+    <article className="group rounded-lg border border-vf-border bg-vf-bg-1/40 hover:bg-vf-bg-1 hover:border-vf-border-1 transition-colors">
+      <div className="flex items-center gap-4 px-4 py-3.5">
+        {/* Status dot */}
+        <div className="flex-shrink-0">
+          <span
+            className={cn("inline-block w-2 h-2 rounded-full", tone.dot)}
+            title={tone.label}
+            aria-label={tone.label}
+          />
+        </div>
+
+        {/* Identity */}
+        <div className="flex-1 min-w-0">
+          <Link href={`/projects/${project.id}`} className="block group/link">
+            <div className="flex items-center gap-2 min-w-0">
+              <h3 className="text-vf-fg font-medium text-sm truncate group-hover/link:underline">
+                {project.name}
+              </h3>
+              {project.github_private && (
+                <Lock className="w-3 h-3 text-vf-fg-2 flex-shrink-0" />
               )}
-            </div>
-
-            {/* Middle Stats (Vercel & Git Integrations) */}
-            <div className="flex flex-col gap-2.5 z-10 w-full my-3">
-              {/* Vercel Status */}
-              {card.vercelUrl ? (
-                <div className="flex items-center justify-between bg-white/[0.02] border border-white/5 rounded-xl px-3 py-2">
-                  <div className="flex items-center gap-2 text-[10px] font-semibold text-white/70">
-                    <Globe className="w-3.5 h-3.5 text-blue-400" />
-                    <span className="truncate max-w-[140px]">{card.vercelUrl.replace("https://", "")}</span>
-                  </div>
-                  
-                  {/* Deployment Status Pill */}
-                  <span className={cn(
-                    "text-[8px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border flex items-center gap-1",
-                    card.vercelStatus === "active" ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20" : 
-                    card.vercelStatus === "building" ? "bg-amber-500/10 text-amber-400 border-amber-500/20 animate-pulse" :
-                    "bg-red-500/10 text-red-400 border-red-500/20"
-                  )}>
-                    {card.vercelStatus === "active" ? (
-                      <>
-                        <span className="w-1 h-1 rounded-full bg-emerald-400" />
-                        <span>Active</span>
-                      </>
-                    ) : card.vercelStatus === "building" ? (
-                      <>
-                        <span className="w-1 h-1 rounded-full bg-amber-400 animate-ping" />
-                        <span>Building</span>
-                      </>
-                    ) : (
-                      <>
-                        <span className="w-1 h-1 rounded-full bg-red-400" />
-                        <span>Offline</span>
-                      </>
-                    )}
-                  </span>
-                </div>
-              ) : (
-                <div className="text-[9px] text-white/30 italic">Sin enlace de Vercel configurado</div>
-              )}
-
-              {/* GitHub Link */}
-              {card.gitRepo && (
-                <div className="flex items-center justify-between bg-white/[0.02] border border-white/5 rounded-xl px-3 py-1.5">
-                  <div className="flex items-center gap-2 text-[10px] font-semibold text-white/70">
-                    <Github className="w-3.5 h-3.5 text-white/60" />
-                    <span className="truncate max-w-[140px]">{card.gitRepo}</span>
-                  </div>
-                  <span className="text-[9px] text-white/40 font-mono font-bold bg-white/5 px-2 py-0.5 rounded">
-                    {card.gitBranch || "main"}
-                  </span>
-                </div>
-              )}
-            </div>
-
-            {/* Bottom info (Linked Assets) */}
-            <div className="flex justify-between items-center z-10 w-full border-t border-white/5 pt-3">
-              <span className="text-[10px] font-bold text-white/40 tracking-wider">
-                {card.assets.length} VÍNCULOS
+              <span className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2 px-1.5 py-0.5 rounded bg-vf-bg-2 flex-shrink-0">
+                {tone.label}
               </span>
-              
-              <div className="flex items-center gap-1.5">
-                <span className="text-[9px] font-bold text-white/60 bg-white/5 border border-white/10 px-2 py-0.5 rounded-lg">
-                  DETALLES
-                </span>
-              </div>
             </div>
-          </motion.div>
-        ))}
+            <div className="flex items-center gap-1.5 mt-1 font-mono text-[11px] text-vf-fg-2 min-w-0">
+              <GitBranch className="w-3 h-3 flex-shrink-0" />
+              <span className="truncate">
+                {project.github_repo ?? "sin repo"}
+              </span>
+              {project.github_language && (
+                <span className="ml-1 text-vf-fg-3 flex-shrink-0">
+                  · {project.github_language}
+                </span>
+              )}
+            </div>
+          </Link>
+        </div>
 
-        {/* Add Workspace Bento button */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          onClick={() => {
-            playHapticSound("click");
-            setIsCreateOpen(true);
-          }}
-          className={cn(
-            "relative group overflow-hidden rounded-[28px] border-2 border-dashed border-white/10 flex flex-col items-center justify-center p-6 cursor-pointer",
-            "bg-transparent hover:border-white/30 transition-all duration-300 min-h-[220px]",
-            "hover:-translate-y-1.5 active:scale-[0.98] text-white/30 hover:text-white"
+        {/* Actions */}
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {project.vercel_url && (
+            <a
+              href={project.vercel_url}
+              target="_blank"
+              rel="noreferrer"
+              title="Ver deploy"
+              aria-label="Ver deploy"
+              className="hidden sm:inline-flex w-8 h-8 items-center justify-center rounded text-vf-fg-2 hover:text-vf-fg hover:bg-vf-bg-2 transition-colors"
+              style={{ touchAction: "manipulation" }}
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+            </a>
           )}
-        >
-          <div className="w-12 h-12 rounded-full border border-white/10 flex items-center justify-center bg-white/[0.01] mb-3 group-hover:scale-110 transition-transform">
-            <Plus className="w-6 h-6" />
-          </div>
-          <span className="text-xs font-bold tracking-wider uppercase text-white/40 group-hover:text-white/80 transition-colors">
-            Crear Espacio
-          </span>
-        </motion.div>
-
+          {project.github_repo && (
+            <a
+              href={`https://github.com/${project.github_repo}`}
+              target="_blank"
+              rel="noreferrer"
+              title="Ver repo"
+              aria-label="Ver repo"
+              className="hidden sm:inline-flex w-8 h-8 items-center justify-center rounded text-vf-fg-2 hover:text-vf-fg hover:bg-vf-bg-2 transition-colors"
+              style={{ touchAction: "manipulation" }}
+            >
+              <GitBranch className="w-3.5 h-3.5" />
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={onAskV}
+            title="Preguntar a V sobre este proyecto"
+            aria-label="Preguntar a V"
+            className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded text-vf-green hover:bg-vf-green/10 transition-colors"
+            style={{ touchAction: "manipulation" }}
+          >
+            <Sparkles className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline text-xs font-medium">V</span>
+          </button>
+        </div>
       </div>
+    </article>
+  );
+}
 
-      {/* Expanded Bento Card Workspace Detail Overlay */}
-      <AnimatePresence>
-        {activeCard && !isEditing && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setActiveCard(null)}
-              className="absolute inset-0 bg-black/75 backdrop-blur-2xl"
-            />
-            
-            <motion.div
-              initial={{ scale: 0.9, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.9, opacity: 0 }}
-              transition={{ type: "spring", damping: 25, stiffness: 230 }}
-              className="relative w-full max-w-2xl bg-neutral-900 border border-white/10 rounded-[32px] p-8 shadow-[0_30px_70px_rgba(0,0,0,0.6)] backdrop-blur-2xl flex flex-col overflow-hidden max-h-[90vh]"
-            >
-              {/* Blur accent */}
-              <div className={cn(
-                "absolute -right-20 -top-20 w-48 h-48 rounded-full bg-gradient-to-br opacity-30 blur-3xl pointer-events-none",
-                activeCard.color
-              )} />
-
-              {/* Detail Header */}
-              <div className="flex justify-between items-start z-10 w-full mb-6 pb-6 border-b border-white/5">
-                <div>
-                  <div className="flex items-center gap-3">
-                    <h2 className="text-xl font-bold text-white tracking-wide">{activeCard.title}</h2>
-                    {activeCard.sisterConnected && (
-                      <span className="bg-vf-green/10 text-vf-green text-[9px] font-bold tracking-widest px-2.5 py-0.5 rounded-full border border-vf-green/20">
-                        V LINKED
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-xs text-white/50 mt-1 max-w-[90%] font-medium">{activeCard.description}</p>
-                </div>
-                
-                <div className="flex gap-2">
-                  <button 
-                    onClick={() => {
-                      playHapticSound("click");
-                      setEditedCard(activeCard);
-                      setIsEditing(true);
-                    }}
-                    className="p-2 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-white/60 hover:text-white transition-all active:scale-95"
-                    title="Configurar Tarjeta"
-                  >
-                    <Settings className="w-4 h-4" />
-                  </button>
-                  <button 
-                    onClick={() => setActiveCard(null)}
-                    className="p-2 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-white/60 hover:text-white transition-all active:scale-95"
-                  >
-                    <X className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-
-              {/* Integrations Stats Display */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6 z-10">
-                {/* Vercel Status Info */}
-                <div className="bg-white/[0.02] border border-white/5 rounded-2xl p-4 flex flex-col justify-between min-h-[110px]">
-                  <div className="flex justify-between items-center w-full">
-                    <span className="text-[10px] font-bold text-white/40 uppercase tracking-widest">Vercel Deploy</span>
-                    <Globe className="w-4 h-4 text-blue-400" />
-                  </div>
-                  {activeCard.vercelUrl ? (
-                    <div>
-                      <a 
-                        href={activeCard.vercelUrl} 
-                        target="_blank" 
-                        rel="noreferrer"
-                        className="text-xs font-semibold text-white hover:text-vf-green underline transition-colors break-all"
-                      >
-                        {activeCard.vercelUrl}
-                      </a>
-                      <div className="flex items-center gap-1.5 mt-2">
-                        <span className={cn(
-                          "w-2 h-2 rounded-full",
-                          activeCard.vercelStatus === "active" ? "bg-emerald-400" : "bg-amber-400 animate-ping"
-                        )} />
-                        <span className="text-[10px] font-bold tracking-wider text-white/60 uppercase">
-                          {activeCard.vercelStatus}
-                        </span>
-                      </div>
-                    </div>
-                  ) : (
-                    <span className="text-xs text-white/40 italic">Sin vincular</span>
-                  )}
-                </div>
-
-                {/* Git Status Info */}
-                <div className="bg-white/[0.02] border border-white/5 rounded-2xl p-4 flex flex-col justify-between min-h-[110px]">
-                  <div className="flex justify-between items-center w-full">
-                    <span className="text-[10px] font-bold text-white/40 uppercase tracking-widest">Git Repository</span>
-                    <Github className="w-4 h-4 text-white/60" />
-                  </div>
-                  {activeCard.gitRepo ? (
-                    <div>
-                      <div className="text-xs font-semibold text-white break-all">{activeCard.gitRepo}</div>
-                      <div className="flex items-center gap-2 mt-2">
-                        <span className="text-[9px] font-bold bg-white/5 px-2 py-0.5 rounded text-white/50">
-                          {activeCard.gitBranch || "main"}
-                        </span>
-                        <span className="text-[9px] text-white/40 font-mono">Sync Active</span>
-                      </div>
-                    </div>
-                  ) : (
-                    <span className="text-xs text-white/40 italic">Sin vincular</span>
-                  )}
-                </div>
-              </div>
-
-              {/* Assets / Connected Materials section */}
-              <div className="flex-1 flex flex-col min-h-[200px] overflow-hidden z-10">
-                <h3 className="text-xs font-bold uppercase tracking-widest text-white/50 mb-3 flex items-center gap-2">
-                  <LinkIcon className="w-4 h-4 text-vf-green" />
-                  <span>Vinculaciones & Materiales</span>
-                </h3>
-                
-                <div className="flex-1 overflow-y-auto bg-white/[0.01] border border-white/5 rounded-2xl p-4 flex flex-col gap-2">
-                  {activeCard.assets.length > 0 ? (
-                    activeCard.assets.map((asset) => (
-                      <div key={asset.id} className="flex justify-between items-center bg-white/[0.02] hover:bg-white/[0.04] border border-white/5 rounded-xl px-4 py-2.5 transition-colors">
-                        <div className="flex items-center gap-3">
-                          {asset.type === "image" ? (
-                            <ImageIcon className="w-4 h-4 text-purple-400" />
-                          ) : (
-                            <FileText className="w-4 h-4 text-blue-400" />
-                          )}
-                          <span className="text-xs font-semibold text-white/80">{asset.name}</span>
-                        </div>
-                        {asset.url && asset.url !== "#" && (
-                          <a 
-                            href={asset.url}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-[9px] font-bold text-vf-green hover:underline uppercase"
-                          >
-                            Ver Archivo
-                          </a>
-                        )}
-                      </div>
-                    ))
-                  ) : (
-                    <div className="flex-1 flex flex-col items-center justify-center text-center p-6 text-white/30">
-                      <FileText className="w-8 h-8 opacity-20 mb-2" />
-                      <p className="text-xs font-medium">No hay fotos, capturas o archivos enlazados.</p>
-                      <p className="text-[10px] mt-1 text-white/20">Configura la tarjeta para agregar tus materiales de trabajo.</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
-
-      {/* Modal: Configurar Bento Card (Edit workspace properties) */}
-      <AnimatePresence>
-        {isEditing && editedCard && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setIsEditing(false)}
-              className="absolute inset-0 bg-black/80 backdrop-blur-md"
-            />
-            
-            <motion.div
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              className="relative w-full max-w-md bg-neutral-900 border border-white/10 rounded-[32px] p-6 shadow-2xl z-10 flex flex-col max-h-[90vh] overflow-y-auto"
-            >
-              <div className="flex justify-between items-center mb-6">
-                <h3 className="text-md font-bold text-white">Configuración del Espacio</h3>
-                <button 
-                  onClick={() => setIsEditing(false)}
-                  className="p-1 rounded-lg hover:bg-white/5 text-white/50 hover:text-white"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              </div>
-
-              {/* Title & description */}
-              <div className="flex flex-col gap-4 mb-6">
-                <div>
-                  <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1.5">Nombre del Proyecto</label>
-                  <input 
-                    type="text"
-                    value={editedCard.title}
-                    onChange={(e) => setEditedCard({ ...editedCard, title: e.target.value })}
-                    className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2 text-sm text-white focus:outline-none focus:border-vf-green"
-                  />
-                </div>
-                <div>
-                  <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1.5">Descripción</label>
-                  <textarea 
-                    value={editedCard.description}
-                    onChange={(e) => setEditedCard({ ...editedCard, description: e.target.value })}
-                    className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2 text-sm text-white focus:outline-none focus:border-vf-green min-h-[60px]"
-                  />
-                </div>
-                <div>
-                  <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1.5">Imagen de Fondo (URL)</label>
-                  <input 
-                    type="text"
-                    value={editedCard.bgImage}
-                    onChange={(e) => setEditedCard({ ...editedCard, bgImage: e.target.value })}
-                    className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2 text-sm text-white focus:outline-none focus:border-vf-green"
-                  />
-                </div>
-              </div>
-
-              {/* Integrations inputs */}
-              <div className="flex flex-col gap-4 mb-6 border-t border-white/5 pt-4">
-                <h4 className="text-xs font-bold text-vf-green uppercase tracking-widest mb-1">Integraciones Vercel & Git</h4>
-                
-                <div>
-                  <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1.5">Vercel Deployment URL</label>
-                  <input 
-                    type="text"
-                    value={editedCard.vercelUrl || ""}
-                    onChange={(e) => setEditedCard({ ...editedCard, vercelUrl: e.target.value })}
-                    placeholder="https://..."
-                    className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2 text-sm text-white focus:outline-none focus:border-vf-green"
-                  />
-                </div>
-                
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1.5">GitHub Repository</label>
-                    <input 
-                      type="text"
-                      value={editedCard.gitRepo || ""}
-                      onChange={(e) => setEditedCard({ ...editedCard, gitRepo: e.target.value })}
-                      placeholder="usuario/repo"
-                      className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2 text-sm text-white focus:outline-none focus:border-vf-green"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1.5">Active Branch</label>
-                    <input 
-                      type="text"
-                      value={editedCard.gitBranch || "main"}
-                      onChange={(e) => setEditedCard({ ...editedCard, gitBranch: e.target.value })}
-                      className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2 text-sm text-white focus:outline-none focus:border-vf-green"
-                    />
-                  </div>
-                </div>
-
-                {/* V Brain connection state */}
-                <div className="flex items-center justify-between bg-white/[0.01] border border-white/5 rounded-2xl p-3">
-                  <div className="flex flex-col">
-                    <span className="text-[11px] font-bold text-white">Conexión con V Core (Hermana)</span>
-                    <span className="text-[9px] text-white/40">Activar canal directo neural de asistencia</span>
-                  </div>
-                  <input 
-                    type="checkbox"
-                    checked={editedCard.sisterConnected}
-                    onChange={(e) => setEditedCard({ ...editedCard, sisterConnected: e.target.checked })}
-                    className="w-4 h-4 rounded border-neutral-700 bg-neutral-800 text-vf-green focus:ring-vf-green"
-                  />
-                </div>
-              </div>
-
-              {/* Actions footer */}
-              <div className="flex justify-between items-center border-t border-white/5 pt-4">
-                <button 
-                  onClick={() => handleDelete(editedCard.id)}
-                  className="bg-red-500/10 border border-red-500/20 text-red-400 font-semibold px-3 py-2 rounded-xl text-xs flex items-center gap-1.5 hover:bg-red-500 hover:text-white transition-all"
-                >
-                  <Trash2 className="w-3.5 h-3.5" />
-                  <span>Eliminar</span>
-                </button>
-
-                <div className="flex gap-2">
-                  <button 
-                    onClick={() => setIsEditing(false)}
-                    className="px-4 py-2 text-xs font-semibold text-white/50 hover:text-white transition-colors"
-                  >
-                    Cancelar
-                  </button>
-                  <button 
-                    onClick={handleUpdate}
-                    className="bg-vf-green text-black font-bold px-4 py-2 rounded-xl text-xs flex items-center gap-1 hover:bg-vf-green/80 transition-colors active:scale-95"
-                  >
-                    <span>Guardar</span>
-                  </button>
-                </div>
-              </div>
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
-
-      {/* Modal: Crear Espacio (Bento Grid Workspace Creation) */}
-      <AnimatePresence>
-        {isCreateOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setIsCreateOpen(false)}
-              className="absolute inset-0 bg-black/80 backdrop-blur-md"
-            />
-
-            <motion.div
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              className="relative w-full max-w-md bg-neutral-900 border border-white/10 rounded-[32px] p-6 shadow-2xl z-10 flex flex-col max-h-[90vh] overflow-y-auto"
-            >
-              <h3 className="text-md font-bold text-white mb-4">Crear Nuevo Espacio Bento</h3>
-              
-              <div className="flex flex-col gap-4 mb-6">
-                <div>
-                  <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1">Nombre del Proyecto</label>
-                  <input 
-                    type="text"
-                    placeholder="Ej: Ecosistema Castores"
-                    value={newTitle}
-                    onChange={(e) => setNewTitle(e.target.value)}
-                    className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors"
-                  />
-                </div>
-                
-                <div>
-                  <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1">Descripción Corta</label>
-                  <input 
-                    type="text"
-                    placeholder="Resumen del trabajo de la app..."
-                    value={newDesc}
-                    onChange={(e) => setNewDesc(e.target.value)}
-                    className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors"
-                  />
-                </div>
-
-                <div>
-                  <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1">Imagen URL del Proyecto</label>
-                  <input 
-                    type="text"
-                    placeholder="https://..."
-                    value={newBg}
-                    onChange={(e) => setNewBg(e.target.value)}
-                    className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors"
-                  />
-                </div>
-
-                <div className="border-t border-white/5 pt-3">
-                  <h4 className="text-xs font-bold text-vf-green uppercase tracking-widest mb-3">Módulos Git & Vercel (Opcional)</h4>
-                  
-                  <div className="flex flex-col gap-3">
-                    <div>
-                      <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1">Liga Vercel</label>
-                      <input 
-                        type="text"
-                        placeholder="https://..."
-                        value={newVercel}
-                        onChange={(e) => setNewVercel(e.target.value)}
-                        className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors"
-                      />
-                    </div>
-                    <div>
-                      <label className="text-[10px] font-bold text-white/40 uppercase tracking-wider block mb-1">Repositorio GitHub</label>
-                      <input 
-                        type="text"
-                        placeholder="usuario/repo"
-                        value={newGit}
-                        onChange={(e) => setNewGit(e.target.value)}
-                        className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex gap-3 justify-end border-t border-white/5 pt-4">
-                <button 
-                  onClick={() => setIsCreateOpen(false)}
-                  className="px-4 py-2 text-xs font-semibold text-white/50 hover:text-white transition-colors"
-                >
-                  Cancelar
-                </button>
-                <button 
-                  onClick={handleCreate}
-                  className="bg-vf-green text-black font-bold px-5 py-2.5 rounded-xl text-xs flex items-center gap-1 transition-colors active:scale-95"
-                >
-                  <span>Crear Espacio</span>
-                </button>
-              </div>
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
-
+function EmptyState() {
+  return (
+    <div className="rounded-lg border border-dashed border-vf-border-1 bg-vf-bg-1/30 px-6 py-16 text-center space-y-5">
+      <div className="inline-flex w-12 h-12 items-center justify-center rounded-full bg-vf-bg-2 border border-vf-border">
+        <CircleDot className="w-5 h-5 text-vf-fg-2" />
+      </div>
+      <div className="space-y-1.5">
+        <h2 className="text-vf-fg font-semibold text-lg">
+          Aún no hay proyectos
+        </h2>
+        <p className="text-vf-fg-1 text-sm max-w-md mx-auto">
+          Da de alta tus proyectos uno por uno. V los irá conociendo conforme
+          los agregues y los podrá administrar contigo.
+        </p>
+      </div>
+      <Link
+        href="/projects"
+        className="inline-flex items-center gap-2 h-10 px-4 rounded-md bg-vf-green text-black text-sm font-semibold hover:bg-vf-green/90 transition-colors"
+      >
+        <Plus className="w-4 h-4" />
+        Dar de alta el primero
+      </Link>
     </div>
   );
 }

--- a/components/V/VDock.tsx
+++ b/components/V/VDock.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ChevronRight, X, Sparkles, Maximize2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ChatPage } from "./ChatPage";
+
+interface VDockProps {
+  /** Optional context to surface to V (current route, project, etc.) — for now display only */
+  context?: { label: string; value: string } | null;
+}
+
+const STORAGE_KEY = "v_dock_collapsed";
+
+/**
+ * VDock — V always present, never hidden in a sidebar item.
+ *
+ * Desktop: anchored right column (380px expanded, 56px collapsed).
+ * Mobile: hidden by default; opened as a fullscreen sheet via the
+ * topbar V button.
+ */
+export function VDock({ context }: VDockProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "1") setCollapsed(true);
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !hydrated) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, collapsed ? "1" : "0");
+    } catch {
+      // ignore
+    }
+  }, [collapsed, hydrated]);
+
+  // Listen for global "open V" events from the mobile topbar button.
+  useEffect(() => {
+    const handler = () => setMobileOpen(true);
+    window.addEventListener("vforge:open-v", handler);
+    return () => window.removeEventListener("vforge:open-v", handler);
+  }, []);
+
+  return (
+    <>
+      {/* Desktop dock */}
+      <aside
+        className={cn(
+          "hidden lg:flex flex-col",
+          "fixed right-0 top-0 bottom-0 z-30",
+          "bg-vf-bg border-l border-vf-border",
+          "transition-[width] duration-200 ease-out",
+          collapsed ? "w-14" : "w-[380px]",
+        )}
+        aria-label="Chat con V"
+      >
+        {collapsed ? (
+          <button
+            onClick={() => setCollapsed(false)}
+            className="flex flex-col items-center gap-3 pt-4 w-full text-vf-fg-1 hover:text-vf-fg transition-colors"
+            aria-label="Expandir chat con V"
+          >
+            <div className="w-9 h-9 rounded-md bg-vf-green/10 border border-vf-green/30 flex items-center justify-center">
+              <Sparkles className="w-4 h-4 text-vf-green" />
+            </div>
+            <span className="font-mono text-[10px] uppercase tracking-widest text-vf-fg-2 [writing-mode:vertical-rl] rotate-180">
+              V · chat
+            </span>
+          </button>
+        ) : (
+          <>
+            {/* Dock header */}
+            <div className="h-12 flex items-center justify-between px-4 border-b border-vf-border">
+              <div className="flex items-center gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-vf-green animate-pulse" />
+                <span className="text-sm font-semibold text-vf-fg">V</span>
+                <span className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2">
+                  · agente
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <a
+                  href="/v"
+                  className="p-1.5 rounded hover:bg-vf-bg-1 text-vf-fg-2 hover:text-vf-fg transition-colors"
+                  title="Abrir sesión completa"
+                  aria-label="Abrir sesión completa"
+                >
+                  <Maximize2 className="w-3.5 h-3.5" />
+                </a>
+                <button
+                  onClick={() => setCollapsed(true)}
+                  className="p-1.5 rounded hover:bg-vf-bg-1 text-vf-fg-2 hover:text-vf-fg transition-colors"
+                  aria-label="Colapsar"
+                >
+                  <ChevronRight className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Context strip */}
+            {context && (
+              <div className="px-4 py-2 border-b border-vf-border bg-vf-bg-1/40">
+                <div className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2">
+                  {context.label}
+                </div>
+                <div className="text-xs text-vf-fg-1 truncate">{context.value}</div>
+              </div>
+            )}
+
+            {/* Chat */}
+            <div className="flex-1 min-h-0">
+              <ChatPage />
+            </div>
+          </>
+        )}
+      </aside>
+
+      {/* Mobile fullscreen sheet — controlled by global event from topbar */}
+      {mobileOpen && (
+        <div
+          className="lg:hidden fixed inset-0 z-50 bg-vf-bg flex flex-col"
+          role="dialog"
+          aria-label="Chat con V"
+        >
+          <div className="h-12 flex items-center justify-between px-4 border-b border-vf-border flex-shrink-0">
+            <div className="flex items-center gap-2">
+              <span className="w-1.5 h-1.5 rounded-full bg-vf-green animate-pulse" />
+              <span className="text-sm font-semibold text-vf-fg">V</span>
+            </div>
+            <button
+              onClick={() => setMobileOpen(false)}
+              className="p-2 -mr-2 rounded text-vf-fg-1 hover:text-vf-fg"
+              aria-label="Cerrar"
+              style={{ touchAction: "manipulation" }}
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+          {context && (
+            <div className="px-4 py-2 border-b border-vf-border bg-vf-bg-1/40 flex-shrink-0">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2">
+                {context.label}
+              </div>
+              <div className="text-xs text-vf-fg-1 truncate">{context.value}</div>
+            </div>
+          )}
+          <div className="flex-1 min-h-0">
+            <ChatPage />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+/** Helper for any component to open V on mobile. */
+export function openV() {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("vforge:open-v"));
+  }
+}

--- a/components/vforge/app-shell.tsx
+++ b/components/vforge/app-shell.tsx
@@ -1,155 +1,68 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { Sidebar } from "./sidebar";
 import { MobileNav } from "./mobile-nav";
+import { Topbar } from "./topbar";
 import { Drawer } from "./drawer";
-import { MultichatDrawer } from "@/components/V/MultichatDrawer";
-import { usePathname, useRouter } from "next/navigation";
-import { motion, AnimatePresence } from "framer-motion";
-import { cn } from "@/lib/utils";
-import { ChevronLeft } from "lucide-react";
+import { VDock } from "@/components/V/VDock";
+import { usePathname } from "next/navigation";
 
 interface AppShellProps {
   children: React.ReactNode;
 }
 
+/**
+ * Vercel/Linear-style shell:
+ *   Desktop ≥ lg   → [ Sidebar 240px | Main (fluid) | V dock 380px ]
+ *   md → lg        → [ Sidebar 220px | Main (fluid) ]  · V via topbar button
+ *   < md           → [ Topbar | Main | Bottom hint ]   · Sidebar via drawer
+ *
+ * No spring animations on route transitions — content paints immediately.
+ */
 export function AppShell({ children }: AppShellProps) {
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [isMultichatOpen, setIsMultichatOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const pathname = usePathname();
-  const router = useRouter();
 
-  const isHome = pathname ? (pathname.replace(/\/$/, "") === "/hub" || pathname === "/") : false;
+  // Close mobile drawer on route change.
+  useEffect(() => {
+    setDrawerOpen(false);
+  }, [pathname]);
 
   return (
-    <div className="min-h-screen bg-neutral-950 relative overflow-hidden flex select-none text-white font-sans w-full">
-      
-      {/* Immersive Cinematic Wallpaper (glowing ambient orbs) */}
-      <div 
-        className="absolute inset-0 z-0 overflow-hidden pointer-events-none"
-        style={{ background: "radial-gradient(circle at center, #15102a 0%, #03000a 100%)" }}
+    <div className="min-h-screen bg-vf-bg text-vf-fg font-sans antialiased">
+      {/* Mobile topbar (hamburger + V button) */}
+      <Topbar onMenuClick={() => setDrawerOpen(true)} />
+
+      {/* Desktop left sidebar (fixed) */}
+      <Sidebar />
+
+      {/* Mobile slide-in drawer wrapping the same Sidebar tree */}
+      <Drawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
+
+      {/* V dock — desktop ≥ lg only; mobile uses topbar button */}
+      <VDock />
+
+      {/* Main content
+          - Desktop: left padded by sidebar (240px) and right padded by V dock (380px lg)
+          - Mobile: top padded by topbar (56px) */}
+      <main
+        className="
+          pt-14 md:pt-0
+          md:pl-[220px] lg:pl-[240px]
+          lg:pr-[380px]
+          min-h-screen
+        "
       >
-        {/* Ambient Orb 1 */}
-        <motion.div 
-          animate={{
-            x: [0, 40, -20, 0],
-            y: [0, -30, 20, 0],
-            scale: [1, 1.1, 0.9, 1],
-          }}
-          transition={{
-            duration: 15,
-            repeat: Infinity,
-            ease: "easeInOut"
-          }}
-          className="absolute -top-40 -left-40 w-96 h-96 rounded-full bg-violet-600/25 blur-[120px]"
-        />
-        {/* Ambient Orb 2 */}
-        <motion.div 
-          animate={{
-            x: [0, -50, 30, 0],
-            y: [0, 40, -30, 0],
-            scale: [1, 0.9, 1.1, 1],
-          }}
-          transition={{
-            duration: 18,
-            repeat: Infinity,
-            ease: "easeInOut"
-          }}
-          className="absolute top-1/2 left-1/3 w-[500px] h-[500px] rounded-full bg-blue-600/10 blur-[150px]"
-        />
-        {/* Ambient Orb 3 */}
-        <motion.div 
-          animate={{
-            x: [0, 30, -30, 0],
-            y: [0, 50, 20, 0],
-          }}
-          transition={{
-            duration: 12,
-            repeat: Infinity,
-            ease: "easeInOut"
-          }}
-          className="absolute -bottom-20 -right-20 w-96 h-96 rounded-full bg-vf-green/15 blur-[100px]"
-        />
-      </div>
-
-      {/* Main OS Viewport (Always full-screen for absolute immersion) */}
-      <div className="flex-1 flex flex-col min-h-screen w-full relative z-10">
-        
-        {/* Glassmorphic Top Status Bar (Clean and modern like macOS/iOS) */}
-        <header className="h-12 w-full border-b border-white/5 bg-white/[0.02] backdrop-blur-md px-6 flex items-center justify-between z-30 select-none">
-          <div className="flex items-center gap-4">
-            <span className="text-xs font-semibold tracking-wider text-white/90 font-mono">vForge OS</span>
-            <div className="flex items-center gap-1.5 bg-vf-green/10 px-2 py-0.5 rounded-full border border-vf-green/30">
-              <span className="w-1.5 h-1.5 rounded-full bg-vf-green animate-pulse" />
-              <span className="text-[9px] font-bold text-vf-green tracking-wider uppercase font-mono">Anillo 0</span>
-            </div>
-          </div>
-          <div className="flex items-center gap-3 text-xs text-white/40 font-mono">
-            <span>v1.2.0</span>
-          </div>
-        </header>
-
-        {/* Desktop Viewport Wrapper */}
-        <div className="flex-1 relative w-full h-full flex items-center justify-center p-4 md:p-8">
-          <AnimatePresence mode="wait">
-            {!isHome && (
-              <motion.div
-                key={pathname}
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 12 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
-                className={cn(
-                  "absolute inset-x-2 top-2 bottom-16 md:inset-x-8 md:top-6 md:bottom-24 max-w-5xl mx-auto",
-                  "bg-vf-bg/80 backdrop-blur-2xl border border-white/10 rounded-3xl shadow-[0_25px_60px_-15px_rgba(0,0,0,0.8)]",
-                  "flex flex-col overflow-hidden"
-                )}
-              >
-                {/* App Navigation Header */}
-                <div className="h-14 flex items-center justify-between px-6 border-b border-white/5 bg-white/[0.03]">
-                  <button 
-                    onClick={() => router.push("/hub")}
-                    className="flex items-center gap-2 text-xs font-semibold text-vf-green hover:text-white transition-colors py-1.5 px-3 rounded-xl bg-white/5 border border-white/10 active:scale-95"
-                  >
-                    <ChevronLeft className="w-4 h-4" />
-                    <span>Regresar</span>
-                  </button>
-                  <div className="w-16 h-1.5 bg-white/20 rounded-full" />
-                  <div className="w-24" />
-                </div>
-
-                {/* Content Inside Active App */}
-                <div className="flex-1 overflow-y-auto px-6 py-6 scrollbar-thin scrollbar-thumb-white/10">
-                  {children}
-                </div>
-              </motion.div>
-            )}
-
-            {isHome && (
-              <motion.div
-                key="home-desktop"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.2, ease: "easeOut" }}
-                className="absolute inset-0 overflow-y-auto flex items-center justify-center"
-              >
-                <div className="w-full max-w-6xl h-full flex flex-col items-center justify-start">
-                  {children}
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+        <div className="mx-auto max-w-6xl px-4 md:px-8 py-6 md:py-10">
+          {children}
         </div>
+      </main>
 
-        {/* Global Bottom OS Navigation & Dock */}
-        <div className="fixed bottom-0 left-0 right-0 z-40 pb-safe">
-          <MobileNav onOrbClick={() => setIsMultichatOpen(true)} />
-        </div>
+      {/* Mobile bottom nav (hidden on md+) */}
+      <div className="md:hidden fixed bottom-0 inset-x-0 z-40 pb-safe">
+        <MobileNav />
       </div>
-
-      {/* Multichat Panel */}
-      <MultichatDrawer isOpen={isMultichatOpen} onClose={() => setIsMultichatOpen(false)} />
     </div>
   );
 }

--- a/components/vforge/drawer.tsx
+++ b/components/vforge/drawer.tsx
@@ -11,7 +11,6 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard,
   FolderKanban,
-  Sparkles,
   Activity,
   Eye,
   Search,
@@ -21,13 +20,15 @@ import {
   Settings,
 } from "lucide-react";
 
+// Note: "Forge AI" / V isn't in this drawer — V is the central
+// element, accessed from the topbar button (mobile) or right dock
+// (desktop). This drawer mirrors the desktop sidebar nav.
 const navSections = [
   {
     label: "CONTROL",
     items: [
       { name: "Hub", href: "/hub", icon: LayoutDashboard },
       { name: "Proyectos", href: "/projects", icon: FolderKanban },
-      { name: "Forge AI", href: "/forge", icon: Sparkles },
       { name: "Actividad", href: "/activity", icon: Activity },
     ],
   },

--- a/components/vforge/mobile-nav.tsx
+++ b/components/vforge/mobile-nav.tsx
@@ -3,116 +3,63 @@
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ForgeOrb } from "@/components/ui/forge-orb";
-import { motion } from "framer-motion";
 import {
   LayoutDashboard,
   FolderKanban,
   Lock,
   Boxes,
+  Activity,
 } from "lucide-react";
 
 const navItems = [
   { name: "Hub", href: "/hub", icon: LayoutDashboard },
   { name: "Proyectos", href: "/projects", icon: FolderKanban },
-  { name: "FORGE", href: "/forge", icon: null, isCenter: true },
   { name: "Bóveda", href: "/vault", icon: Lock },
   { name: "Módulos", href: "/modules", icon: Boxes },
+  { name: "Activity", href: "/activity", icon: Activity },
 ];
 
-interface MobileNavProps {
-  className?: string;
-  onOrbClick?: () => void;
-}
-
-export function MobileNav({ className, onOrbClick }: MobileNavProps) {
+/**
+ * Bottom nav for mobile. Clean GitHub-style:
+ * - 5 equal items
+ * - No floating orb (V is accessed from the topbar — central, always)
+ * - Solid background, no backdrop blur (cheap on mobile)
+ */
+export function MobileNav({ className }: { className?: string }) {
   const pathname = usePathname();
 
-  const handleTap = () => {
-    if (typeof navigator !== "undefined" && navigator.vibrate) {
-      navigator.vibrate(8);
-    }
-  };
-
   return (
-    <div className="w-full flex justify-center px-4 pb-4 select-none">
-      <nav
-        className={cn(
-          "w-full max-w-lg h-16 px-4 flex items-center justify-around",
-          "bg-white/[0.04] backdrop-blur-2xl border border-white/10 rounded-[28px] shadow-[0_20px_50px_rgba(0,0,0,0.6)]",
-          "pb-safe transition-all duration-300",
-          className
-        )}
-      >
-        {navItems.map((item) => {
-          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
-
-          if (item.isCenter) {
-            return (
-              <button
-                key="orb"
-                onClick={() => {
-                  handleTap();
-                  if (onOrbClick) onOrbClick();
-                }}
-                className={cn(
-                  "flex flex-col items-center justify-center",
-                  "w-12 h-12 -mt-6 rounded-full relative group",
-                  "bg-black border border-white/10",
-                  "ring-2 ring-vf-green/50 hover:ring-vf-green",
-                  "shadow-[0_0_20px_rgba(124,255,60,0.25)] hover:shadow-[0_0_30px_rgba(124,255,60,0.5)]",
-                  "transition-all duration-300",
-                  "active:scale-90 hover:scale-110"
-                )}
-                aria-label="V"
-              >
-                {/* Micro-glow indicator under Orb */}
-                <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-4 h-1 bg-vf-green/60 blur-[3px] rounded-full opacity-0 group-hover:opacity-100 transition-opacity" />
-                <ForgeOrb size={28} state="idle" glow={false} />
-              </button>
-            );
-          }
-
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={handleTap}
-              className={cn(
-                "flex flex-col items-center justify-center gap-0.5 py-1 px-3 relative group",
-                "min-w-[50px] min-h-[44px] rounded-2xl",
-                "transition-all duration-300 hover:-translate-y-1 hover:bg-white/[0.02] active:scale-95"
-              )}
-            >
-              {item.icon && (
-                <item.icon
-                  className={cn(
-                    "w-5 h-5 transition-transform duration-300 group-hover:scale-110",
-                    isActive ? "text-vf-green" : "text-white/40 group-hover:text-white/70"
-                  )}
-                />
-              )}
-              
-              <span
-                className={cn(
-                  "text-[9px] font-semibold tracking-wide transition-colors",
-                  isActive ? "text-vf-green" : "text-white/40 group-hover:text-white/70"
-                )}
-              >
-                {item.name}
-              </span>
-
-              {/* Active navigation indicator dot */}
-              {isActive && (
-                <motion.span 
-                  layoutId="activeDot"
-                  className="absolute bottom-1 w-1 h-1 bg-vf-green rounded-full shadow-[0_0_8px_#7cff3c]" 
-                />
-              )}
-            </Link>
-          );
-        })}
-      </nav>
-    </div>
+    <nav
+      className={cn(
+        "h-14 px-1 flex items-stretch justify-around",
+        "bg-vf-bg border-t border-vf-border",
+        className,
+      )}
+      style={{ touchAction: "manipulation" }}
+    >
+      {navItems.map((item) => {
+        const isActive =
+          pathname === item.href ||
+          (pathname?.startsWith(`${item.href}/`) ?? false);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "flex-1 flex flex-col items-center justify-center gap-0.5",
+              "transition-colors",
+              "min-h-[44px]",
+              isActive ? "text-vf-green" : "text-vf-fg-2 hover:text-vf-fg-1",
+            )}
+            style={{ touchAction: "manipulation" }}
+          >
+            <item.icon className="w-5 h-5" strokeWidth={isActive ? 2.4 : 2} />
+            <span className="text-[10px] font-medium leading-none">
+              {item.name}
+            </span>
+          </Link>
+        );
+      })}
+    </nav>
   );
 }

--- a/components/vforge/sidebar.tsx
+++ b/components/vforge/sidebar.tsx
@@ -8,7 +8,6 @@ import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   FolderKanban,
-  Sparkles,
   Activity,
   Eye,
   Search,
@@ -18,13 +17,15 @@ import {
   Settings,
 } from "lucide-react";
 
+// Note: "Forge AI" / V is intentionally NOT in this sidebar.
+// V lives permanently in the right dock (VDock) and on mobile is
+// accessed via the topbar button — V is central, not a side item.
 const navSections = [
   {
     label: "CONTROL",
     items: [
       { name: "Hub", href: "/hub", icon: LayoutDashboard },
       { name: "Proyectos", href: "/projects", icon: FolderKanban },
-      { name: "Forge AI", href: "/forge", icon: Sparkles },
       { name: "Actividad", href: "/activity", icon: Activity },
     ],
   },
@@ -45,49 +46,58 @@ const navSections = [
 ];
 
 interface SidebarProps {
-  className?: string;
+  /** When true, renders without the responsive wrapper (used inside the mobile drawer). */
+  inDrawer?: boolean;
+  onItemClick?: () => void;
 }
 
-export function Sidebar({ className }: SidebarProps) {
+export function Sidebar({ inDrawer = false, onItemClick }: SidebarProps) {
   const pathname = usePathname();
 
   return (
     <aside
       className={cn(
-        "hidden md:flex flex-col w-[220px] lg:w-[240px] h-screen",
+        "flex flex-col w-[220px] lg:w-[240px] h-screen",
         "bg-vf-bg border-r border-vf-border",
-        "fixed left-0 top-0",
-        className
+        inDrawer ? "" : "hidden md:flex fixed left-0 top-0 z-30",
       )}
     >
+      {/* Brand header */}
+      <div className="h-14 flex items-center px-5 border-b border-vf-border flex-shrink-0">
+        <Brand size="sm" />
+      </div>
+
+      {/* Nav */}
       <div className="flex-1 overflow-y-auto px-3 py-4">
         {navSections.map((section) => (
           <div key={section.label} className="mb-6">
-            <div className="px-3 mb-2 text-[11px] uppercase tracking-wide text-vf-fg-2 font-medium">
+            <div className="px-3 mb-1.5 text-[10px] uppercase tracking-widest text-vf-fg-2 font-medium font-mono">
               {section.label}
             </div>
             <nav className="flex flex-col gap-0.5">
               {section.items.map((item) => {
-                const isActive = pathname === item.href;
+                const isActive =
+                  pathname === item.href ||
+                  (pathname?.startsWith(`${item.href}/`) ?? false);
                 return (
                   <Link
                     key={item.href}
                     href={item.href}
+                    onClick={onItemClick}
                     className={cn(
                       "relative flex items-center gap-3 px-3 py-2 rounded-md",
                       "text-sm transition-colors duration-150",
+                      "min-h-[40px]",
                       isActive
                         ? "text-vf-fg bg-vf-bg-1"
-                        : "text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1"
+                        : "text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1",
                     )}
                   >
                     {isActive && (
-                      <span
-                        className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-vf-green rounded-r green-glow-sm"
-                      />
+                      <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-vf-green rounded-r" />
                     )}
-                    <item.icon className="w-4 h-4" />
-                    <span>{item.name}</span>
+                    <item.icon className="w-4 h-4 flex-shrink-0" />
+                    <span className="truncate">{item.name}</span>
                   </Link>
                 );
               })}
@@ -95,11 +105,10 @@ export function Sidebar({ className }: SidebarProps) {
           </div>
         ))}
       </div>
-      <div className="px-4 py-2 border-t border-vf-border">
+
+      {/* Footer */}
+      <div className="px-3 py-3 border-t border-vf-border flex-shrink-0">
         <ThemeToggle variant="row" />
-      </div>
-      <div className="px-6 py-4 border-t border-vf-border">
-        <Brand size="md" />
       </div>
     </aside>
   );

--- a/components/vforge/topbar.tsx
+++ b/components/vforge/topbar.tsx
@@ -2,56 +2,57 @@
 
 import { cn } from "@/lib/utils";
 import { Brand } from "./brand";
-import { ProjectSwitcher } from "./project-switcher";
-import { ThemeToggle } from "@/components/ui/theme-toggle";
-import { Menu, Bell, Settings } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Menu, Sparkles } from "lucide-react";
+import { openV } from "@/components/V/VDock";
 
 interface TopbarProps {
   onMenuClick?: () => void;
   className?: string;
 }
 
+/**
+ * Mobile-only topbar (md:hidden).
+ * - Left: hamburger → opens Sidebar drawer
+ * - Center: brand
+ * - Right: V button → opens VDock as fullscreen sheet
+ *
+ * Desktop has no topbar — sidebar + content + V dock fill the viewport
+ * (Vercel/Linear style).
+ */
 export function Topbar({ onMenuClick, className }: TopbarProps) {
   return (
     <header
       className={cn(
         "md:hidden fixed top-0 left-0 right-0 z-40",
-        "h-14 px-4 flex items-center justify-between",
-        "bg-vf-bg/60 backdrop-blur-xl border-b border-vf-border/50",
-        className
+        "h-14 px-3 flex items-center justify-between gap-3",
+        "bg-vf-bg/90 backdrop-blur-md border-b border-vf-border",
+        className,
       )}
     >
-      <div className="flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="w-9 h-9 text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1"
+      <div className="flex items-center gap-2 min-w-0">
+        <button
+          type="button"
           onClick={onMenuClick}
+          aria-label="Abrir menú"
+          className="w-10 h-10 flex items-center justify-center rounded-md text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1 active:bg-vf-bg-2 transition-colors"
+          style={{ touchAction: "manipulation" }}
         >
           <Menu className="w-5 h-5" />
-        </Button>
+        </button>
         <Brand size="sm" />
       </div>
 
-      <div className="flex items-center gap-2">
-        <ProjectSwitcher />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="w-9 h-9 text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1"
-        >
-          <Bell className="w-4 h-4" />
-        </Button>
-        <ThemeToggle />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="w-9 h-9 text-vf-fg-1 hover:text-vf-fg hover:bg-vf-bg-1"
-        >
-          <Settings className="w-4 h-4" />
-        </Button>
-      </div>
+      <button
+        type="button"
+        onClick={openV}
+        aria-label="Abrir chat con V"
+        className="h-9 px-3 flex items-center gap-2 rounded-md bg-vf-green/10 border border-vf-green/30 text-vf-green hover:bg-vf-green/20 active:bg-vf-green/30 transition-colors"
+        style={{ touchAction: "manipulation" }}
+      >
+        <Sparkles className="w-3.5 h-3.5" />
+        <span className="text-xs font-semibold tracking-wide">V</span>
+        <span className="w-1.5 h-1.5 rounded-full bg-vf-green animate-pulse" />
+      </button>
     </header>
   );
 }


### PR DESCRIPTION
## Para qué

Reemplaza el shell "vForge OS" (bonito de mockup, impráctico en mobile) por un dashboard sobrio tipo Vercel/Linear con **V como elemento central y siempre accesible**, no como item escondido de sidebar.

Es **PR-1 de 3** del rediseño. Cuando confirmes que la dirección te funciona, sigo con el rediseño consistente de proyectos/vault/módulos y las acciones reales de V por card.

## Estructura nueva

| Viewport | Layout |
|---|---|
| Desktop ≥ lg | Sidebar 240px · Main · **V dock derecho 380px** (colapsable a 56px) |
| md → lg | Sidebar 220px · Main · V via botón verde en topbar |
| Mobile | Topbar minimal · Main · Bottom nav (5 items) · V abre overlay fullscreen |

Sin animaciones spring/slide-from-bottom (eran lo que dejaba `/projects` en negro). Solo fades 150-200ms.

## V central

- **`components/V/VDock.tsx`** (nuevo): dock derecho con `ChatPage` embebido, estatus pulsante, link a `/v`, botón colapsar. En mobile abre fullscreen via `CustomEvent("vforge:open-v")` — la topbar y cualquier card pueden dispararlo.
- Sidebar pierde el item "Forge AI" (V no es un item — es el centro).
- Topbar mobile tiene botón **V verde explícito** a la derecha, siempre visible.
- Bottom nav simplificado: 5 items normales, sin orb flotante ni backdrop-blur.

## Hub reescrito

- **984 líneas → 313 líneas**. Mismo contenido, sin grasa.
- Fetcha `/api/projects` REAL (antes había mock + bento art deco).
- Filas estilo GitHub repo list: status dot · nombre · repo (mono) · badges · acciones.
- **Botón "V" en cada fila** dispara `CustomEvent("vforge:v-context")` que abre el dock con contexto del proyecto pre-cargado.
- Empty state honesto que invita a `/projects` para dar de alta.

## Mobile-first

- `touch-action: manipulation` en todos los tappables
- `fontSize: 16` en inputs (previene zoom iOS Safari)
- `min-height: 44px` en todos los hit targets
- Sin `backdrop-blur` en superficies persistentes (cheap on mobile)

## Cómo probar el preview

1. Abre el preview de Vercel (link arriba)
2. **Desktop**: deberías ver sidebar izq + hub + V dock derecho con chat real
3. **Mobile**: top bar verde con botón "V" pulsante → ábrelo → debe ser overlay fullscreen del chat real con V respondiendo (no mock)
4. Hub: si hay proyectos, debe mostrarlos en filas limpias; cada uno con botón V que abre el dock

## Pendiente próximos PRs (con tu OK del estilo)

1. VDock escuchar `vforge:v-context` y autoinyectar el prompt en el composer (hoy solo abre el dock).
2. Rediseño consistente de `/projects`, `/vault`, `/modules`, `/activity`.
3. Acciones reales por card (deploy, restart, rotate key) que llamen tools de V vía `/api/forge/run`.

## Verificación

- `tsc --noEmit` → 0 errores
- Diff: -1013 / +563 (menos código que antes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_