### PR TITLE
fix(chat): mensajes pegados al composer con flex-col-reverse

### DIFF
--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -444,13 +444,16 @@ export function ChatExperience() {
         </div>
       </div>
 
-      {/* Messages scroller — el ÚNICO que scrollea. Wrapper interno
-          usa justify-end para que el contenido quede pegado al composer
-          (chat-style: vacío al inicio = poco scroll; mucha conversación
-          empuja al usuario arriba). Antes flotaba pegado arriba dejando
-          medio viewport vacío. */}
-      <div ref={scrollerRef} className="flex-1 min-h-0 overflow-y-auto px-3 py-3 md:px-10 md:py-5">
-        <div className="mx-auto flex min-h-full max-w-3xl flex-col justify-end">
+      {/* Messages scroller — flex-col-reverse hace que el scroll empiece
+          anclado al BOTTOM. Pocos mensajes → quedan pegados al composer.
+          Muchos → el scroll funciona normal. El wrapper interno mantiene
+          el orden cronológico real (sin invertir messages[]). Este es el
+          patrón estándar de chat (WhatsApp/Claude/ChatGPT). */}
+      <div
+        ref={scrollerRef}
+        className="flex-1 min-h-0 overflow-y-auto flex flex-col-reverse"
+      >
+        <div className="mx-auto w-full max-w-3xl px-3 py-3 md:px-10 md:py-5">
           {/* Operator header — solo visible cuando el chat está vacío (más
               espacio para mensajes cuando ya hay conversación). */}
           {messages.length <= 1 && (


### PR DESCRIPTION
Scroller con `flex-col-reverse` para anclar mensajes al bottom (patrón WhatsApp/Claude). Quita el gap enorme entre el último mensaje y el composer. tsc clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01726tiq2eHttztt2uhxTi7J)_