### PR TITLE
feat(v): dock context-aware + acciones V por card en /projects

### DIFF
--- a/app/(dashboard)/projects/page.tsx
+++ b/app/(dashboard)/projects/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Plus, ExternalLink, GitBranch, Lock, RefreshCw } from "lucide-react";
+import { Plus, ExternalLink, GitBranch, Lock, RefreshCw, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { openV } from "@/components/V/VDock";
 
 interface Project {
   id: string;
@@ -191,14 +192,18 @@ export default function ProjectsPage() {
         ) : (
           <div className="border-t border-vf-border">
             {filtered.map((p) => (
-              <Link
+              <div
                 key={p.id}
-                href={`/projects/${p.id}`}
-                className="flex items-center justify-between py-4 px-4 -mx-4 md:mx-0 hover:bg-vf-bg-1 transition-colors border-b border-vf-border"
+                className="flex items-center gap-3 py-4 px-4 -mx-4 md:mx-0 hover:bg-vf-bg-1 transition-colors border-b border-vf-border"
               >
-                <div className="min-w-0 flex-1 pr-3">
+                <Link
+                  href={`/projects/${p.id}`}
+                  className="min-w-0 flex-1 pr-3 block group"
+                >
                   <div className="flex items-center gap-2">
-                    <span className="text-vf-fg font-medium truncate">{p.name}</span>
+                    <span className="text-vf-fg font-medium truncate group-hover:underline">
+                      {p.name}
+                    </span>
                     {p.github_private && (
                       <Lock className="w-3 h-3 text-vf-fg-2 flex-shrink-0" />
                     )}
@@ -212,14 +217,34 @@ export default function ProjectsPage() {
                       </span>
                     )}
                   </div>
-                </div>
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  {p.vercel_url && <ExternalLink className="w-3.5 h-3.5 text-vf-green-quiet" />}
-                  <span className="font-mono text-[10px] uppercase text-vf-fg-2">
+                </Link>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  {p.vercel_url && (
+                    <ExternalLink className="w-3.5 h-3.5 text-vf-green-quiet" />
+                  )}
+                  <span className="font-mono text-[10px] uppercase text-vf-fg-2 mr-1">
                     {p.category}
                   </span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openV({
+                        label: "PROYECTO",
+                        value: `${p.name} · ${p.github_repo ?? "sin repo"}`,
+                        prompt: `Cuéntame el estado actual de ${p.name} (repo ${p.github_repo ?? "n/a"}, deploy ${p.vercel_url ?? "n/a"}, categoría ${p.category}). ¿Algo que necesite atención?`,
+                      });
+                    }}
+                    title="Preguntar a V sobre este proyecto"
+                    aria-label="Preguntar a V"
+                    className="inline-flex items-center gap-1 h-8 px-2 rounded text-vf-green hover:bg-vf-green/10 transition-colors"
+                    style={{ touchAction: "manipulation" }}
+                  >
+                    <Sparkles className="w-3.5 h-3.5" />
+                    <span className="hidden sm:inline text-xs font-medium">V</span>
+                  </button>
                 </div>
-              </Link>
+              </div>
             ))}
           </div>
         )}

--- a/components/V/ChatPage.tsx
+++ b/components/V/ChatPage.tsx
@@ -3,8 +3,11 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { ChatContainer, Message } from './ChatContainer';
 import { ChatComposer } from './ChatComposer';
+import { V_PENDING_PROMPT_KEY } from './VDock';
 
 const SESSION_KEY = 'v_chat_session_id';
+/** Stale prompts older than this are ignored — prevents replaying yesterday's question. */
+const PROMPT_TTL_MS = 10_000;
 
 function getOrCreateSessionId(): string {
   if (typeof window === 'undefined') return `v_${Date.now()}`;
@@ -47,6 +50,35 @@ export const ChatPage = () => {
       ctrl.current?.abort();
     };
   }, []);
