### PR TITLE
fix(chat): elimina overflow horizontal + tipografía sólida y estable

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -98,8 +98,22 @@ body {
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "ss01", "cv11";
   transition: background-color 0.3s ease, color 0.3s ease;
-  overflow-x: hidden;
+  /* `clip` no crea nuevo contexto de scroll y es respetado por iOS
+     Safari mucho mejor que `hidden` (que ahí se rompe con pinch-zoom
+     y contenido absoluto). Doble cinturón: max-width 100vw para que
+     ningún hijo intrínsecamente ancho empuje el body. */
+  overflow-x: clip;
+  overflow-y: auto;
+  max-width: 100vw;
   width: 100%;
+  position: relative;
+}
+
+/* Belt-and-suspenders: ningún hijo directo del body debe poder hacer
+   scroll horizontal. Sirve cuando un componente nuevo accidentalmente
+   suelta un elemento sin min-w-0. */
+body > * {
+  max-width: 100vw;
 }
 
 html {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,6 +38,11 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  // Cuando el teclado soft aparece, redimensiona el VIEWPORT en vez de
+  // overlay (iOS 16+ / Chrome Android). Esto hace que `h-dvh` y los
+  // layouts flex shrinken correctamente, manteniendo el composer
+  // pegado arriba del teclado sin necesidad de hacks JS.
+  interactiveWidget: "resizes-content",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -107,16 +107,16 @@ export function WorkspaceShell({ children }: { children: React.ReactNode }) {
         </div>
       </aside>
 
-      <div className="flex min-w-0 flex-1 flex-col h-dvh">
+      <div className="flex min-w-0 max-w-full flex-1 flex-col h-dvh overflow-x-hidden">
         <TopBar />
         <div
           className={cn(
-            "flex-1 min-h-0",
+            "flex-1 min-h-0 min-w-0 max-w-full overflow-x-hidden",
             // Chat manages its own bottom clearance via .vf-composer-pad — no
             // pb-24 here or we get a double-reserve gap. Other routes need pb-24
             // mobile to clear the floating MobileNav.
             pathname?.startsWith("/app/chat")
-              ? "overflow-hidden"
+              ? "overflow-y-hidden"
               : "overflow-y-auto pb-24 md:pb-0",
           )}
         >
@@ -134,13 +134,15 @@ function TopBar() {
       className="sticky top-0 z-30 border-b border-app bg-void/85 backdrop-blur-xl"
       style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
     >
-      <div className="flex items-center justify-between gap-2 px-3 py-2.5 sm:gap-3 sm:px-4 sm:py-3 md:px-8">
-        <div className="flex items-center gap-2 text-on-surface-variant md:hidden">
+      <div className="flex min-w-0 items-center justify-between gap-2 px-3 py-2.5 sm:gap-3 sm:px-4 sm:py-3 md:px-8">
+        <div className="flex shrink-0 items-center gap-2 text-on-surface-variant md:hidden">
           <VMark size={20} />
           <span className="font-display text-sm font-semibold tracking-tight text-on-surface">VForge</span>
         </div>
-        <Breadcrumbs />
-        <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <Breadcrumbs />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
           <LocaleToggle compact />
           <ThemeToggle compact />
           <button

--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -545,9 +545,9 @@ export function ChatExperience() {
           patrón estándar de chat (WhatsApp/Claude/ChatGPT). */}
       <div
         ref={scrollerRef}
-        className="flex-1 min-h-0 overflow-y-auto flex flex-col-reverse"
+        className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col-reverse"
       >
-        <div className="mx-auto w-full max-w-3xl px-3 py-3 md:px-10 md:py-5">
+        <div className="mx-auto w-full max-w-3xl overflow-x-hidden px-3 py-3 md:px-10 md:py-5">
           {/* Operator header — solo visible cuando el chat está vacío (más
               espacio para mensajes cuando ya hay conversación). */}
           {messages.length <= 1 && (
@@ -971,10 +971,10 @@ function MessageBubble({
       <motion.div
         initial={{ opacity: 0, y: 6 }}
         animate={{ opacity: 1, y: 0 }}
-        className="group/msg flex w-full gap-3"
+        className="group/msg flex w-full min-w-0 gap-3"
       >
         <VOrb size={26} />
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 overflow-hidden">
           {msg.image && (
             // eslint-disable-next-line @next/next/no-img-element
             <img
@@ -1015,9 +1015,9 @@ function MessageBubble({
     <motion.div
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
-      className="flex w-full justify-end"
+      className="flex w-full min-w-0 justify-end"
     >
-      <div className="max-w-[85%] rounded-2xl rounded-br-md bg-gradient-to-br from-violet-500 to-cyan-500 px-4 py-2.5 text-[15px] leading-relaxed text-white shadow-glow-violet">
+      <div className="max-w-[82%] min-w-0 rounded-2xl rounded-br-md bg-gradient-to-br from-violet-500 to-cyan-500 px-4 py-2.5 font-sans text-[15px] font-normal leading-[1.55] tracking-[-0.005em] text-white shadow-glow-violet sm:text-[16px]">
         {msg.image && (
           // eslint-disable-next-line @next/next/no-img-element
           <img
@@ -1027,7 +1027,12 @@ function MessageBubble({
           />
         )}
         {msg.text && (
-          <p className="whitespace-pre-wrap break-words">{msg.text}</p>
+          <p
+            className="whitespace-pre-wrap"
+            style={{ overflowWrap: "anywhere", wordBreak: "break-word" }}
+          >
+            {msg.text}
+          </p>
         )}
       </div>
     </motion.div>
@@ -1039,10 +1044,10 @@ function StreamingBubble({ text, image }: { text: string; image?: string }) {
     <motion.div
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
-      className="flex w-full gap-3"
+      className="flex w-full min-w-0 gap-3"
     >
       <VOrb size={26} />
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 overflow-hidden">
         {image && (
           // eslint-disable-next-line @next/next/no-img-element
           <img

--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -181,12 +181,13 @@ export function ChatExperience() {
     );
   }, [t.chat.intro]);
 
-  // Autoscroll
+  // Autoscroll instantáneo — el smooth de 300ms causaba que el usuario
+  // no viera el thinking indicator inmediatamente al enviar y se
+  // preguntara si V estaba haciendo algo.
   useEffect(() => {
-    scrollerRef.current?.scrollTo({
-      top: scrollerRef.current.scrollHeight,
-      behavior: "smooth",
-    });
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
   }, [messages]);
 
   // Load projects + initial scope

--- a/components/workspace/chat/Markdown.tsx
+++ b/components/workspace/chat/Markdown.tsx
@@ -94,40 +94,40 @@ const components: Components = {
     </a>
   ),
   ul: ({ children }) => (
-    <ul className="my-2 ml-1 list-disc space-y-1 pl-4 marker:text-violet-400">{children}</ul>
+    <ul className="vf-md-block my-2.5 ml-0 list-disc space-y-1.5 pl-5 marker:text-violet-400/80">{children}</ul>
   ),
   ol: ({ children }) => (
-    <ol className="my-2 ml-1 list-decimal space-y-1 pl-5 marker:text-violet-400">{children}</ol>
+    <ol className="vf-md-block my-2.5 ml-0 list-decimal space-y-1.5 pl-5 marker:text-violet-400/80">{children}</ol>
   ),
-  li: ({ children }) => <li className="pl-1 leading-relaxed">{children}</li>,
+  li: ({ children }) => <li className="vf-md-block pl-1 leading-[1.65]">{children}</li>,
   h1: ({ children }) => (
-    <h1 className="mt-4 mb-2 font-display text-[1.15rem] font-semibold tracking-tight text-on-surface">
+    <h1 className="vf-md-block mt-5 mb-2.5 font-display text-[1.2rem] font-semibold leading-tight tracking-[-0.01em] text-on-surface">
       {children}
     </h1>
   ),
   h2: ({ children }) => (
-    <h2 className="mt-3 mb-1.5 font-display text-[1.05rem] font-semibold tracking-tight text-on-surface">
+    <h2 className="vf-md-block mt-4 mb-2 font-display text-[1.08rem] font-semibold leading-tight tracking-[-0.01em] text-on-surface">
       {children}
     </h2>
   ),
   h3: ({ children }) => (
-    <h3 className="mt-3 mb-1 font-display text-[0.98rem] font-semibold tracking-tight text-on-surface">
+    <h3 className="vf-md-block mt-3.5 mb-1.5 font-display text-[0.98rem] font-semibold leading-snug tracking-[-0.005em] text-on-surface">
       {children}
     </h3>
   ),
-  p: ({ children }) => <p className="my-1.5 leading-relaxed">{children}</p>,
+  p: ({ children }) => <p className="vf-md-block my-2 leading-[1.65]">{children}</p>,
   blockquote: ({ children }) => (
-    <blockquote className="my-2 border-l-2 border-violet-400/60 bg-violet-500/[0.04] py-1 pl-3 italic text-on-surface-variant">
+    <blockquote className="vf-md-block my-3 border-l-2 border-violet-400/60 bg-violet-500/[0.04] py-1.5 pl-3 italic text-on-surface-variant">
       {children}
     </blockquote>
   ),
-  hr: () => <hr className="my-3 border-0 border-t border-violet-500/15" />,
+  hr: () => <hr className="my-4 border-0 border-t border-violet-500/15" />,
   strong: ({ children }) => (
     <strong className="font-semibold text-on-surface">{children}</strong>
   ),
   em: ({ children }) => <em className="text-on-surface-variant">{children}</em>,
   table: ({ children }) => (
-    <div className="my-2 overflow-x-auto rounded-lg border border-app">
+    <div className="my-3 max-w-full overflow-x-auto rounded-lg border border-app">
       <table className="w-full border-collapse text-left text-[13px]">{children}</table>
     </div>
   ),
@@ -153,7 +153,10 @@ function MarkdownInner({ text, streaming }: MarkdownProps) {
   const rehype = useMemo(() => [[rehypeSanitize, sanitizeSchema]] as const, []);
 
   return (
-    <div className="vf-md text-[15px] leading-relaxed text-on-surface">
+    <div
+      className="vf-md min-w-0 max-w-full font-sans text-[15px] font-normal leading-[1.65] tracking-[-0.005em] text-on-surface sm:text-[16px]"
+      style={{ overflowWrap: "anywhere", wordBreak: "break-word" }}
+    >
       <ReactMarkdown
         remarkPlugins={plugins}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/components/workspace/chat/ThinkingIndicator.tsx
+++ b/components/workspace/chat/ThinkingIndicator.tsx
@@ -32,11 +32,11 @@ export function ThinkingIndicator() {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -4 }}
       transition={{ duration: 0.25 }}
-      className="flex items-center gap-2.5 py-1"
+      className="flex items-center gap-3 rounded-xl border border-violet-500/20 bg-violet-500/[0.06] px-3 py-2"
       aria-live="polite"
       aria-label="V está procesando"
     >
-      <div className="relative h-5 w-5">
+      <div className="relative h-6 w-6 shrink-0">
         <motion.div
           className="absolute inset-0 rounded-full"
           style={{
@@ -45,38 +45,48 @@ export function ThinkingIndicator() {
             filter: "blur(0.5px)",
           }}
           animate={{ rotate: 360 }}
-          transition={{ duration: 2.6, ease: "linear", repeat: Infinity }}
+          transition={{ duration: 2.2, ease: "linear", repeat: Infinity }}
         />
         <div className="absolute inset-[3px] rounded-full bg-void" />
         <motion.div
           className="absolute inset-[5px] rounded-full bg-gradient-to-br from-violet-400 to-cyan-400"
-          animate={{ scale: [0.85, 1.05, 0.85], opacity: [0.85, 1, 0.85] }}
-          transition={{ duration: 1.4, ease: "easeInOut", repeat: Infinity }}
+          animate={{ scale: [0.8, 1.1, 0.8], opacity: [0.85, 1, 0.85] }}
+          transition={{ duration: 1.3, ease: "easeInOut", repeat: Infinity }}
         />
         <div
           aria-hidden
           className="pointer-events-none absolute -inset-2 rounded-full"
           style={{
             background:
-              "radial-gradient(circle at center, rgba(139,92,246,0.25), transparent 65%)",
-            filter: "blur(4px)",
+              "radial-gradient(circle at center, rgba(139,92,246,0.35), transparent 65%)",
+            filter: "blur(5px)",
           }}
         />
       </div>
-      <div className="relative h-5 min-w-[140px] overflow-hidden">
+      <div className="relative h-[1.2rem] flex-1 min-w-0 overflow-hidden">
         <AnimatePresence mode="wait">
           <motion.span
             key={phase}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
-            transition={{ duration: 0.32, ease: "easeOut" }}
-            className="absolute inset-0 bg-gradient-to-r from-violet-300 via-on-surface to-cyan-300 bg-clip-text font-mono text-[12px] uppercase tracking-[0.18em] text-transparent"
+            transition={{ duration: 0.3, ease: "easeOut" }}
+            className="absolute inset-0 bg-gradient-to-r from-violet-300 via-on-surface to-cyan-300 bg-clip-text font-sans text-[14px] font-semibold tracking-tight text-transparent"
           >
             {PHASES[phase]}
           </motion.span>
         </AnimatePresence>
       </div>
+      <motion.div
+        aria-hidden
+        className="flex shrink-0 items-center gap-1"
+        animate={{ opacity: [0.4, 1, 0.4] }}
+        transition={{ duration: 1.4, ease: "easeInOut", repeat: Infinity }}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-violet-400" />
+        <span className="h-1.5 w-1.5 rounded-full bg-violet-400" />
+        <span className="h-1.5 w-1.5 rounded-full bg-cyan-400" />
+      </motion.div>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Bug

El chat "bailaba" porque NADA impedía overflow horizontal:
- El scroller solo tenía `overflow-y-auto` → cualquier elemento ancho hacía aparecer scroll horizontal en TODA la conversación
- El bubble del usuario tenía `max-w-[85%]` pero sin `min-w-0` ni `break-word`
- Markdown: `<p>`, `<li>`, `<h*>` sin `overflow-wrap`, cualquier token largo desbordaba

Resultado visible en mobile (screenshot de Luis): texto cortado a la derecha o cortado a la izquierda con scroll lateral. Sentía como si "bailara" entre re-renders del stream.

## Fix (defensa en capas)

1. Scroller + wrapper interno: `overflow-x-hidden`
2. MessageBubble: `min-w-0` en el flex container, `overflow-hidden` en el body, `max-w-[82%]` en el bubble user
3. Markdown wrapper: `min-w-0 max-w-full` + `overflow-wrap:anywhere` + `word-break:break-word` (inline style — más fuerte que clase)
4. Cada `p/li/h/blockquote` con clase `vf-md-block` para intervenciones futuras

## Tipografía sólida (Claude-style)
- Base: 15px mobile → 16px desktop (era 15 fijo, se sentía pequeño)
- leading: 1.65 (era `relaxed` = 1.625 sin tracking)
- tracking: `-0.005em` (sutil tightening premium)
- `font-sans` explícito (Hanken Grotesk) en vez de heredar
- Headings: `tracking -0.01em` + `leading-tight`
- Listas: `ml-0 + pl-5` (alineadas, no flotando) y `space-y-1.5` para respirar
- Bubble user: mismo sistema

Ancho del contenedor sigue siendo `max-w-3xl` (768px desktop), constante y centrado.

## Test plan
- [ ] Mensaje con URL larga / token sin espacios → se rompe en línea, no overflow
- [ ] Mensaje con líneas largas en `<p>` → wrap correcto, sin scroll horizontal
- [ ] Streaming → no hay layout jiggle visible
- [ ] Light mode + dark mode → ambos legibles

https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm)_