### PR TITLE
feat: densidad chat + Clerk activo en /app/*

### DIFF
--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -385,22 +385,26 @@ export function ChatExperience() {
       </div>
 
       {/* Messages scroller — el ÚNICO que scrollea */}
-      <div ref={scrollerRef} className="flex-1 min-h-0 overflow-y-auto px-4 py-6 md:px-10">
+      <div ref={scrollerRef} className="flex-1 min-h-0 overflow-y-auto px-3 py-3 md:px-10 md:py-5">
         <div className="mx-auto max-w-3xl">
-          <div className="mb-6 flex items-center gap-3">
-            <div className="relative h-9 w-9 rounded-full bg-violet-500/10 ring-1 ring-violet-500/30">
-              <div className="absolute inset-0 animate-pulse-soft rounded-full bg-violet-500/20" />
-              <div className="absolute inset-2 rounded-full bg-gradient-to-br from-violet-400 to-cyan-400" />
+          {/* Operator header — solo visible cuando el chat está vacío (más
+              espacio para mensajes cuando ya hay conversación). */}
+          {messages.length <= 1 && (
+            <div className="mb-4 flex items-center gap-3 md:mb-6">
+              <div className="relative h-9 w-9 rounded-full bg-violet-500/10 ring-1 ring-violet-500/30">
+                <div className="absolute inset-0 animate-pulse-soft rounded-full bg-violet-500/20" />
+                <div className="absolute inset-2 rounded-full bg-gradient-to-br from-violet-400 to-cyan-400" />
+              </div>
+              <div>
+                <p className="font-display text-lg font-semibold tracking-tight">
+                  {t.common.label_b}
+                </p>
+                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted">
+                  {t.chat.operator_label} · {currentScope.label}
+                </p>
+              </div>
             </div>
-            <div>
-              <p className="font-display text-lg font-semibold tracking-tight">
-                {t.common.label_b}
-              </p>
-              <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted">
-                {t.chat.operator_label} · {currentScope.label}
-              </p>
-            </div>
-          </div>
+          )}
 
           {isHydrating && (
             <div className="mb-6 text-center">
@@ -410,7 +414,7 @@ export function ChatExperience() {
             </div>
           )}
 
-          <div className="space-y-5">
+          <div className="space-y-3 md:space-y-4">
             <AnimatePresence initial={false}>
               {messages.map((m) => (
                 <MessageBubble key={m.id} msg={m} />

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,18 +1,25 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+
+const isProtectedRoute = createRouteMatcher([
+  "/app(.*)",
+  "/onboarding(.*)",
+]);
 
 const hasClerk = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
 
-// Clerk se inicializa cuando hay keys (para que /sign-in y /sign-up
-// rendericen los componentes oficiales), pero NO protege rutas: el
-// backend de V usa operator_luis hardcoded hasta que aterrice M11
-// (Clerk-backed auth real cableada al user_id en BD). Bloquear /app
-// sin que vaya cableado al user_id solo nos deja afuera del producto
-// sin agregar seguridad real. Cuando Clerk se conecte al user_id en
-// BD, recuperamos la protección con auth.protect() aquí.
+// Cuando Clerk tiene keys configuradas (producción), protege /app y
+// /onboarding — no entra cualquiera, hay que loguearse vía /sign-in o
+// /sign-up. En previews sin keys, el middleware pasa todo para no
+// bloquear el desarrollo.
+//
+// Nota: el backend de V todavía usa operator_luis hardcoded en
+// `lib/forge/run/route.ts`. Mientras tanto, Clerk solo es el guard
+// frontend. Cuando M11 aterrice, mapearemos el Clerk user.id al user_id
+// real en BD para que V identifique a cada operador en serio.
 export default hasClerk
-  ? clerkMiddleware(async () => {
-      // pass-through; no auth.protect() yet
+  ? clerkMiddleware(async (auth, req) => {
+      if (isProtectedRoute(req)) await auth.protect();
     })
   : () => NextResponse.next();
 


### PR DESCRIPTION
Tres mejoras pedidas por Luis tras producción:
1. Más espacio para leer en el chat (compactar paddings, esconder header del avatar cuando hay conversación)
2. Clerk activo: `auth.protect()` en `/app/*` y `/onboarding/*` — solo entra quien se loguea, Luis aparece en su Clerk dashboard
3. Pasada de lint (los 13 warnings son zona protegida de V, no se tocan)

tsc 0 errores. V intocada.

---
_Generated by [Claude Code](https://claude.ai/code/session_01726tiq2eHttztt2uhxTi7J)_