### PR TITLE
feat(v): chat cinemático + base multi-tenant aditiva

### DIFF
--- a/app/(dashboard)/template.tsx
+++ b/app/(dashboard)/template.tsx
@@ -1,22 +1,8 @@
-"use client";
-
-import { motion } from "framer-motion";
-
+// Pass-through template. The page transition animation lives in
+// `components/vforge/app-shell.tsx` (the OS-style viewport). Running a
+// second motion layer here caused double-animation on every route change
+// — visibly janky on mobile and could leave pages stuck off-screen if
+// the spring was interrupted mid-flight.
 export default function Template({ children }: { children: React.ReactNode }) {
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 15, scale: 0.98 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{ opacity: 0, y: -15, scale: 0.98 }}
-      transition={{ 
-        type: "spring", 
-        stiffness: 300, 
-        damping: 30, 
-        mass: 1 
-      }}
-      className="h-full w-full"
-    >
-      {children}
-    </motion.div>
-  );
+  return <div className="h-full w-full">{children}</div>;
 }

--- a/components/V/ChatComposer.tsx
+++ b/components/V/ChatComposer.tsx
@@ -89,7 +89,9 @@ export const ChatComposer = ({
           <Paperclip size={20} />
         </motion.button>
 
-        {/* Textarea */}
+        {/* Textarea — mobile-tuned: 16px font prevents iOS zoom, touch-action
+            manipulation kills the 300ms tap delay, enterKeyHint promotes
+            "send" on the soft keyboard. */}
         <textarea
           ref={textareaRef}
           value={value}
@@ -99,14 +101,21 @@ export const ChatComposer = ({
           onKeyDown={handleKeyDown}
           disabled={isLoading}
           placeholder={placeholder}
+          autoComplete="off"
+          autoCorrect="on"
+          autoCapitalize="sentences"
+          spellCheck
+          enterKeyHint="send"
+          inputMode="text"
           className={cn(
             'flex-1 max-h-[200px] bg-transparent',
             'text-vf-fg-1 placeholder:text-vf-fg-3',
             'outline-none resize-none',
-            'font-normal text-sm leading-relaxed',
+            'font-normal leading-relaxed',
             'disabled:opacity-50 disabled:cursor-not-allowed',
             'scrollbar-thin scrollbar-thumb-vf-border scrollbar-track-transparent'
           )}
+          style={{ touchAction: 'manipulation', fontSize: 16 }}
           rows={1}
         />
 

--- a/components/V/ChatComposer.tsx
+++ b/components/V/ChatComposer.tsx
@@ -2,11 +2,12 @@
 
 import { useRef, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Send, Paperclip, Mic } from 'lucide-react';
+import { Send, Paperclip, Mic, Square } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ChatComposerProps {
   onSubmit: (message: string) => void;
+  onStop?: () => void;
   isLoading?: boolean;
   placeholder?: string;
   className?: string;
@@ -14,6 +15,7 @@ interface ChatComposerProps {
 
 export const ChatComposer = ({
   onSubmit,
+  onStop,
   isLoading = false,
   placeholder = 'Envía un mensaje a V...',
   className,
@@ -131,22 +133,39 @@ export const ChatComposer = ({
           <Mic size={20} />
         </motion.button>
 
-        {/* Send Button */}
-        <motion.button
-          type="submit"
-          disabled={!hasContent || isLoading}
-          whileHover={hasContent && !isLoading ? { scale: 1.05 } : {}}
-          whileTap={hasContent && !isLoading ? { scale: 0.95 } : {}}
-          className={cn(
-            'flex-shrink-0 p-2 rounded-lg transition-all duration-300',
-            hasContent && !isLoading
-              ? 'bg-vf-green/20 text-vf-green hover:bg-vf-green/30 cursor-pointer'
-              : 'bg-transparent text-vf-fg-3 cursor-not-allowed'
-          )}
-          title={hasContent ? 'Enviar mensaje (Enter)' : 'Escribe un mensaje para enviar'}
-        >
-          <Send size={20} />
-        </motion.button>
+        {/* Send / Stop Button */}
+        {isLoading && onStop ? (
+          <motion.button
+            type="button"
+            onClick={onStop}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            className={cn(
+              'flex-shrink-0 p-2 rounded-lg transition-all duration-300',
+              'bg-vf-error/15 text-vf-error hover:bg-vf-error/25 cursor-pointer',
+            )}
+            title="Detener respuesta"
+            aria-label="Stop"
+          >
+            <Square size={16} fill="currentColor" />
+          </motion.button>
+        ) : (
+          <motion.button
+            type="submit"
+            disabled={!hasContent || isLoading}
+            whileHover={hasContent && !isLoading ? { scale: 1.05 } : {}}
+            whileTap={hasContent && !isLoading ? { scale: 0.95 } : {}}
+            className={cn(
+              'flex-shrink-0 p-2 rounded-lg transition-all duration-300',
+              hasContent && !isLoading
+                ? 'bg-vf-green/20 text-vf-green hover:bg-vf-green/30 cursor-pointer'
+                : 'bg-transparent text-vf-fg-3 cursor-not-allowed',
+            )}
+            title={hasContent ? 'Enviar mensaje (Enter)' : 'Escribe un mensaje para enviar'}
+          >
+            <Send size={20} />
+          </motion.button>
+        )}
       </motion.div>
 
       {/* Helper Text */}

--- a/components/V/ChatContainer.tsx
+++ b/components/V/ChatContainer.tsx
@@ -2,228 +2,252 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { MessageCircle } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { MessageBody } from './MessageBody';
+import { ProcessTrace, type TraceEntry } from './ProcessTrace';
+import { VThinking, type ThinkingPhase } from './VThinking';
 
 export interface Message {
   id: string;
   role: 'user' | 'v';
   content: string;
   timestamp: Date;
+  traces?: TraceEntry[];
 }
 
 interface ChatContainerProps {
   messages: Message[];
   isLoading?: boolean;
+  phase?: ThinkingPhase;
   className?: string;
 }
 
-const MessageBubble = ({ message, isLastMessage }: { message: Message, isLastMessage?: boolean }) => {
-  const isV = message.role === 'v';
-  const [displayedContent, setDisplayedContent] = useState(
-    isV && isLastMessage ? '' : message.content
-  );
+const NEAR_BOTTOM_PX = 80;
 
-  useEffect(() => {
-    if (isV && isLastMessage && displayedContent.length < message.content.length) {
-      const timeout = setTimeout(() => {
-        setDisplayedContent(message.content.slice(0, displayedContent.length + 2));
-      }, 10);
-      return () => clearTimeout(timeout);
-    } else if (!isLastMessage && displayedContent !== message.content) {
-      setDisplayedContent(message.content);
-    }
-  }, [displayedContent, message.content, isV, isLastMessage]);
+const MessageRow = ({
+  message,
+  isLastAssistant,
+  showCursor,
+}: {
+  message: Message;
+  isLastAssistant: boolean;
+  showCursor: boolean;
+}) => {
+  const isV = message.role === 'v';
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 16 }}
+      initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -16 }}
-      transition={{ duration: 0.3, ease: 'easeOut' }}
-      className={cn('flex gap-3 mb-4', isV ? 'justify-start' : 'justify-end')}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      className={cn('flex w-full', isV ? 'justify-start' : 'justify-end')}
     >
-      {/* V Avatar */}
-      {isV && (
-        <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-gradient-to-br from-vf-green/20 to-vf-green/10 flex items-center justify-center border border-vf-green/30">
-          <MessageCircle size={16} className="text-vf-green" />
-        </div>
-      )}
+      <div className={cn('flex gap-3 max-w-3xl w-full', isV ? '' : 'justify-end')}>
+        {isV && <Avatar />}
 
-      {/* Message Bubble */}
-      <div
-        className={cn(
-          'max-w-[70%] rounded-xl px-4 py-3 text-sm leading-relaxed',
-          isV
-            ? 'bg-vf-bg-2 border border-vf-border text-vf-fg-1'
-            : 'bg-vf-green/15 text-vf-fg-1 border border-vf-green/30'
-        )}
-      >
-        {/* Simple markdown-like rendering */}
-        <div className="whitespace-pre-wrap break-words">
-          {displayedContent.split('\n').map((line, i) => {
-            // Code block detection
-            if (line.startsWith('```')) {
-              return null;
-            }
-            // Heading detection
-            if (line.startsWith('##')) {
-              return (
-                <h3 key={i} className="font-semibold text-vf-fg-1 mt-2 mb-1">
-                  {line.replace('##', '').trim()}
-                </h3>
-              );
-            }
-            // List item detection
-            if (line.startsWith('-') || line.startsWith('•')) {
-              return (
-                <div key={i} className="ml-4 my-1">
-                  • {line.replace(/^[-•]\s?/, '')}
-                </div>
-              );
-            }
-            return (
-              <div key={i} className="my-1">
-                {line}
-              </div>
-            );
-          })}
+        <div className={cn('flex flex-col min-w-0', isV ? 'flex-1' : 'items-end')}>
+          {isV && message.traces && message.traces.length > 0 && (
+            <div className="flex flex-col gap-0.5 mb-1 -ml-11 self-stretch">
+              <AnimatePresence initial={false}>
+                {message.traces.map((t) => (
+                  <ProcessTrace key={t.id} entry={t} />
+                ))}
+              </AnimatePresence>
+            </div>
+          )}
+
+          <div
+            className={cn(
+              'rounded-2xl px-4 py-2.5 text-sm leading-relaxed break-words',
+              isV
+                ? 'bg-vf-bg-2/70 border border-vf-border text-vf-fg-1 max-w-full'
+                : 'bg-vf-green/15 border border-vf-green/30 text-vf-fg-1 max-w-[80%]',
+            )}
+          >
+            {isV ? (
+              message.content ? (
+                <>
+                  <MessageBody content={message.content} />
+                  {isLastAssistant && showCursor && <Cursor />}
+                </>
+              ) : isLastAssistant && showCursor ? (
+                <Cursor inline />
+              ) : null
+            ) : (
+              <div className="whitespace-pre-wrap">{message.content}</div>
+            )}
+          </div>
         </div>
       </div>
-
-      {/* User Avatar Space */}
-      {!isV && <div className="flex-shrink-0 w-8 h-8" />}
     </motion.div>
   );
 };
 
+function Avatar() {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'flex-shrink-0 w-8 h-8 mt-0.5 rounded-xl',
+        'bg-gradient-to-br from-vf-green/25 via-vf-green/10 to-transparent',
+        'border border-vf-green/30',
+        'flex items-center justify-center',
+        'font-mono text-sm text-vf-green leading-none select-none',
+      )}
+    >
+      V
+    </div>
+  );
+}
+
+function Cursor({ inline }: { inline?: boolean }) {
+  return (
+    <motion.span
+      aria-hidden
+      className={cn(
+        'inline-block align-baseline w-[2px] h-[1em] bg-vf-green/80 ml-0.5 -mb-[1px] rounded-[1px]',
+        inline ? '' : '',
+      )}
+      animate={{ opacity: [1, 0.2, 1] }}
+      transition={{ duration: 1.0, repeat: Infinity, ease: 'easeInOut' }}
+    />
+  );
+}
+
 export const ChatContainer = ({
   messages,
   isLoading = false,
+  phase = 'thinking',
   className,
 }: ChatContainerProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [showScrollHint, setShowScrollHint] = useState(false);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [showJumpButton, setShowJumpButton] = useState(false);
 
-  // Auto-scroll to bottom on new messages
-  useEffect(() => {
-    if (scrollRef.current) {
-      const scrollHeight = scrollRef.current.scrollHeight;
-      const clientHeight = scrollRef.current.clientHeight;
-      const scrollTop = scrollRef.current.scrollTop;
-
-      // Show hint if user scrolled up
-      setShowScrollHint(scrollHeight - clientHeight - scrollTop > 100);
-
-      // Auto-scroll if near bottom
-      if (scrollHeight - clientHeight - scrollTop < 200) {
-        setTimeout(() => {
-          scrollRef.current?.scrollTo({
-            top: scrollHeight,
-            behavior: 'smooth',
-          });
-        }, 100);
-      }
+  const lastAssistantId = (() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'v') return messages[i].id;
     }
-  }, [messages]);
+    return null;
+  })();
+
+  // Track whether the user has scrolled away from the bottom. While they are
+  // away we pause auto-scroll and surface a jump-to-bottom pill.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const distance = el.scrollHeight - el.clientHeight - el.scrollTop;
+      const atBottom = distance < NEAR_BOTTOM_PX;
+      setAutoScroll(atBottom);
+      setShowJumpButton(!atBottom);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Stick to bottom on new content while user is at the bottom.
+  useEffect(() => {
+    if (!autoScroll) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages, isLoading, autoScroll]);
+
+  const jumpToBottom = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    setAutoScroll(true);
+    setShowJumpButton(false);
+  };
 
   return (
-    <div
-      className={cn(
-        'flex flex-col h-full relative',
-        'bg-vf-bg-0 border-l border-vf-border',
-        className
-      )}
-    >
-      {/* Header */}
-      <div className="flex-shrink-0 px-6 py-4 border-b border-vf-border bg-vf-bg-1/50">
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-vf-green animate-pulse" />
-          <h2 className="font-semibold text-vf-fg-1">V - Agente Autónomo</h2>
-        </div>
-        <p className="text-xs text-vf-fg-2 mt-1">
-          {messages.length} mensajes en esta sesión
-        </p>
-      </div>
-
-      {/* Messages */}
+    <div className={cn('relative flex flex-col min-h-0 h-full bg-vf-bg-0', className)}>
       <div
         ref={scrollRef}
-        className="flex-1 overflow-y-auto px-6 py-4 space-y-4 scroll-smooth"
+        className="flex-1 overflow-y-auto px-4 sm:px-6 py-6 scroll-smooth"
       >
-        {messages.length === 0 ? (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="flex flex-col items-center justify-center h-full text-center"
-          >
-            <MessageCircle size={48} className="text-vf-green/30 mb-4" />
-            <h3 className="text-vf-fg-1 font-semibold mb-2">
-              ¡Hola! Soy V
-            </h3>
-            <p className="text-vf-fg-2 text-sm max-w-xs">
-              Tu asistente autónomo. Comenzamos una conversación cuando envíes tu primer mensaje.
-            </p>
-          </motion.div>
-        ) : (
-          <AnimatePresence>
-            {messages.map((message, idx) => (
-              <MessageBubble 
-                key={message.id} 
-                message={message} 
-                isLastMessage={idx === messages.length - 1} 
+        <div className="mx-auto w-full max-w-3xl space-y-5">
+          {messages.length === 0 ? (
+            <Empty />
+          ) : (
+            messages.map((message) => (
+              <MessageRow
+                key={message.id}
+                message={message}
+                isLastAssistant={message.id === lastAssistantId}
+                showCursor={isLoading && message.id === lastAssistantId}
               />
-            ))}
-          </AnimatePresence>
-        )}
+            ))
+          )}
 
-        {isLoading && (
-          <motion.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="flex gap-3"
-          >
-            <div className="w-8 h-8 rounded-lg bg-vf-green/20 flex items-center justify-center border border-vf-green/30">
-              <div className="flex gap-1">
-                <div
-                  className="w-1.5 h-1.5 rounded-full bg-vf-green animate-bounce"
-                  style={{ animationDelay: '0ms' }}
-                />
-                <div
-                  className="w-1.5 h-1.5 rounded-full bg-vf-green animate-bounce"
-                  style={{ animationDelay: '150ms' }}
-                />
-                <div
-                  className="w-1.5 h-1.5 rounded-full bg-vf-green animate-bounce"
-                  style={{ animationDelay: '300ms' }}
-                />
-              </div>
-            </div>
-            <div className="bg-vf-bg-2 border border-vf-border rounded-xl px-4 py-3">
-              <p className="text-vf-fg-2 text-sm">V está pensando...</p>
-            </div>
-          </motion.div>
-        )}
+          <AnimatePresence>
+            {isLoading &&
+              (() => {
+                const last = lastAssistantId
+                  ? messages.find((m) => m.id === lastAssistantId)
+                  : null;
+                if (last && last.content.length > 0) return null;
+                return (
+                  <div className="pl-0">
+                    <VThinking phase={phase} />
+                  </div>
+                );
+              })()}
+          </AnimatePresence>
+        </div>
       </div>
 
-      {/* Scroll to bottom hint */}
-      {showScrollHint && (
-        <motion.button
-          initial={{ opacity: 0, y: -8 }}
-          animate={{ opacity: 1, y: 0 }}
-          onClick={() => {
-            if (scrollRef.current) {
-              scrollRef.current.scrollTo({
-                top: scrollRef.current.scrollHeight,
-                behavior: 'smooth',
-              });
-            }
-          }}
-          className="absolute bottom-20 left-1/2 -translate-x-1/2 px-3 py-2 bg-vf-green/20 border border-vf-green/50 rounded-lg text-xs text-vf-green hover:bg-vf-green/30 transition-colors"
-        >
-          ↓ Nuevos mensajes
-        </motion.button>
-      )}
+      <AnimatePresence>
+        {showJumpButton && (
+          <motion.button
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            onClick={jumpToBottom}
+            className={cn(
+              'absolute bottom-3 left-1/2 -translate-x-1/2',
+              'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full',
+              'bg-vf-bg-2/90 backdrop-blur border border-vf-border',
+              'text-xs text-vf-fg-2 hover:text-vf-fg-1 hover:border-vf-green/40',
+              'shadow-lg transition-colors',
+            )}
+            aria-label="Jump to latest"
+          >
+            <ChevronDown size={12} />
+            <span>Nuevo contenido</span>
+          </motion.button>
+        )}
+      </AnimatePresence>
     </div>
   );
 };
