### PR TITLE
fix(chat): inline code se renderea inline (react-markdown v10 quitó prop `inline`)

### DIFF
--- a/components/workspace/chat/Markdown.tsx
+++ b/components/workspace/chat/Markdown.tsx
@@ -20,18 +20,22 @@ function CodeBlock({ inline, className, children }: {
   className?: string;
   children: React.ReactNode;
 }) {
-  const text = String(children ?? "").replace(/\n$/, "");
+  const raw = String(children ?? "");
+  const text = raw.replace(/\n$/, "");
   const [copied, setCopied] = useState(false);
 
   // react-markdown v10 ya NO pasa `inline`. Heurística robusta: es
-  // inline si NO tiene className de lenguaje Y el texto no contiene
-  // saltos de línea. Los fenced blocks SIEMPRE terminan con \n (el
-  // tokenizer de remark añade uno), los inline ` ` jamás llevan \n.
+  // inline si NO tiene className de lenguaje Y el texto crudo no
+  // contiene saltos de línea. Los fenced blocks SIEMPRE traen al
+  // menos un \n del tokenizer de remark (incluso si la línea trimmed
+  // queda en blanco), los inline ` ` jamás llevan \n. Cuidado: hay
+  // que revisar el `raw` ANTES del trim, si no un fence de una sola
+  // línea sin lenguaje (```\nhello\n```) pasaría como inline.
   const looksInline =
     inline === true ||
     (inline === undefined &&
       !/^language-/.test(className ?? "") &&
-      !/\n/.test(text));
+      !/\n/.test(raw));
 
   if (looksInline) {
     return (

--- a/components/workspace/chat/Markdown.tsx
+++ b/components/workspace/chat/Markdown.tsx
@@ -23,7 +23,17 @@ function CodeBlock({ inline, className, children }: {
   const text = String(children ?? "").replace(/\n$/, "");
   const [copied, setCopied] = useState(false);
 
-  if (inline) {
+  // react-markdown v10 ya NO pasa `inline`. Heurística robusta: es
+  // inline si NO tiene className de lenguaje Y el texto no contiene
+  // saltos de línea. Los fenced blocks SIEMPRE terminan con \n (el
+  // tokenizer de remark añade uno), los inline ` ` jamás llevan \n.
+  const looksInline =
+    inline === true ||
+    (inline === undefined &&
+      !/^language-/.test(className ?? "") &&
+      !/\n/.test(text));
+
+  if (looksInline) {
     return (
       <code className="rounded-[5px] border border-violet-500/25 bg-violet-500/[0.1] px-1.5 py-px font-mono text-[0.88em] text-violet-300">
         {children}
@@ -59,7 +69,7 @@ function CodeBlock({ inline, className, children }: {
           <span className="hidden sm:inline">{copied ? "Copiado" : "Copy"}</span>
         </button>
       </div>
-      <pre className="m-0 overflow-x-auto px-3 py-2.5 font-mono text-[13px] leading-relaxed text-on-surface">
+      <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words px-3 py-2.5 font-mono text-[13px] leading-relaxed text-on-surface select-text">
         <code className={className}>{text}</code>
       </pre>
     </div>


### PR DESCRIPTION
## Bug

react-markdown v10 quitó la prop `inline` que el componente custom de `code` recibía. Mi `if (inline)` siempre era `undefined` → cada backtick simple (`` `Dockerfile` ``, `` `README` ``, `` `pm2` ``) terminaba en el path de bloque → header "CODE" + borde violeta + 2 líneas por palabra → imposible seleccionar y copiar texto del párrafo, Luis se veía forzado a screenshot toda la pantalla.

## Fix

1. Heurística robusta de inline-vs-block: es inline si NO tiene `className` de lenguaje Y el texto no contiene `\n`. Los fenced blocks de remark siempre terminan con `\n`; los inline nunca.
2. Bloques reales ahora hacen soft-wrap en mobile (`whitespace-pre-wrap break-words`) → líneas largas se envuelven en vez de cortarse fuera de pantalla.
3. `select-text` en el `<pre>` → el usuario puede arrastrar para seleccionar partes específicas sin tener que copiar el bloque entero.

## Test plan
- [ ] Mensaje con `` `Dockerfile` `` inline → aparece como pill violeta pequeña dentro del párrafo, NO como bloque
- [ ] Fenced ``` ```ts ... ``` ``` → sigue siendo bloque con header CODE
- [ ] Líneas largas en bloque → se envuelven, no se cortan fuera de pantalla
- [ ] Mobile long-press en código → selección nativa funciona

https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm)_