### PR TITLE
fix(nav): restaurar bottom-nav en /app/chat

### DIFF
--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -174,9 +174,10 @@ function Breadcrumbs() {
 
 function MobileNav({ pathname }: { pathname: string }) {
   const t = useT();
-  // En /app/chat la barra estorba — V ES el contexto, no necesitas un
-  // botón "V" para ir donde ya estás. Más pantalla para conversar.
-  if (pathname.startsWith("/app/chat")) return null;
+  // El bottom-nav vive en TODAS las rutas, incluyendo /app/chat. Sin él
+  // Luis se queda sin navegación rápida hacia Proyectos / Bóveda /
+  // Deploy / Alertas. Cuando el teclado mobile está abierto, la clase
+  // body.keyboard-open lo oculta automáticamente (CSS en globals.css).
   const mobileNav = [
     { href: "/app/chat", label: t.workspace.mobile_labels.b, icon: MessagesSquare },
     { href: "/app/deployments", label: t.workspace.mobile_labels.deploy, icon: Activity },


### PR DESCRIPTION
Restaurar bottom-nav en /app/chat. Cuando teclado abierto se sigue escondiendo automático. Permite navegar a Proyectos/Bóveda/Deploy/Alertas desde el chat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01726tiq2eHttztt2uhxTi7J)_