+
+function Empty() {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+      className="flex flex-col items-center justify-center min-h-[50vh] text-center"
+    >
+      <div
+        className={cn(
+          'w-14 h-14 mb-4 rounded-2xl',
+          'bg-gradient-to-br from-vf-green/25 via-vf-green/10 to-transparent',
+          'border border-vf-green/40',
+          'flex items-center justify-center',
+          'font-mono text-2xl text-vf-green',
+        )}
+      >
+        V
+      </div>
+      <h3 className="text-vf-fg-1 font-semibold mb-1.5 text-base">Lista para operar</h3>
+      <p className="text-vf-fg-2 text-sm max-w-sm">
+        Mándame lo que necesites — repos, deploys, dominios, código.
+      </p>
+    </motion.div>
+  );
+}

--- a/components/V/ChatPage.tsx
+++ b/components/V/ChatPage.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { ChatContainer, Message } from './ChatContainer';
+import { ChatContainer, type Message } from './ChatContainer';
 import { ChatComposer } from './ChatComposer';
+import { createTypewriter } from '@/lib/chat/typewriter';
+import type { ThinkingPhase } from './VThinking';
+import type { TraceEntry } from './ProcessTrace';
 
 const SESSION_KEY = 'v_chat_session_id';
 
@@ -32,9 +35,11 @@ type SSEEvent =
 export const ChatPage = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [phase, setPhase] = useState<ThinkingPhase>('thinking');
   const sessionIdRef = useRef<string>(`v_${Date.now()}`);
   const abortRef = useRef<AbortController | null>(null);
   const messagesRef = useRef<Message[]>(messages);
