### PR TITLE
fix(chat): SW cache bust + contain layout + guard CSS contra overflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -116,6 +116,15 @@ body > * {
   max-width: 100vw;
 }
 
+/* Defensa absoluta del chat: cualquier elemento dentro de un mensaje
+   markdown SIEMPRE rompe palabras largas, jamás empuja el contenedor.
+   Exceptúa <pre> y <code> que tienen su propio overflow-x-auto. */
+.vf-md *:not(pre):not(code) {
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
+  max-width: 100% !important;
+}
+
 html {
   /* Respeta safe-area en iOS (notch, home indicator) */
   --safe-top: env(safe-area-inset-top, 0px);

--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -1046,9 +1046,10 @@ function StreamingBubble({ text, image }: { text: string; image?: string }) {
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       className="flex w-full min-w-0 gap-3"
+      style={{ contain: "layout style" }}
     >
       <VOrb size={26} />
-      <div className="min-w-0 flex-1 overflow-hidden">
+      <div className="min-w-0 flex-1 overflow-hidden" style={{ contain: "layout style" }}>
         {image && (
           // eslint-disable-next-line @next/next/no-img-element
           <img

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // VForge minimal service worker — offline shell + network-first for documents
 // Bump VERSION on every deploy where you want forced cache invalidation
 // (Luis: "se ve de la verga todavía" → asset cache pegado).
-const VERSION = "vforge-v3-2026-05-18";
+const VERSION = "vforge-v6-2026-05-20-stable";
 const SHELL = ["/", "/app/chat", "/offline"];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Por qué Luis seguía viendo el chat moverse después de PR #70

**Service worker en caché.** El SW estaba en versión `vforge-v3-2026-05-18` y servía el shell viejo desde caché. Aunque PR #70 se mergeó y desployó a prod, Luis veía la app SIN mis fixes hasta que el SW se invalidara solo.

## Fix

1. **SW version bump** → `vforge-v6-2026-05-20-stable`. Install dispara activate → caches.delete de versiones viejas → fetch fresco de todo.
2. **`contain: layout style`** en StreamingBubble (wrapper + body). Aísla los re-renders del markdown durante streaming para que no causen jitter en hermanos.
3. **CSS guard absoluto** en `.vf-md *:not(pre):not(code)` con `overflow-wrap: anywhere !important` y `max-width: 100% !important`. Ningún elemento dentro de un mensaje markdown puede empujar el contenedor horizontalmente.

## Test plan
- [ ] Hard-refresh en mobile (Cmd+Shift+R desktop, dev tools "Empty Cache and Hard Reload" móvil)
- [ ] Verificar SW activado en nueva versión vía DevTools → Application → Service Workers
- [ ] Enviar mensajes largos / con URLs largas → no scroll horizontal
- [ ] Streaming → texto crece sin que la conversación "baile"

https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm)_