+
+  // Consume pending prompt from sessionStorage (set by openV({ prompt }))
+  // and auto-send. Runs on mount AND on every "vforge:open-v" event so
+  // that a second card click on the same page re-triggers it.
+  useEffect(() => {
+    const consume = () => {
+      if (typeof window === 'undefined') return;
+      const raw = window.sessionStorage.getItem(V_PENDING_PROMPT_KEY);
+      if (!raw) return;
+      try {
+        const parsed = JSON.parse(raw) as { prompt?: string; ts?: number };
+        window.sessionStorage.removeItem(V_PENDING_PROMPT_KEY);
+        if (
+          parsed?.prompt &&
+          typeof parsed.ts === 'number' &&
+          Date.now() - parsed.ts < PROMPT_TTL_MS
+        ) {
+          void handleSubmitRef.current?.(parsed.prompt);
+        }
+      } catch {
+        window.sessionStorage.removeItem(V_PENDING_PROMPT_KEY);
+      }
+    };
+    consume();
+    window.addEventListener('vforge:open-v', consume);
+    return () => window.removeEventListener('vforge:open-v', consume);
+  }, []);
+
+  const handleSubmitRef = useRef<((c: string) => Promise<void>) | null>(null);
 
   const handleSubmit = useCallback(async (content: string) => {
     const userMessage: Message = {
@@ -149,6 +181,12 @@ export const ChatPage = () => {
       setIsLoading(false);
     }
   }, []);
+
+  // Keep the ref up to date so the "vforge:open-v" listener sees the
+  // latest handler closure.
+  useEffect(() => {
+    handleSubmitRef.current = handleSubmit;
+  }, [handleSubmit]);
 
   return (
     <div className="flex flex-col h-full bg-vf-bg-0">

--- a/components/V/VDock.tsx
+++ b/components/V/VDock.tsx
@@ -5,24 +5,31 @@ import { ChevronRight, X, Sparkles, Maximize2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ChatPage } from "./ChatPage";
 
-interface VDockProps {
-  /** Optional context to surface to V (current route, project, etc.) — for now display only */
-  context?: { label: string; value: string } | null;
-}
-
 const STORAGE_KEY = "v_dock_collapsed";
+/** sessionStorage key — picked up by ChatPage on mount/on open. */
+export const V_PENDING_PROMPT_KEY = "v_pending_prompt";
+
+interface VContext {
+  label: string;
+  value: string;
+}
 
 /**
  * VDock — V always present, never hidden in a sidebar item.
  *
  * Desktop: anchored right column (380px expanded, 56px collapsed).
  * Mobile: hidden by default; opened as a fullscreen sheet via the
- * topbar V button.
+ * topbar V button (or `openV()` from anywhere).
+ *
+ * Context-aware: when a card calls `openV({ label, value, prompt })`,
+ * the header surfaces the context strip and ChatPage auto-sends the
+ * prompt as the next user turn.
  */
-export function VDock({ context }: VDockProps) {
+export function VDock() {
   const [collapsed, setCollapsed] = useState(false);
   const [hydrated, setHydrated] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [context, setContext] = useState<VContext | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -40,9 +47,19 @@ export function VDock({ context }: VDockProps) {
     }
   }, [collapsed, hydrated]);
 
-  // Listen for global "open V" events from the mobile topbar button.
+  // Listen for global "open V" events. Detail may carry context to
+  // surface in the header strip.
   useEffect(() => {
-    const handler = () => setMobileOpen(true);
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { label?: string; value?: string }
+        | undefined;
+      setMobileOpen(true);
+      setCollapsed(false);
+      if (detail?.label && detail?.value) {
+        setContext({ label: detail.label, value: detail.value });
+      }
+    };
     window.addEventListener("vforge:open-v", handler);
     return () => window.removeEventListener("vforge:open-v", handler);
   }, []);
@@ -105,11 +122,22 @@ export function VDock({ context }: VDockProps) {
 
             {/* Context strip */}
             {context && (
-              <div className="px-4 py-2 border-b border-vf-border bg-vf-bg-1/40">
-                <div className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2">
-                  {context.label}
+              <div className="px-4 py-2 border-b border-vf-border bg-vf-bg-1/40 flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2">
+                    {context.label}
+                  </div>
+                  <div className="text-xs text-vf-fg-1 truncate">
+                    {context.value}
+                  </div>
                 </div>
-                <div className="text-xs text-vf-fg-1 truncate">{context.value}</div>
+                <button
+                  onClick={() => setContext(null)}
+                  className="p-1 -m-1 rounded text-vf-fg-2 hover:text-vf-fg hover:bg-vf-bg-2"
+                  aria-label="Quitar contexto"
+                >
+                  <X className="w-3 h-3" />
+                </button>
               </div>
             )}
 
@@ -121,7 +149,7 @@ export function VDock({ context }: VDockProps) {
         )}
       </aside>
 
-      {/* Mobile fullscreen sheet — controlled by global event from topbar */}
+      {/* Mobile fullscreen sheet — controlled by global event from topbar / cards */}
       {mobileOpen && (
         <div
           className="lg:hidden fixed inset-0 z-50 bg-vf-bg flex flex-col"
@@ -143,11 +171,22 @@ export function VDock({ context }: VDockProps) {
             </button>
           </div>
           {context && (
-            <div className="px-4 py-2 border-b border-vf-border bg-vf-bg-1/40 flex-shrink-0">
-              <div className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2">
-                {context.label}
+            <div className="px-4 py-2 border-b border-vf-border bg-vf-bg-1/40 flex items-start justify-between gap-2 flex-shrink-0">
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-wider text-vf-fg-2">
+                  {context.label}
+                </div>
+                <div className="text-xs text-vf-fg-1 truncate">
+                  {context.value}
+                </div>
               </div>
-              <div className="text-xs text-vf-fg-1 truncate">{context.value}</div>
+              <button
+                onClick={() => setContext(null)}
+                className="p-1 -m-1 rounded text-vf-fg-2 hover:text-vf-fg hover:bg-vf-bg-2"
+                aria-label="Quitar contexto"
+              >
+                <X className="w-3 h-3" />
+              </button>
             </div>
           )}
           <div className="flex-1 min-h-0">
@@ -159,9 +198,29 @@ export function VDock({ context }: VDockProps) {
   );
 }
 
-/** Helper for any component to open V on mobile. */
-export function openV() {
-  if (typeof window !== "undefined") {
-    window.dispatchEvent(new CustomEvent("vforge:open-v"));
+/**
+ * Open V from anywhere in the app. If `context.prompt` is provided,
+ * ChatPage will auto-send it as the next user turn.
+ */
+export function openV(opts?: {
+  label?: string;
+  value?: string;
+  prompt?: string;
+}) {
+  if (typeof window === "undefined") return;
+  if (opts?.prompt) {
+    try {
+      window.sessionStorage.setItem(
+        V_PENDING_PROMPT_KEY,
+        JSON.stringify({ prompt: opts.prompt, ts: Date.now() }),
+      );
+    } catch {
+      // ignore
+    }
   }
+  const detail = {
+    label: opts?.label,
+    value: opts?.value,
+  };
+  window.dispatchEvent(new CustomEvent("vforge:open-v", { detail }));
 }

--- a/components/vforge/topbar.tsx
+++ b/components/vforge/topbar.tsx
@@ -44,7 +44,7 @@ export function Topbar({ onMenuClick, className }: TopbarProps) {
 
       <button
         type="button"
-        onClick={openV}
+        onClick={() => openV()}
         aria-label="Abrir chat con V"
         className="h-9 px-3 flex items-center gap-2 rounded-md bg-vf-green/10 border border-vf-green/30 text-vf-green hover:bg-vf-green/20 active:bg-vf-green/30 transition-colors"
         style={{ touchAction: "manipulation" }}


### PR DESCRIPTION
## Qué cierra

Cierra el círculo **"cada cosa funciona con V"** — cuando tocas el botón V de una card, el dock se abre, surface el contexto en el header, y V **auto-responde** con su personalidad real (system-prompt v2 + tools + memoria). Una sola tap, sin teclado.

**🛑 Línea roja respetada**: no toca `system-prompt.ts`, `tools.ts`, ni la BD de identidad de V. V sigue siendo V.

## Cómo funciona el cable

```
Card → openV({ label, value, prompt })
       │
       ├─ sessionStorage: V_PENDING_PROMPT_KEY ← { prompt, ts }
       └─ window.dispatchEvent("vforge:open-v", { detail: { label, value } })
                │
                ├─→ VDock: abre/expande dock, pinta context strip
                └─→ ChatPage: consume prompt de sessionStorage, auto-send via handleSubmit
                              → /api/forge/run → V responde con su voz
```

Sin prop drilling. Cualquier botón en cualquier ruta puede llamar `openV({ prompt })` y V responde.

## Cambios

| Archivo | Qué |
|---|---|
| `components/V/VDock.tsx` | `openV()` acepta `{ label, value, prompt }`. Header del dock muestra context strip con ✕ para limpiar. Al recibir evento expande si está colapsado. |
| `components/V/ChatPage.tsx` | `useEffect` consume `V_PENDING_PROMPT_KEY` y auto-envía. TTL 10s para no replayar prompts viejos. `handleSubmitRef` para closure fresco. |
| `app/(dashboard)/projects/page.tsx` | Cada fila tiene botón **V** (icono Sparkles) que llama `openV()` con contexto del proyecto + prompt pre-armado. |
| `components/vforge/topbar.tsx` | `onClick={openV}` → `onClick={() => openV()}` (fix tsc — evita pasar MouseEvent como opts). |

## UX

1. Estás en `/hub` o `/projects`
2. Tocas el botón **V** verde de una fila
3. El dock se abre (desktop derecha · mobile fullscreen)
4. Header muestra `PROYECTO · RideMe · turbillon50/rideme-portal`
5. V auto-responde con análisis del proyecto, usando sus tools

## Verificación

- `tsc --noEmit` → 0 errores
- TTL guarda contra replay si abres el dock minutos después
- Listener limpia en unmount, no leak

## Pendiente próximo PR

- Acciones reales por card (deploy, restart, rotate key) que invoquen tools de V directamente
- Rediseño visual de `/vault`, `/modules`, `/activity` consistente con hub

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD9ckFDdBjDhYB6aaH1HR4)_