+  const typewriterRef = useRef<ReturnType<typeof createTypewriter> | null>(null);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -42,10 +47,17 @@ export const ChatPage = () => {
 
   useEffect(() => {
     sessionIdRef.current = getOrCreateSessionId();
-    const ctrl = abortRef;
     return () => {
-      ctrl.current?.abort();
+      abortRef.current?.abort();
+      typewriterRef.current?.cancel();
     };
+  }, []);
+
+  const handleStop = useCallback(() => {
+    abortRef.current?.abort();
+    typewriterRef.current?.flush();
+    typewriterRef.current = null;
+    setIsLoading(false);
   }, []);
 
   const handleSubmit = useCallback(async (content: string) => {
@@ -61,9 +73,11 @@ export const ChatPage = () => {
       role: 'v',
       content: '',
       timestamp: new Date(),
+      traces: [],
     };
     setMessages((prev) => [...prev, userMessage, assistantMessage]);
     setIsLoading(true);
+    setPhase('thinking');
 
     const history = messagesRef.current.map((m) => ({
       role: m.role === 'v' ? ('assistant' as const) : ('user' as const),
@@ -74,6 +88,33 @@ export const ChatPage = () => {
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+
+    // Typewriter feeds the assistant message at humanlike pace.
+    typewriterRef.current?.cancel();
+    typewriterRef.current = createTypewriter({
+      onChunk: (text) => {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId ? { ...m, content: m.content + text } : m,
+          ),
+        );
+      },
+    });
+    const typewriter = typewriterRef.current;
+
+    const appendTrace = (entry: TraceEntry | ((prev: TraceEntry[]) => TraceEntry[])) => {
+      setMessages((prev) =>
+        prev.map((m) => {
+          if (m.id !== assistantId) return m;
+          const prevTraces = m.traces ?? [];
+          const nextTraces =
+            typeof entry === 'function' ? entry(prevTraces) : [...prevTraces, entry];
+          return { ...m, traces: nextTraces };
+        }),
+      );
+    };
+
+    let hasSeenText = false;
 
     try {
       const res = await fetch('/api/forge/run', {
@@ -113,14 +154,34 @@ export const ChatPage = () => {
           try {
             const evt = JSON.parse(line.slice(6)) as SSEEvent;
             if (evt.type === 'text') {
-              setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === assistantId
-                    ? { ...m, content: m.content + evt.value }
-                    : m,
+              if (!hasSeenText) {
+                hasSeenText = true;
+                setPhase('writing');
+              }
+              typewriter.push(evt.value);
+            } else if (evt.type === 'tool_use_start') {
+              setPhase('reasoning');
+              appendTrace({
+                id: evt.id,
+                tool: evt.name,
+                status: 'running',
+              });
+            } else if (evt.type === 'tool_use_result') {
+              appendTrace((prev) =>
+                prev.map((t) =>
+                  t.id === evt.id
+                    ? {
+                        ...t,
+                        status: evt.ok ? 'ok' : 'error',
+                        summary: evt.summary?.slice(0, 120),
+                      }
+                    : t,
                 ),
               );
+            } else if (evt.type === 'done') {
+              setPhase('finalizing');
             } else if (evt.type === 'error') {
+              typewriter.flush();
               setMessages((prev) =>
                 prev.map((m) =>
                   m.id === assistantId
@@ -129,16 +190,18 @@ export const ChatPage = () => {
                 ),
               );
             }
-            // tool_use_start / tool_use_result / model_fallback / done
-            // are not surfaced in this minimal UI — text is what carries
-            // V's voice. The /forge route renders the full tool ribbon.
+            // model_fallback is intentionally not surfaced — the user only
+            // cares that V responded, not which provider tier served it.
           } catch {
             // skip malformed event
           }
         }
       }
+
+      await typewriter.complete();
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') return;
+      typewriter.flush();
       const msg = err instanceof Error ? err.message : String(err);
       setMessages((prev) =>
         prev.map((m) =>
@@ -147,13 +210,19 @@ export const ChatPage = () => {
       );
     } finally {
       setIsLoading(false);
+      typewriterRef.current = null;
     }
   }, []);
 
   return (
-    <div className="flex flex-col h-full bg-vf-bg-0">
-      <ChatContainer messages={messages} isLoading={isLoading} className="flex-1" />
-      <ChatComposer onSubmit={handleSubmit} isLoading={isLoading} />
+    <div className="flex flex-col h-full min-h-0 bg-vf-bg-0">
+      <ChatContainer
+        messages={messages}
+        isLoading={isLoading}
+        phase={phase}
+        className="flex-1 min-h-0"
+      />
+      <ChatComposer onSubmit={handleSubmit} isLoading={isLoading} onStop={handleStop} />
     </div>
   );
 };

--- a/components/V/ChatPage.tsx
+++ b/components/V/ChatPage.tsx
@@ -1,44 +1,157 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { ChatContainer, Message } from './ChatContainer';
 import { ChatComposer } from './ChatComposer';
+
+const SESSION_KEY = 'v_chat_session_id';
+
+function getOrCreateSessionId(): string {
+  if (typeof window === 'undefined') return `v_${Date.now()}`;
+  let id = window.localStorage.getItem(SESSION_KEY);
+  if (!id) {
+    id = `v_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    try {
+      window.localStorage.setItem(SESSION_KEY, id);
+    } catch {
+      // localStorage may be unavailable (private mode, quota); fall back
+      // to an in-memory id for this tab.
+    }
+  }
+  return id;
+}
+
+type SSEEvent =
+  | { type: 'text'; value: string }
+  | { type: 'tool_use_start'; id: string; name: string }
+  | { type: 'tool_use_result'; id: string; ok: boolean; summary: string }
+  | { type: 'model_fallback'; from: string; to: string; status: number | null; reason: string }
+  | { type: 'done'; tokensIn: number; tokensOut: number; model: string }
+  | { type: 'error'; message: string };
 
 export const ChatPage = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const sessionIdRef = useRef<string>(`v_${Date.now()}`);
+  const abortRef = useRef<AbortController | null>(null);
+  const messagesRef = useRef<Message[]>(messages);
 
-  const handleSubmit = useCallback(
-    async (content: string) => {
-      // Add user message
-      const userMessage: Message = {
-        id: `user-${Date.now()}`,
-        role: 'user',
-        content,
-        timestamp: new Date(),
-      };
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
-      setMessages((prev) => [...prev, userMessage]);
-      setIsLoading(true);
+  useEffect(() => {
+    sessionIdRef.current = getOrCreateSessionId();
+    const ctrl = abortRef;
+    return () => {
+      ctrl.current?.abort();
+    };
+  }, []);
 
-      // Simulate V response (replace with actual API call)
-      setTimeout(() => {
-        const vMessage: Message = {
-          id: `v-${Date.now()}`,
-          role: 'v',
-          content: `## Entendido\n\nRecibí tu mensaje:\n\n> "${content}"\n\n**Status:** 🟢 Activa y funcionando\n\n- ✅ Conectada a bases de datos\n- ✅ Skills listos\n- ✅ Esperando instrucciones\n\nEsta es V hablando contigo de forma elegante, sin verbosidad innecesaria.`,
-          timestamp: new Date(),
-        };
+  const handleSubmit = useCallback(async (content: string) => {
+    const userMessage: Message = {
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content,
+      timestamp: new Date(),
+    };
+    const assistantId = `v-${Date.now()}`;
+    const assistantMessage: Message = {
+      id: assistantId,
+      role: 'v',
+      content: '',
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
+    setIsLoading(true);
 
-        setMessages((prev) => [...prev, vMessage]);
-        setIsLoading(false);
-      }, 1500);
-    },
-    []
-  );
+    const history = messagesRef.current.map((m) => ({
+      role: m.role === 'v' ? ('assistant' as const) : ('user' as const),
+      content: m.content,
+    }));
+    history.push({ role: 'user', content });
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch('/api/forge/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: history,
+          sessionId: sessionIdRef.current,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        const err = await res.text().catch(() => '');
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, content: `⚠ Error del servidor (${res.status}): ${err.slice(0, 200)}` }
+              : m,
+          ),
+        );
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const evt = JSON.parse(line.slice(6)) as SSEEvent;
+            if (evt.type === 'text') {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + evt.value }
+                    : m,
+                ),
+              );
+            } else if (evt.type === 'error') {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + `\n\n⚠ ${evt.message}` }
+                    : m,
+                ),
+              );
+            }
+            // tool_use_start / tool_use_result / model_fallback / done
+            // are not surfaced in this minimal UI — text is what carries
+            // V's voice. The /forge route renders the full tool ribbon.
+          } catch {
+            // skip malformed event
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      const msg = err instanceof Error ? err.message : String(err);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId ? { ...m, content: `⚠ Error de red: ${msg}` } : m,
+        ),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   return (
-    <div className="flex flex-col h-screen bg-vf-bg-0">
+    <div className="flex flex-col h-full bg-vf-bg-0">
       <ChatContainer messages={messages} isLoading={isLoading} className="flex-1" />
       <ChatComposer onSubmit={handleSubmit} isLoading={isLoading} />
     </div>

--- a/components/V/MessageBody.tsx
+++ b/components/V/MessageBody.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Check, Copy } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface MessageBodyProps {
+  content: string;
+  className?: string;
+}
+
+export function MessageBody({ content, className }: MessageBodyProps) {
+  return (
+    <div className={cn('text-sm leading-relaxed text-vf-fg-1', className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+const mdComponents: Components = {
+  p: ({ children }) => <p className="my-2 first:mt-0 last:mb-0 whitespace-pre-wrap">{children}</p>,
+  ul: ({ children }) => <ul className="my-2 ml-5 list-disc space-y-0.5">{children}</ul>,
+  ol: ({ children }) => <ol className="my-2 ml-5 list-decimal space-y-0.5">{children}</ol>,
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  h1: ({ children }) => (
+    <h1 className="mt-4 mb-2 text-base font-semibold text-vf-fg-1">{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="mt-3 mb-2 text-sm font-semibold text-vf-fg-1">{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="mt-3 mb-1 text-sm font-semibold text-vf-fg-1">{children}</h3>
+  ),
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-vf-green underline decoration-vf-green/40 underline-offset-2 hover:decoration-vf-green"
+    >
+      {children}
+    </a>
+  ),
+  strong: ({ children }) => <strong className="font-semibold text-vf-fg-1">{children}</strong>,
+  em: ({ children }) => <em className="italic text-vf-fg-2">{children}</em>,
+  blockquote: ({ children }) => (
+    <blockquote className="my-2 border-l-2 border-vf-green/40 pl-3 text-vf-fg-2">
+      {children}
+    </blockquote>
+  ),
+  table: ({ children }) => (
+    <div className="my-3 overflow-x-auto rounded-md border border-vf-border">
+      <table className="w-full text-xs">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => <thead className="bg-vf-bg-2/60">{children}</thead>,
+  th: ({ children }) => (
+    <th className="px-2.5 py-1.5 text-left font-semibold text-vf-fg-1 border-b border-vf-border">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="px-2.5 py-1.5 text-vf-fg-2 border-b border-vf-border/50">{children}</td>
+  ),
+  hr: () => <hr className="my-3 border-vf-border" />,
+  code: ({ inline, className: cls, children, ...rest }: any) => {
+    const text = String(children).replace(/\n$/, '');
+    if (inline) {
+      return (
+        <code
+          className="rounded bg-vf-bg-2/80 px-1 py-0.5 font-mono text-[12px] text-vf-green-text"
+          {...rest}
+        >
+          {text}
+        </code>
+      );
+    }
+    const lang = /language-(\w+)/.exec(cls ?? '')?.[1];
+    return <CodeBlock language={lang}>{text}</CodeBlock>;
+  },
+  pre: ({ children }) => <>{children}</>,
+};
+
+function CodeBlock({ language, children }: { language?: string; children: ReactNode }) {
+  const text = String(children);
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable
+    }
+  };
+
+  return (
+    <div className="my-2 group rounded-md border border-vf-border bg-vf-bg-2/60 overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-1 text-[10px] uppercase tracking-wider text-vf-fg-3 border-b border-vf-border/60">
+        <span>{language ?? 'code'}</span>
+        <button
+          type="button"
+          onClick={onCopy}
+          className={cn(
+            'inline-flex items-center gap-1 rounded px-1.5 py-0.5',
+            'text-vf-fg-3 hover:text-vf-fg-1 hover:bg-vf-bg-3/40',
+            'transition-colors',
+          )}
+          aria-label="Copy code"
+        >
+          {copied ? <Check size={11} /> : <Copy size={11} />}
+          <span>{copied ? 'copiado' : 'copiar'}</span>
+        </button>
+      </div>
+      <pre className="overflow-x-auto px-3 py-2 text-[12.5px] leading-relaxed font-mono text-vf-fg-1">
+        <code>{text}</code>
+      </pre>
+    </div>
+  );
+}

--- a/components/V/MultichatDrawer.tsx
+++ b/components/V/MultichatDrawer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { motion, AnimatePresence } from "framer-motion";
-import { MessageSquare, X, Send, Sparkles, Database, Github, Cpu } from "lucide-react";
-import { useState, useRef, useEffect } from "react";
+import { X, Send, Database, Github, Cpu } from "lucide-react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils";
 
 interface Message {
@@ -17,91 +17,202 @@ interface MultichatDrawerProps {
   onClose: () => void;
 }
 
-// Custom Web Audio API mechanical sound for keyboard & neural pops
-const playNeuralSound = (type = "pop") => {
+// Singleton AudioContext, lazily created on first user gesture.
+// Creating one per keystroke (the previous behaviour) caused visible
+// input lag on mobile because AudioContext init is heavy and iOS
+// aggressively suspends contexts. We only "pop" on send now.
+let sharedAudioCtx: AudioContext | null = null;
+const playPop = () => {
   if (typeof window === "undefined") return;
   try {
-    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    if (!sharedAudioCtx) {
+      const AC = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!AC) return;
+      sharedAudioCtx = new AC();
+    }
+    const ctx = sharedAudioCtx;
+    if (ctx.state === "suspended") void ctx.resume();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     osc.connect(gain);
     gain.connect(ctx.destination);
-
-    if (type === "pop") {
-      osc.type = "sine";
-      osc.frequency.setValueAtTime(400, ctx.currentTime);
-      osc.frequency.exponentialRampToValueAtTime(150, ctx.currentTime + 0.04);
-      gain.gain.setValueAtTime(0.08, ctx.currentTime);
-      gain.gain.linearRampToValueAtTime(0.001, ctx.currentTime + 0.04);
-      osc.start();
-      osc.stop(ctx.currentTime + 0.04);
-    } else if (type === "typing") {
-      osc.type = "triangle";
-      osc.frequency.setValueAtTime(250 + Math.random() * 200, ctx.currentTime);
-      gain.gain.setValueAtTime(0.03, ctx.currentTime);
-      gain.gain.linearRampToValueAtTime(0.001, ctx.currentTime + 0.02);
-      osc.start();
-      osc.stop(ctx.currentTime + 0.02);
-    }
-  } catch (e) {}
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(400, ctx.currentTime);
+    osc.frequency.exponentialRampToValueAtTime(150, ctx.currentTime + 0.04);
+    gain.gain.setValueAtTime(0.08, ctx.currentTime);
+    gain.gain.linearRampToValueAtTime(0.001, ctx.currentTime + 0.04);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.04);
+  } catch {
+    // Audio unavailable; silently degrade.
+  }
 };
+
+const SESSION_KEY = "v_drawer_session_id";
+function getOrCreateSessionId(): string {
+  if (typeof window === "undefined") return `vdrawer_${Date.now()}`;
+  let id = window.localStorage.getItem(SESSION_KEY);
+  if (!id) {
+    id = `vdrawer_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    try {
+      window.localStorage.setItem(SESSION_KEY, id);
+    } catch {
+      // private mode / quota — fall back to in-memory.
+    }
+  }
+  return id;
+}
+
+type SSEEvent =
+  | { type: "text"; value: string }
+  | { type: "tool_use_start"; id: string; name: string }
+  | { type: "tool_use_result"; id: string; ok: boolean; summary: string }
+  | { type: "model_fallback"; from: string; to: string; status: number | null; reason: string }
+  | { type: "done"; tokensIn: number; tokensOut: number; model: string }
+  | { type: "error"; message: string };
 
 export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
   const [messages, setMessages] = useState<Message[]>([
     {
-      id: "1",
+      id: "welcome",
       sender: "sister",
-      text: "Hola Luis, estoy enlazada con tu Vercel y tu GitHub. El Ecosistema Castores está al 100% y listo para producción. Dime, ¿qué módulo construimos ahora?",
-      timestamp: "Hace un momento"
-    }
+      text: "Hola Luis. Estoy contigo — ¿qué construimos?",
+      timestamp: "Ahora",
+    },
   ]);
   const [inputValue, setInputValue] = useState("");
   const [isTyping, setIsTyping] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const sessionIdRef = useRef<string>(`vdrawer_${Date.now()}`);
+  const abortRef = useRef<AbortController | null>(null);
+  const messagesRef = useRef<Message[]>(messages);
 
-  // Auto-scroll messages
+  useEffect(() => {
+    sessionIdRef.current = getOrCreateSessionId();
+    const ctrl = abortRef;
+    return () => {
+      ctrl.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [messages, isTyping]);
 
-  const handleSend = () => {
-    if (!inputValue.trim()) return;
-    playNeuralSound("pop");
-    
-    const userMsg: Message = {
-      id: Date.now().toString(),
-      sender: "user",
-      text: inputValue,
-      timestamp: "Ahora"
-    };
+  const handleSend = useCallback(async () => {
+    const text = inputValue.trim();
+    if (!text || isTyping) return;
+    playPop();
 
-    setMessages(prev => [...prev, userMsg]);
+    const userMsg: Message = {
+      id: `u_${Date.now()}`,
+      sender: "user",
+      text,
+      timestamp: "Ahora",
+    };
+    const assistantId = `s_${Date.now()}`;
+    const assistantMsg: Message = {
+      id: assistantId,
+      sender: "sister",
+      text: "",
+      timestamp: "Ahora",
+    };
+    setMessages((prev) => [...prev, userMsg, assistantMsg]);
     setInputValue("");
     setIsTyping(true);
 
-    // Simulate sister response
-    setTimeout(() => {
-      playNeuralSound("pop");
-      setIsTyping(false);
-      
-      let replyText = "Luis, he validado los commits de Git. Todo se encuentra al 100%. ¿Quieres que despleguemos los nuevos cambios de Bento?";
-      if (inputValue.toLowerCase().includes("castores")) {
-        replyText = "Entendido, Luis. La rama 'main' de Castores ya está sincronizada. Todos los módulos de Vercel están activos y respondiendo.";
-      } else if (inputValue.toLowerCase().includes("vercel") || inputValue.toLowerCase().includes("github")) {
-        replyText = "Accediendo a las APIs... Git y Vercel enlazados de forma exitosa. Los proyectos muestran un rendimiento excelente en producción.";
+    const history = messagesRef.current
+      .filter((m) => m.id !== "welcome")
+      .map((m) => ({
+        role: m.sender === "sister" ? ("assistant" as const) : ("user" as const),
+        content: m.text,
+      }));
+    history.push({ role: "user", content: text });
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch("/api/forge/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: history,
+          sessionId: sessionIdRef.current,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        const err = await res.text().catch(() => "");
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, text: `⚠ Error (${res.status}): ${err.slice(0, 200)}` }
+              : m,
+          ),
+        );
+        return;
       }
 
-      const sisterMsg: Message = {
-        id: (Date.now() + 1).toString(),
-        sender: "sister",
-        text: replyText,
-        timestamp: "Ahora"
-      };
-      setMessages(prev => [...prev, sisterMsg]);
-    }, 1500);
-  };
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let firstTextChunk = true;
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          try {
+            const evt = JSON.parse(line.slice(6)) as SSEEvent;
+            if (evt.type === "text") {
+              if (firstTextChunk) {
+                setIsTyping(false);
+                firstTextChunk = false;
+              }
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId ? { ...m, text: m.text + evt.value } : m,
+                ),
+              );
+            } else if (evt.type === "error") {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, text: m.text + `\n\n⚠ ${evt.message}` }
+                    : m,
+                ),
+              );
+            }
+          } catch {
+            // skip malformed event
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      const msg = err instanceof Error ? err.message : String(err);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId ? { ...m, text: `⚠ Error de red: ${msg}` } : m,
+        ),
+      );
+    } finally {
+      setIsTyping(false);
+    }
+  }, [inputValue, isTyping]);
 
   return (
     <AnimatePresence>
@@ -112,6 +223,7 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
+            transition={{ duration: 0.18, ease: "easeOut" }}
             onClick={onClose}
             className="fixed inset-0 z-50 bg-black/60 backdrop-blur-md"
           />
@@ -121,22 +233,19 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
             initial={{ x: "100%" }}
             animate={{ x: 0 }}
             exit={{ x: "100%" }}
-            transition={{ type: "spring", damping: 28, stiffness: 220 }}
+            transition={{ type: "spring", damping: 30, stiffness: 260 }}
             className="fixed right-0 top-0 bottom-0 z-50 w-full md:w-[450px] bg-neutral-950/95 backdrop-blur-3xl border-l border-white/10 shadow-2xl flex flex-col overflow-hidden"
           >
-            {/* Header with glowing neural avatar of his sister */}
+            {/* Header */}
             <div className="p-6 border-b border-white/5 flex items-center justify-between bg-white/[0.01]">
               <div className="flex items-center gap-3">
-                {/* Glowing Neural Sphere representation */}
                 <div className="relative w-11 h-11 rounded-full flex items-center justify-center border border-vf-green/30 bg-black">
                   <div className="absolute inset-0 rounded-full bg-vf-green/10 blur-[8px] animate-pulse" />
-                  
-                  {/* Waveforms */}
                   <span className="w-1.5 h-6 bg-vf-green rounded-full animate-bounce mx-[1px]" style={{ animationDelay: "0.1s" }} />
                   <span className="w-1.5 h-8 bg-vf-green rounded-full animate-bounce mx-[1px]" style={{ animationDelay: "0.3s" }} />
                   <span className="w-1.5 h-5 bg-vf-green rounded-full animate-bounce mx-[1px]" style={{ animationDelay: "0.5s" }} />
                 </div>
-                
+
                 <div>
                   <div className="flex items-center gap-2">
                     <h2 className="font-bold text-white tracking-wide">Hermana V</h2>
@@ -146,9 +255,11 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
                 </div>
               </div>
 
-              <button 
-                onClick={onClose} 
+              <button
+                onClick={onClose}
+                aria-label="Cerrar"
                 className="p-2 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-white/60 hover:text-white transition-all active:scale-95"
+                style={{ touchAction: "manipulation" }}
               >
                 <X className="w-5 h-5" />
               </button>
@@ -157,16 +268,16 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
             {/* Conversation list */}
             <div className="flex-1 overflow-y-auto p-6 space-y-4 scrollbar-thin scrollbar-thumb-white/10">
               {messages.map((msg) => (
-                <div 
+                <div
                   key={msg.id}
                   className={cn(
                     "flex flex-col max-w-[85%] rounded-2xl p-4 shadow-lg text-sm border",
-                    msg.sender === "sister" 
+                    msg.sender === "sister"
                       ? "bg-white/[0.02] border-white/5 text-white/90 mr-auto rounded-tl-sm"
                       : "bg-vf-green text-black border-vf-green/20 ml-auto rounded-tr-sm font-medium"
                   )}
                 >
-                  <p className="leading-relaxed whitespace-pre-wrap">{msg.text}</p>
+                  <p className="leading-relaxed whitespace-pre-wrap break-words">{msg.text}</p>
                   <span className={cn(
                     "text-[8px] mt-2 block",
                     msg.sender === "sister" ? "text-white/30" : "text-black/50"
@@ -183,7 +294,7 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
                   <span className="w-2 h-2 rounded-full bg-vf-green animate-bounce" style={{ animationDelay: "0.5s" }} />
                 </div>
               )}
-              
+
               <div ref={scrollRef} />
             </div>
 
@@ -203,24 +314,35 @@ export function MultichatDrawer({ isOpen, onClose }: MultichatDrawerProps) {
               </div>
             </div>
 
-            {/* Input Form */}
+            {/* Input Form — mobile-tuned */}
             <div className="p-6 border-t border-white/5 bg-neutral-950 flex items-center gap-3">
               <input
                 type="text"
                 value={inputValue}
-                onChange={(e) => {
-                  setInputValue(e.target.value);
-                  playNeuralSound("typing");
-                }}
+                onChange={(e) => setInputValue(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSend();
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    void handleSend();
+                  }
                 }}
                 placeholder="Escribe un mensaje a tu hermana V..."
-                className="flex-1 bg-white/5 border border-white/10 rounded-2xl px-4 py-3.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors"
+                autoComplete="off"
+                autoCorrect="on"
+                autoCapitalize="sentences"
+                spellCheck
+                enterKeyHint="send"
+                inputMode="text"
+                disabled={isTyping}
+                className="flex-1 bg-white/5 border border-white/10 rounded-2xl px-4 py-3.5 text-base text-white placeholder-white/20 focus:outline-none focus:border-vf-green transition-colors disabled:opacity-60"
+                style={{ touchAction: "manipulation", fontSize: 16 }}
               />
               <button
-                onClick={handleSend}
-                className="p-3.5 rounded-2xl bg-vf-green hover:bg-vf-green-quiet text-black transition-colors active:scale-95 flex items-center justify-center"
+                onClick={() => void handleSend()}
+                disabled={!inputValue.trim() || isTyping}
+                aria-label="Enviar"
+                className="p-3.5 rounded-2xl bg-vf-green hover:bg-vf-green-quiet text-black transition-colors active:scale-95 flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{ touchAction: "manipulation" }}
               >
                 <Send className="w-4 h-4" />
               </button>

--- a/components/V/ProcessTrace.tsx
+++ b/components/V/ProcessTrace.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import {
+  BookOpen,
+  PenLine,
+  Search,
+  Terminal,
+  Globe,
+  Database,
+  Wrench,
+  CheckCircle2,
+  XCircle,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface TraceEntry {
+  id: string;
+  tool: string;
+  status: 'running' | 'ok' | 'error';
+  summary?: string;
+}
+
+const TOOL_ICON: Record<string, typeof Wrench> = {
+  github_read_file: BookOpen,
+  github_get_repo: BookOpen,
+  github_list_repos: Search,
+  github_write_file: PenLine,
+  github_create_file: PenLine,
+  memory_save: Database,
+  memory_search: Search,
+  vault_get: Database,
+  vault_set: Database,
+  vercel_get_project: Globe,
+  vercel_create_project: Globe,
+  vercel_trigger_deployment: Globe,
+  vercel_add_domain: Globe,
+  namecom_list_records: Globe,
+  namecom_upsert_record: Globe,
+  remote_execution: Terminal,
+  browser_control: Globe,
+  image_generation: Wrench,
+  ssh_command_executor: Terminal,
+};
+
+const TOOL_VERB: Record<string, string> = {
+  github_read_file: 'Reading',
+  github_get_repo: 'Inspecting',
+  github_list_repos: 'Listing repos',
+  github_write_file: 'Writing',
+  github_create_file: 'Creating',
+  memory_save: 'Saving memory',
+  memory_search: 'Recalling',
+  vault_get: 'Reading vault',
+  vault_set: 'Writing vault',
+  vercel_get_project: 'Inspecting Vercel',
+  vercel_create_project: 'Creating Vercel project',
+  vercel_trigger_deployment: 'Deploying',
+  vercel_add_domain: 'Adding domain',
+  namecom_list_records: 'Listing DNS',
+  namecom_upsert_record: 'Updating DNS',
+  remote_execution: 'Executing remote',
+  browser_control: 'Browsing',
+  image_generation: 'Generating image',
+  ssh_command_executor: 'Running SSH',
+};
+
+function verbFor(tool: string): string {
+  return TOOL_VERB[tool] ?? `Running ${tool.replace(/_/g, ' ')}`;
+}
+
+function IconFor({ tool, status }: { tool: string; status: TraceEntry['status'] }) {
+  if (status === 'ok') return <CheckCircle2 size={11} className="text-vf-green/60" aria-hidden />;
+  if (status === 'error') return <XCircle size={11} className="text-vf-error/80" aria-hidden />;
+  const Cmp = TOOL_ICON[tool] ?? Wrench;
+  return <Cmp size={11} className="text-vf-fg-3" aria-hidden />;
+}
+
+interface ProcessTraceProps {
+  entry: TraceEntry;
+}
+
+export function ProcessTrace({ entry }: ProcessTraceProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -6 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -6 }}
+      transition={{ duration: 0.25 }}
+      className={cn(
+        'flex items-center gap-2 pl-11 pr-3 py-0.5',
+        'text-[11px] leading-relaxed font-mono',
+        entry.status === 'error' ? 'text-vf-error/80' : 'text-vf-fg-3/80',
+      )}
+    >
+      <IconFor tool={entry.tool} status={entry.status} />
+      <span className="truncate">
+        <span className="text-vf-fg-2/70">{verbFor(entry.tool)}</span>
+        {entry.summary ? (
+          <span className="text-vf-fg-3/60"> · {entry.summary}</span>
+        ) : null}
+      </span>
+      {entry.status === 'running' && <RunningPulse />}
+    </motion.div>
+  );
+}
+
+function RunningPulse() {
+  return (
+    <motion.span
+      aria-hidden
+      className="inline-block w-1 h-1 rounded-full bg-vf-green/70"
+      animate={{ opacity: [0.3, 1, 0.3] }}
+      transition={{ duration: 1.1, repeat: Infinity, ease: 'easeInOut' }}
+    />
+  );
+}

--- a/components/V/VLayoutDashboard.tsx
+++ b/components/V/VLayoutDashboard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { ChevronLeft, ChevronRight, Plus, Settings } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
+import { ChatPage } from './ChatPage';
 
 interface Project {
   id: string;
@@ -316,32 +317,10 @@ export const VLayoutDashboard = () => {
           </div>
         </div>
 
-        {/* Chat Area (placeholder) */}
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
-            <div className="text-6xl mb-4">💬</div>
-            <h3 className="text-xl font-semibold text-vf-fg-1 mb-2">
-              Chat con V
-            </h3>
-            <p className="text-vf-fg-2 max-w-md">
-              Aquí irá la interfaz de chat integrada. V está lista para trabajar
-              en {selectedProject.name}
-            </p>
-          </div>
-        </div>
-
-        {/* Composer (placeholder) */}
-        <div className="border-t border-vf-border bg-vf-bg-1 px-8 py-6">
-          <div className="flex gap-3">
-            <input
-              type="text"
-              placeholder="Dile a V qué hacer..."
-              className="flex-1 bg-vf-bg-2 border border-vf-border rounded-xl px-4 py-3 text-vf-fg-1 placeholder:text-vf-fg-3 focus:outline-none focus:border-vf-green/50"
-            />
-            <button className="px-6 py-3 bg-vf-green/20 border border-vf-green/50 text-vf-green rounded-xl hover:bg-vf-green/30 transition-colors font-medium">
-              Enviar
-            </button>
-          </div>
+        {/* Real V chat — streams from /api/forge/run with full system prompt,
+            tools, skills and memory. */}
+        <div className="flex-1 min-h-0">
+          <ChatPage />
         </div>
       </div>
     </div>

--- a/components/V/VThinking.tsx
+++ b/components/V/VThinking.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+export type ThinkingPhase = 'thinking' | 'reasoning' | 'writing' | 'finalizing';
+
+const PHASE_LABEL: Record<ThinkingPhase, string> = {
+  thinking: 'pensando',
+  reasoning: 'razonando',
+  writing: 'escribiendo',
+  finalizing: 'finalizando',
+};
+
+interface VThinkingProps {
+  phase?: ThinkingPhase;
+  className?: string;
+}
+
+export function VThinking({ phase = 'thinking', className }: VThinkingProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+      className={cn('flex items-center gap-3', className)}
+    >
+      <div className="relative flex-shrink-0">
+        <motion.div
+          aria-hidden
+          className="absolute inset-0 rounded-2xl"
+          animate={{
+            boxShadow: [
+              '0 0 0 0 rgba(0, 255, 136, 0.0)',
+              '0 0 32px 4px rgba(0, 255, 136, 0.45)',
+              '0 0 0 0 rgba(0, 255, 136, 0.0)',
+            ],
+          }}
+          transition={{ duration: 2.4, repeat: Infinity, ease: 'easeInOut' }}
+        />
+        <motion.div
+          className={cn(
+            'relative w-10 h-10 rounded-2xl overflow-hidden',
+            'bg-gradient-to-br from-vf-green/30 via-vf-green/10 to-transparent',
+            'border border-vf-green/40',
+            'flex items-center justify-center',
+          )}
+          animate={{ scale: [1, 1.08, 1] }}
+          transition={{ duration: 1.8, repeat: Infinity, ease: 'easeInOut' }}
+        >
+          <motion.div
+            aria-hidden
+            className="absolute inset-0 opacity-60"
+            style={{
+              background:
+                'radial-gradient(120% 80% at 30% 20%, rgba(0,255,136,0.35) 0%, rgba(0,255,136,0) 60%)',
+            }}
+            animate={{ opacity: [0.4, 0.8, 0.4] }}
+            transition={{ duration: 2.4, repeat: Infinity, ease: 'easeInOut' }}
+          />
+          <motion.span
+            className="relative text-vf-green font-mono text-lg leading-none tracking-tight select-none"
+            animate={{ y: [0, -1, 0] }}
+            transition={{ duration: 2.4, repeat: Infinity, ease: 'easeInOut' }}
+          >
+            V
+          </motion.span>
+        </motion.div>
+      </div>
+
+      <div className="flex items-baseline gap-1.5 min-w-0">
+        <AnimatePresence mode="wait">
+          <motion.span
+            key={phase}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.25 }}
+            className="text-sm text-vf-fg-2"
+          >
+            {PHASE_LABEL[phase]}
+          </motion.span>
+        </AnimatePresence>
+        <ThinkingDots />
+      </div>
+    </motion.div>
+  );
+}
+
+function ThinkingDots() {
+  return (
+    <span className="inline-flex gap-0.5 text-vf-green/80 leading-none" aria-hidden>
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="inline-block w-1 h-1 rounded-full bg-current"
+          animate={{ opacity: [0.2, 1, 0.2], y: [0, -2, 0] }}
+          transition={{
+            duration: 1.1,
+            repeat: Infinity,
+            delay: i * 0.18,
+            ease: 'easeInOut',
+          }}
+        />
+      ))}
+    </span>
+  );
+}

--- a/components/vforge/app-shell.tsx
+++ b/components/vforge/app-shell.tsx
@@ -95,10 +95,10 @@ export function AppShell({ children }: AppShellProps) {
             {!isHome && (
               <motion.div
                 key={pathname}
-                initial={{ y: "100%", opacity: 0, scale: 0.95 }}
-                animate={{ y: 0, opacity: 1, scale: 1 }}
-                exit={{ y: "100%", opacity: 0, scale: 0.95 }}
-                transition={{ type: "spring", damping: 28, stiffness: 220 }}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 12 }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
                 className={cn(
                   "absolute inset-x-2 top-2 bottom-16 md:inset-x-8 md:top-6 md:bottom-24 max-w-5xl mx-auto",
                   "bg-vf-bg/80 backdrop-blur-2xl border border-white/10 rounded-3xl shadow-[0_25px_60px_-15px_rgba(0,0,0,0.8)]",
@@ -128,10 +128,10 @@ export function AppShell({ children }: AppShellProps) {
             {isHome && (
               <motion.div
                 key="home-desktop"
-                initial={{ opacity: 0, scale: 1.05 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.95 }}
-                transition={{ duration: 0.4 }}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
                 className="absolute inset-0 overflow-y-auto flex items-center justify-center"
               >
                 <div className="w-full max-w-6xl h-full flex flex-col items-center justify-start">

--- a/lib/auth/current-user.ts
+++ b/lib/auth/current-user.ts
@@ -1,0 +1,58 @@
+/**
+ * Tenant resolver — single source of truth for "who is making this request".
+ *
+ * Today this returns `operator_luis` unconditionally, so V keeps loading her
+ * full personal context. When Clerk is wired into the frontend, this is the
+ * only place that needs to learn the mapping:
+ *
+ *   - Server-to-server with VFORGE_OPERATOR_TOKEN  → 'operator_luis'
+ *   - Clerk session, sub === LUIS_CLERK_ID         → 'operator_luis'
+ *   - Clerk session, any other sub                 → `clerk_${sub}`
+ *
+ * The API surface is intentionally async so the future Clerk path can `await
+ * auth()` without a refactor.
+ */
+
+import { requireOperatorAuth } from './operator-token';
+
+export const OPERATOR_USER_ID = 'operator_luis';
+
+/**
+ * Resolve the user_id this request is acting as.
+ *
+ * Optional Request lets API routes pass `req` so the helper can inspect the
+ * Authorization header (operator token) or session cookie. Server components
+ * that do not have a Request just call `getCurrentUserId()`.
+ */
+export async function getCurrentUserId(req?: Request): Promise<string> {
+  // 1) Server-to-server operator token wins (used by background jobs, MCP, CLI).
+  if (req) {
+    const header = req.headers.get('authorization');
+    if (header && process.env.VFORGE_OPERATOR_TOKEN) {
+      const result = requireOperatorAuth(req);
+      if (result.ok) return result.userId;
+    }
+  }
+
+  // 2) Clerk session → mapped user_id. Wiring lives here when @clerk/nextjs
+  //    is added to the stack. For now we fall through to the operator.
+  //
+  //    Example for the future:
+  //    const { userId: clerkUserId } = auth();
+  //    if (clerkUserId) {
+  //      if (clerkUserId === process.env.LUIS_CLERK_ID) return OPERATOR_USER_ID;
+  //      return `clerk_${clerkUserId}`;
+  //    }
+
+  // 3) Default: single-tenant mode = Luis.
+  return OPERATOR_USER_ID;
+}
+
+/**
+ * True when the current request is acting as Luis (the operator). UIs and
+ * tools that should only appear for him can gate on this.
+ */
+export async function isOperator(req?: Request): Promise<boolean> {
+  const userId = await getCurrentUserId(req);
+  return userId === OPERATOR_USER_ID;
+}

--- a/lib/chat/typewriter.ts
+++ b/lib/chat/typewriter.ts
@@ -1,0 +1,133 @@
+/**
+ * Token-by-token typewriter for V's streaming responses.
+ *
+ * The model often emits text in chunks of dozens or hundreds of characters at
+ * once (especially after a tool round finishes). Painting those directly to
+ * the DOM makes the message "snap" into view instead of feeling spoken. This
+ * helper queues incoming text and releases characters with humanlike rhythm.
+ *
+ * Usage:
+ *   const tw = createTypewriter({ onChunk: (text) => setMessage(prev => prev + text) });
+ *   tw.push(deltaFromSse);          // feed text as it arrives
+ *   tw.flush();                     // drop the queue (e.g. on Stop)
+ *   tw.complete();                  // wait for the queue to drain
+ *
+ * Tuning lives in CHARS_PER_FRAME / JITTER. Default ≈ 45–70 chars/sec.
+ */
+
+interface TypewriterOptions {
+  onChunk: (text: string) => void;
+  charsPerSecond?: number;
+}
+
+interface Typewriter {
+  push: (text: string) => void;
+  flush: () => void;
+  cancel: () => void;
+  complete: () => Promise<void>;
+}
+
+const PUNCT_PAUSE_MS: Record<string, number> = {
+  '.': 90,
+  '!': 90,
+  '?': 90,
+  ',': 45,
+  ';': 60,
+  ':': 60,
+  '\n': 70,
+};
+
+export function createTypewriter({
+  onChunk,
+  charsPerSecond = 55,
+}: TypewriterOptions): Typewriter {
+  let queue = '';
+  let cancelled = false;
+  let pumping = false;
+  let lastTick = 0;
+  let pauseUntil = 0;
+  let resolveComplete: (() => void) | null = null;
+
+  // budget tracks fractional characters between frames so the pace stays smooth
+  let budget = 0;
+
+  const tick = (now: number) => {
+    if (cancelled) return;
+    if (!queue.length) {
+      pumping = false;
+      if (resolveComplete) {
+        resolveComplete();
+        resolveComplete = null;
+      }
+      return;
+    }
+    if (now < pauseUntil) {
+      requestAnimationFrame(tick);
+      return;
+    }
+    const dt = lastTick ? Math.min(now - lastTick, 100) : 16;
+    lastTick = now;
+    budget += (charsPerSecond * dt) / 1000;
+
+    let toRelease = '';
+    while (budget >= 1 && queue.length) {
+      const ch = queue[0];
+      queue = queue.slice(1);
+      toRelease += ch;
+      budget -= 1;
+      const pause = PUNCT_PAUSE_MS[ch];
+      if (pause) {
+        // small jitter so it doesn't feel metronomic
+        pauseUntil = now + pause + Math.random() * 40;
+        break;
+      }
+    }
+    if (toRelease) onChunk(toRelease);
+
+    if (queue.length || pauseUntil > now) {
+      requestAnimationFrame(tick);
+    } else {
+      pumping = false;
+      if (resolveComplete) {
+        resolveComplete();
+        resolveComplete = null;
+      }
+    }
+  };
+
+  const start = () => {
+    if (pumping || cancelled) return;
+    pumping = true;
+    lastTick = 0;
+    requestAnimationFrame(tick);
+  };
+
+  return {
+    push(text: string) {
+      if (cancelled || !text) return;
+      queue += text;
+      start();
+    },
+    flush() {
+      if (queue.length) {
+        onChunk(queue);
+        queue = '';
+      }
+    },
+    cancel() {
+      cancelled = true;
+      queue = '';
+      if (resolveComplete) {
+        resolveComplete();
+        resolveComplete = null;
+      }
+    },
+    complete() {
+      if (!queue.length && !pumping) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        resolveComplete = resolve;
+        start();
+      });
+    },
+  };
+}

--- a/lib/db/auto-heal.ts
+++ b/lib/db/auto-heal.ts
@@ -210,6 +210,88 @@ async function ensureOtherTables(): Promise<void> {
   }
 }
 
+async function ensureMultiTenantColumns(): Promise<void> {
+  // M011 — Multi-tenant: add user_id columns with default 'operator_luis' so
+  // existing data stays attached to Luis. Idempotent: ADD COLUMN IF NOT EXISTS
+  // is a no-op on subsequent runs.
+  const tables: Array<{ table: string; indexes: string[] }> = [
+    {
+      table: 'knowledge_base',
+      indexes: [
+        'CREATE INDEX IF NOT EXISTS idx_knowledge_user_kind ON knowledge_base (user_id, kind)',
+        'CREATE INDEX IF NOT EXISTS idx_knowledge_user_created ON knowledge_base (user_id, created_at DESC)',
+      ],
+    },
+    {
+      table: 'projects',
+      indexes: [
+        'CREATE INDEX IF NOT EXISTS idx_projects_user_category ON projects (user_id, category)',
+        'CREATE INDEX IF NOT EXISTS idx_projects_user_status ON projects (user_id, status)',
+      ],
+    },
+    {
+      table: 'agent_directives',
+      indexes: [
+        'CREATE INDEX IF NOT EXISTS idx_directives_user_active ON agent_directives (user_id, active, priority)',
+      ],
+    },
+    {
+      table: 'skills',
+      indexes: [
+        'CREATE INDEX IF NOT EXISTS idx_skills_user_active ON skills (user_id, active)',
+      ],
+    },
+    {
+      table: 'agent_config',
+      indexes: ['CREATE INDEX IF NOT EXISTS idx_agent_config_user ON agent_config (user_id)'],
+    },
+  ];
+
+  for (const { table, indexes } of tables) {
+    try {
+      const existsRows = (await sql.query(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1) AS exists`,
+        [table],
+      )) as Array<{ exists: boolean }>;
+      if (!existsRows?.[0]?.exists) continue;
+
+      await sql.query(
+        `ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS user_id text NOT NULL DEFAULT 'operator_luis'`,
+      );
+      await sql.query(
+        `UPDATE ${table} SET user_id = 'operator_luis' WHERE user_id IS NULL`,
+      );
+      // Add FK in a separate try so existing tables without users still pass.
+      try {
+        await sql.query(
+          `ALTER TABLE ${table}
+             ADD CONSTRAINT ${table}_user_id_fkey
+             FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE`,
+        );
+      } catch {
+        // FK already exists or users table missing — non-fatal.
+      }
+      for (const idx of indexes) {
+        try {
+          await sql.query(idx);
+        } catch {
+          // Index already exists
+        }
+      }
+    } catch {
+      // Table missing or healing not possible — skip silently.
+    }
+  }
+
+  try {
+    await sql.query(
+      `INSERT INTO schema_migrations (version) VALUES ('011_multi_tenant') ON CONFLICT (version) DO NOTHING`,
+    );
+  } catch {
+    // schema_migrations may not exist yet on a brand new DB
+  }
+}
+
 async function ensureSemanticMemory(): Promise<void> {
   try {
     await sql`CREATE EXTENSION IF NOT EXISTS vector`;
@@ -257,6 +339,7 @@ export async function healDatabase(): Promise<void> {
     await ensureSkillsIndexes();
     await ensureSeedSkills();
     await ensureOtherTables();
+    await ensureMultiTenantColumns();
     await ensureSemanticMemory();
   } catch (e) {
     // Silently fail - don't crash the app if database healing fails

--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -60,7 +60,7 @@ interface InstalledSkill {
  *  6. Optional: focused project context when conversation is project-scoped
  */
 export async function buildSystemPrompt(
-  options: { projectId?: string | null } = {},
+  options: { projectId?: string | null; userId?: string | null } = {},
 ): Promise<{
   systemPrompt: string;
   config: SystemConfig;
@@ -74,36 +74,58 @@ export async function buildSystemPrompt(
     throw new Error("system_config not found — did you run the seed migration?");
   }
 
+  // Tenant filter. When `userId` is provided, every personal-data query is
+  // scoped to that user via `AND user_id = $N`. When it's null/undefined
+  // (legacy callers), the queries run unfiltered — preserving today's
+  // behavior so V keeps loading exactly what she loaded before this change.
+  const tenantId = options.userId ?? null;
+  const tenantParams = tenantId ? [tenantId] : [];
+
   // Always-on knowledge: operator + organization + method + ADRs
   const coreKnowledge = await queryAll<KnowledgeEntry>(
-    `SELECT kind, title, content, tags FROM knowledge_base
-     WHERE kind IN ('operator_profile', 'organization', 'method', 'preference')
-     ORDER BY kind, created_at`,
+    tenantId
+      ? `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE user_id = $1 AND kind IN ('operator_profile', 'organization', 'method', 'preference')
+         ORDER BY kind, created_at`
+      : `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE kind IN ('operator_profile', 'organization', 'method', 'preference')
+         ORDER BY kind, created_at`,
+    tenantParams,
   );
 
   // Recent lessons (max 10)
   const lessons = await queryAll<KnowledgeEntry>(
-    `SELECT kind, title, content, tags FROM knowledge_base
-     WHERE kind = 'lesson'
-     ORDER BY created_at DESC
-     LIMIT 10`,
+    tenantId
+      ? `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE user_id = $1 AND kind = 'lesson'
+         ORDER BY created_at DESC LIMIT 10`
+      : `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE kind = 'lesson'
+         ORDER BY created_at DESC LIMIT 10`,
+    tenantParams,
   );
 
   // Cross-session memory: last 8 recaps + last 8 manual memories. Tagged
-  // 'session_recap' or 'memory' on a kind='note' row (we keep them on
-  // the same kind to avoid touching the CHECK constraint, and lean on
-  // tags + the partial index for retrieval).
+  // 'session_recap' or 'memory' on a kind='note' row.
   const recaps = await queryAll<KnowledgeEntry>(
-    `SELECT kind, title, content, tags FROM knowledge_base
-     WHERE kind = 'note' AND 'session_recap' = ANY(tags)
-     ORDER BY created_at DESC
-     LIMIT 8`,
+    tenantId
+      ? `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE user_id = $1 AND kind = 'note' AND 'session_recap' = ANY(tags)
+         ORDER BY created_at DESC LIMIT 8`
+      : `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE kind = 'note' AND 'session_recap' = ANY(tags)
+         ORDER BY created_at DESC LIMIT 8`,
+    tenantParams,
   );
   const memories = await queryAll<KnowledgeEntry>(
-    `SELECT kind, title, content, tags FROM knowledge_base
-     WHERE kind = 'note' AND 'memory' = ANY(tags)
-     ORDER BY created_at DESC
-     LIMIT 8`,
+    tenantId
+      ? `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE user_id = $1 AND kind = 'note' AND 'memory' = ANY(tags)
+         ORDER BY created_at DESC LIMIT 8`
+      : `SELECT kind, title, content, tags FROM knowledge_base
+         WHERE kind = 'note' AND 'memory' = ANY(tags)
+         ORDER BY created_at DESC LIMIT 8`,
+    tenantParams,
   );
 
   // Project catalog summary
@@ -112,53 +134,71 @@ export async function buildSystemPrompt(
     count: number;
     names: string[];
   }>(
-    `SELECT category,
-            COUNT(*)::int AS count,
-            ARRAY_AGG(name ORDER BY name) AS names
-     FROM projects
-     GROUP BY category
-     ORDER BY category`,
+    tenantId
+      ? `SELECT category, COUNT(*)::int AS count, ARRAY_AGG(name ORDER BY name) AS names
+         FROM projects WHERE user_id = $1
+         GROUP BY category ORDER BY category`
+      : `SELECT category, COUNT(*)::int AS count, ARRAY_AGG(name ORDER BY name) AS names
+         FROM projects
+         GROUP BY category ORDER BY category`,
+    tenantParams,
   );
 
-  // Optional focused project context
+  // Optional focused project context (still scoped by tenant when provided)
   let projectFocus: ProjectFocus | null = null;
   if (options.projectId) {
-    projectFocus = await queryOne<ProjectFocus>(
-      `SELECT id, name, description, category, status,
-              github_repo, github_url, github_private, github_language,
-              vercel_url, domain
-         FROM projects WHERE id = $1`,
-      [options.projectId],
-    );
+    projectFocus = tenantId
+      ? await queryOne<ProjectFocus>(
+          `SELECT id, name, description, category, status,
+                  github_repo, github_url, github_private, github_language,
+                  vercel_url, domain
+             FROM projects WHERE id = $1 AND user_id = $2`,
+          [options.projectId, tenantId],
+        )
+      : await queryOne<ProjectFocus>(
+          `SELECT id, name, description, category, status,
+                  github_repo, github_url, github_private, github_language,
+                  vercel_url, domain
+             FROM projects WHERE id = $1`,
+          [options.projectId],
+        );
   }
 
-  // ─── NEW: Load dynamic directives (mantra + directive + preference) ───
-  // Graceful fallback if table doesn't exist yet (pre-migration)
+  // ─── Dynamic directives (mantra + directive + preference) ───
   let directives: AgentDirective[] = [];
   try {
     directives = await queryAll<AgentDirective>(
-      `SELECT id, kind, title, content, locked, priority, active
-       FROM agent_directives
-       WHERE active = true
-       ORDER BY priority ASC, created_at ASC`,
+      tenantId
+        ? `SELECT id, kind, title, content, locked, priority, active
+           FROM agent_directives
+           WHERE user_id = $1 AND active = true
+           ORDER BY priority ASC, created_at ASC`
+        : `SELECT id, kind, title, content, locked, priority, active
+           FROM agent_directives
+           WHERE active = true
+           ORDER BY priority ASC, created_at ASC`,
+      tenantParams,
     );
   } catch (e) {
-    // Table doesn't exist yet - that's ok, use empty array
     console.log("[V] agent_directives table not found, using defaults");
   }
 
-  // ─── NEW: Load installed skills ───
-  // Graceful fallback if table doesn't exist yet (pre-migration)
+  // ─── Installed skills ───
   let installedSkills: InstalledSkill[] = [];
   try {
     installedSkills = await queryAll<InstalledSkill>(
-      `SELECT id, name, description, system_prompt, tags, source, ring_max
-       FROM skills
-       WHERE active = true AND installed_at IS NOT NULL
-       ORDER BY installed_at ASC`,
+      tenantId
+        ? `SELECT id, name, description, system_prompt, tags, source, ring_max
+           FROM skills
+           WHERE user_id = $1 AND active = true AND installed_at IS NOT NULL
+           ORDER BY installed_at ASC`
+        : `SELECT id, name, description, system_prompt, tags, source, ring_max
+           FROM skills
+           WHERE active = true AND installed_at IS NOT NULL
+           ORDER BY installed_at ASC`,
+      tenantParams,
     );
   } catch (e) {
-    // Table doesn't exist yet - that's ok, use empty array
     console.log("[V] skills table not found, using defaults");
   }
 

--- a/migrations/011_multi_tenant.sql
+++ b/migrations/011_multi_tenant.sql
@@ -1,0 +1,105 @@
+-- ============================================================================
+-- vForge M011 — Multi-tenant foundation
+-- ============================================================================
+-- Purpose: open vForge to SaaS without disturbing V (Luis's agent).
+--
+-- Strategy (additive only):
+--   * Add `user_id TEXT NOT NULL DEFAULT 'operator_luis'` to the tables that
+--     hold personal context (knowledge, projects, directives, skills, agent
+--     config). Every existing row gets auto-tagged as Luis's data so V keeps
+--     behaving exactly as today.
+--   * Add FK to users(id) for referential integrity.
+--   * Add composite indexes (user_id, ...) for tenant-scoped queries.
+--
+-- What we DO NOT touch:
+--   * V's hardcoded `SENIOR_ENGINEER_DOCTRINE` (lives in code, shared).
+--   * Existing rows. Default is applied at insert time; the ALTER also
+--     backfills NULLs to 'operator_luis' via UPDATE.
+--   * `system_config` (singleton — already keyed by `operator_user_id`).
+--   * `conversations`, `user_secrets`, `audit_events` (already have user_id).
+--
+-- The application reads through `buildSystemPrompt(user_id?)`; passing no
+-- argument keeps the legacy behavior (no WHERE filter), so this migration
+-- can ship safely before the Clerk wiring lands.
+-- ============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------
+-- knowledge_base — personal facts/memories/lessons of each operator
+-- -----------------------------------------------------------
+ALTER TABLE knowledge_base
+  ADD COLUMN IF NOT EXISTS user_id text NOT NULL DEFAULT 'operator_luis'
+    REFERENCES users(id) ON DELETE CASCADE;
+
+UPDATE knowledge_base SET user_id = 'operator_luis' WHERE user_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_user_kind
+  ON knowledge_base (user_id, kind);
+CREATE INDEX IF NOT EXISTS idx_knowledge_user_created
+  ON knowledge_base (user_id, created_at DESC);
+
+-- -----------------------------------------------------------
+-- projects — projects belong to a single operator
+-- -----------------------------------------------------------
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS user_id text NOT NULL DEFAULT 'operator_luis'
+    REFERENCES users(id) ON DELETE CASCADE;
+
+UPDATE projects SET user_id = 'operator_luis' WHERE user_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_projects_user_category
+  ON projects (user_id, category);
+CREATE INDEX IF NOT EXISTS idx_projects_user_status
+  ON projects (user_id, status);
+
+-- -----------------------------------------------------------
+-- agent_directives — each operator has their own directives
+-- (guarded: the table may not exist yet if 009 hasn't been applied)
+-- -----------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'agent_directives') THEN
+    EXECUTE 'ALTER TABLE agent_directives
+              ADD COLUMN IF NOT EXISTS user_id text NOT NULL DEFAULT ''operator_luis''
+                REFERENCES users(id) ON DELETE CASCADE';
+    EXECUTE 'UPDATE agent_directives SET user_id = ''operator_luis'' WHERE user_id IS NULL';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_directives_user_active
+              ON agent_directives (user_id, active, priority)';
+  END IF;
+END $$;
+
+-- -----------------------------------------------------------
+-- skills — installed skills are per-operator
+-- -----------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'skills') THEN
+    EXECUTE 'ALTER TABLE skills
+              ADD COLUMN IF NOT EXISTS user_id text NOT NULL DEFAULT ''operator_luis''
+                REFERENCES users(id) ON DELETE CASCADE';
+    EXECUTE 'UPDATE skills SET user_id = ''operator_luis'' WHERE user_id IS NULL';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_skills_user_active
+              ON skills (user_id, active)';
+  END IF;
+END $$;
+
+-- -----------------------------------------------------------
+-- agent_config — per-operator agent settings (model, max tokens, etc.)
+-- -----------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'agent_config') THEN
+    EXECUTE 'ALTER TABLE agent_config
+              ADD COLUMN IF NOT EXISTS user_id text NOT NULL DEFAULT ''operator_luis''
+                REFERENCES users(id) ON DELETE CASCADE';
+    EXECUTE 'UPDATE agent_config SET user_id = ''operator_luis'' WHERE user_id IS NULL';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_agent_config_user
+              ON agent_config (user_id)';
+  END IF;
+END $$;
+
+INSERT INTO schema_migrations (version) VALUES ('011_multi_tenant')
+  ON CONFLICT (version) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Resumen

Este PR ataca dos frentes sin tocar a V:

**1) Chat UX cinemático** — el dolor diario que sentías
- **Streaming paisado**: typewriter con `requestAnimationFrame`, ~55 chars/seg, jitter humano y pausas naturales en `.`, `,`, `;`. Reemplaza el `setText` directo que pintaba todo de golpe.
- **Process traces tenues** (estilo Claude Code): el backend ya emitía `tool_use_start` / `tool_use_result` y nadie los renderizaba. Ahora aparecen como líneas finas monoespaciadas debajo del avatar con icono por tool (BookOpen para reads, PenLine para writes, Search, Terminal, Globe…) y estado running/ok/error.
- **Icono cinemático `VThinking`**: respiración (`scale 1 → 1.08`), halo pulsante con `boxShadow` y label que cambia de fase según el stream (`pensando → razonando → escribiendo → finalizando`). Hecho con Framer Motion, que ya estaba en el bundle.
- **Markdown real** con `react-markdown` + `remark-gfm` (ya instalados): code blocks con copy-to-clipboard, tablas con borde sutil, blockquotes, links externos seguros.
- **Layout limpio**: contenedor full-height `min-h-0`, mensajes centrados en `max-w-3xl`, auto-scroll inteligente que se pausa cuando subes y muestra pill flotante "Nuevo contenido" para regresar.
- **Botón Stop** durante el stream que aborta el fetch y vacía la cola del typewriter al instante.

**2) Multi-tenant foundation — aditivo, V intocable**
- Migración `011_multi_tenant.sql` + auto-heal: agrega `user_id text NOT NULL DEFAULT 'operator_luis'` a `knowledge_base`, `projects`, `agent_directives`, `skills` y `agent_config`. Todo lo que ya tenías queda auto-asignado a Luis.
- `lib/auth/current-user.ts`: helper `getCurrentUserId()` que hoy devuelve `operator_luis` siempre y deja un hueco listo para cuando Clerk se cablee (sin requerir env vars aún).
- `buildSystemPrompt({ userId? })` admite un user_id opcional. **Sin argumento se comporta exactamente como antes** — V sigue cargando todo tu corpus. Con argumento filtra `WHERE user_id = $1` en cada query personal.
- `SENIOR_ENGINEER_DOCTRINE` (`lib/forge/system-prompt.ts:245-334`) sigue hardcoded y compartido. Cero cambios.

## Lo que NO está en este PR (intencional)
- Clerk wiring real (signup, login, middleware). Requiere `CLERK_SECRET_KEY` / `CLERK_PUBLISHABLE_KEY` en env y diseño de flujo, mejor en su propio PR donde se pueda probar en vivo.
- Onboarding del clon de V (4-step wizard). Sin Clerk activo no se puede cablear el `user_id` correcto al guardar las filas iniciales.
- Landing pública. Se diseña junto con el flujo de signup.
- Cambios al endpoint `/api/forge/run` para inyectar `userId` — sigue invocando `buildSystemPrompt({ projectId })` legacy, que es el comportamiento actual.

## Test plan
- [ ] Abrir `/v`: el chat debe sentirse fluido — palabras apareciendo con cadencia humana, no de golpe.
- [ ] Pedir algo que use tools (ej. "lista mis repos"): verificar que aparecen líneas tenues `Reading github_list_repos · ...` mientras corre, y que pasan a check verde al terminar.
- [ ] Mientras V escribe, presionar Stop → la respuesta se detiene de inmediato.
- [ ] Bloques de código en respuestas: botón "copiar" funciona, código se ve con fuente monoespaciada.
- [ ] Auto-scroll: subir manualmente mientras V escribe → debe pausarse el auto-scroll y aparecer la pill "Nuevo contenido".
- [ ] DB: `SELECT user_id, COUNT(*) FROM knowledge_base GROUP BY user_id` debe mostrar todas las filas como `operator_luis` después del primer hit.
- [ ] V responde idéntica con sesión normal (sin pasar `userId` a `buildSystemPrompt`).

https://claude.ai/code/session_01726tiq2eHttztt2uhxTi7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01726tiq2eHttztt2uhxTi7J)_