### PR TITLE
fix(chat): nav OFF + mensajes abajo + Clerk pass-through + SW bust

### DIFF
--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -174,6 +174,9 @@ function Breadcrumbs() {
 
 function MobileNav({ pathname }: { pathname: string }) {
   const t = useT();
+  // En /app/chat la barra estorba — V ES el contexto, no necesitas un
+  // botón "V" para ir donde ya estás. Más pantalla para conversar.
+  if (pathname.startsWith("/app/chat")) return null;
   const mobileNav = [
     { href: "/app/chat", label: t.workspace.mobile_labels.b, icon: MessagesSquare },
     { href: "/app/deployments", label: t.workspace.mobile_labels.deploy, icon: Activity },

--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -444,9 +444,13 @@ export function ChatExperience() {
         </div>
       </div>
 
-      {/* Messages scroller — el ÚNICO que scrollea */}
+      {/* Messages scroller — el ÚNICO que scrollea. Wrapper interno
+          usa justify-end para que el contenido quede pegado al composer
+          (chat-style: vacío al inicio = poco scroll; mucha conversación
+          empuja al usuario arriba). Antes flotaba pegado arriba dejando
+          medio viewport vacío. */}
       <div ref={scrollerRef} className="flex-1 min-h-0 overflow-y-auto px-3 py-3 md:px-10 md:py-5">
-        <div className="mx-auto max-w-3xl">
+        <div className="mx-auto flex min-h-full max-w-3xl flex-col justify-end">
           {/* Operator header — solo visible cuando el chat está vacío (más
               espacio para mensajes cuando ya hay conversación). */}
           {messages.length <= 1 && (

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,16 @@
-import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { clerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-
-const isProtectedRoute = createRouteMatcher([
-  "/app(.*)",
-  "/onboarding(.*)",
-]);
 
 const hasClerk = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
 
-// Cuando Clerk tiene keys configuradas (producción), protege /app y
-// /onboarding — no entra cualquiera, hay que loguearse vía /sign-in o
-// /sign-up. En previews sin keys, el middleware pasa todo para no
-// bloquear el desarrollo.
-//
-// Nota: el backend de V todavía usa operator_luis hardcoded en
-// `lib/forge/run/route.ts`. Mientras tanto, Clerk solo es el guard
-// frontend. Cuando M11 aterrice, mapearemos el Clerk user.id al user_id
-// real en BD para que V identifique a cada operador en serio.
+// Clerk se inicializa para que /sign-in y /sign-up rendericen los
+// componentes oficiales con las keys, pero NO protege rutas. Hasta que
+// M11 cable Clerk.user.id al user_id real en BD, bloquear /app solo
+// nos deja afuera del producto. Cuando aterrice esa pieza, reactivamos
+// auth.protect() aquí.
 export default hasClerk
-  ? clerkMiddleware(async (auth, req) => {
-      if (isProtectedRoute(req)) await auth.protect();
+  ? clerkMiddleware(async () => {
+      // pass-through; no auth.protect() yet
     })
   : () => NextResponse.next();
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,7 @@
 // VForge minimal service worker — offline shell + network-first for documents
-const VERSION = "vforge-v1";
+// Bump VERSION on every deploy where you want forced cache invalidation
+// (Luis: "se ve de la verga todavía" → asset cache pegado).
+const VERSION = "vforge-v3-2026-05-18";
 const SHELL = ["/", "/app/chat", "/offline"];
 
 self.addEventListener("install", (event) => {
@@ -20,7 +22,12 @@ self.addEventListener("fetch", (event) => {
   const url = new URL(req.url);
   if (url.origin !== self.location.origin) return;
 
-  // Network-first for navigations
+  // NUNCA cachear /api/* — siempre red (los datos reales son críticos)
+  if (url.pathname.startsWith("/api/")) {
+    return;
+  }
+
+  // Network-first para HTML/navigation — siempre intenta versión nueva
   if (req.mode === "navigate") {
     event.respondWith(
       fetch(req)
@@ -34,17 +41,16 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Cache-first for static assets
+  // Stale-while-revalidate para assets estáticos — sirve del cache pero
+  // refresca en background para que la próxima vez sea versión nueva.
   event.respondWith(
     caches.match(req).then((cached) => {
-      return (
-        cached ||
-        fetch(req).then((res) => {
-          const copy = res.clone();
-          caches.open(VERSION).then((c) => c.put(req, copy));
-          return res;
-        })
-      );
+      const networkPromise = fetch(req).then((res) => {
+        const copy = res.clone();
+        caches.open(VERSION).then((c) => c.put(req, copy));
+        return res;
+      });
+      return cached || networkPromise;
     })
   );
 });


### PR DESCRIPTION
- Bottom mobile-nav OFF en /app/chat (estorba, V es el contexto)
- Mensajes pegados abajo con justify-end (chat-style, no más vacío arriba)
- Clerk pass-through revert — entras directo sin sign-in
- SW VERSION bump para forzar cache invalidate

V intocada. tsc 0 errores.

---
_Generated by [Claude Code](https://claude.ai/code/session_01726tiq2eHttztt2uhxTi7J)_