### PR TITLE
feat: multi-tab chat + repo integrations + V tono consistente + Clerk webhook

### DIFF
--- a/app/api/auth/webhook/route.ts
+++ b/app/api/auth/webhook/route.ts
@@ -1,0 +1,148 @@
+import { Webhook } from "svix";
+import { sql } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Clerk → VForge user sync webhook.
+ *
+ * Cuando Clerk emite user.created / user.updated / user.deleted, este
+ * endpoint sincroniza la fila en nuestra tabla `users` (la primary key
+ * es el Clerk user id, no un uuid local).
+ *
+ * Config requerida (Vercel env vars):
+ *   - CLERK_WEBHOOK_SECRET (de Clerk dashboard → Webhooks)
+ *
+ * Setup en Clerk:
+ *   1. Endpoint URL: https://<tu-dominio>/api/auth/webhook
+ *   2. Eventos: user.created, user.updated, user.deleted
+ *   3. Copiar el Signing Secret a CLERK_WEBHOOK_SECRET en Vercel
+ *
+ * Sin esto, los usuarios que se registran en Clerk no aparecen en
+ * nuestra DB y no pueden hacer nada que requiera user_id (proyectos,
+ * vault, etc).
+ */
+
+interface ClerkUserEvent {
+  type: "user.created" | "user.updated" | "user.deleted" | string;
+  data: {
+    id: string;
+    email_addresses?: Array<{ email_address: string; verification?: { status: string } }>;
+    first_name?: string | null;
+    last_name?: string | null;
+    username?: string | null;
+    deleted?: boolean;
+  };
+}
+
+function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(req: Request) {
+  const secret = process.env.CLERK_WEBHOOK_SECRET;
+  if (!secret) {
+    return jsonError("CLERK_WEBHOOK_SECRET not configured on server", 503);
+  }
+
+  const svixId = req.headers.get("svix-id");
+  const svixTimestamp = req.headers.get("svix-timestamp");
+  const svixSignature = req.headers.get("svix-signature");
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return jsonError("missing svix headers", 400);
+  }
+
+  const body = await req.text();
+
+  let event: ClerkUserEvent;
+  try {
+    const wh = new Webhook(secret);
+    event = wh.verify(body, {
+      "svix-id": svixId,
+      "svix-timestamp": svixTimestamp,
+      "svix-signature": svixSignature,
+    }) as ClerkUserEvent;
+  } catch (err) {
+    return jsonError(
+      `webhook verification failed: ${err instanceof Error ? err.message : String(err)}`,
+      401,
+    );
+  }
+
+  const userId = event.data.id;
+  if (!userId) return jsonError("event missing user id", 400);
+
+  try {
+    if (event.type === "user.created" || event.type === "user.updated") {
+      const primaryEmail =
+        event.data.email_addresses?.[0]?.email_address ?? null;
+      if (!primaryEmail) {
+        return jsonError("user has no email address", 400);
+      }
+      const name =
+        [event.data.first_name, event.data.last_name]
+          .filter(Boolean)
+          .join(" ")
+          .trim() ||
+        event.data.username ||
+        primaryEmail.split("@")[0];
+
+      // UPSERT: nuevo usuario → insert con role 'client' por defecto.
+      // Update → solo refresca email/name/last_seen, no toca role.
+      await sql`
+        INSERT INTO users (id, email, name, role, created_at, updated_at, last_seen_at)
+        VALUES (${userId}, ${primaryEmail}, ${name}, 'client', now(), now(), now())
+        ON CONFLICT (id) DO UPDATE SET
+          email = EXCLUDED.email,
+          name = EXCLUDED.name,
+          updated_at = now()
+      `;
+      await sql`
+        INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+        VALUES (
+          ${userId},
+          ${event.type === "user.created" ? "user.signup" : "user.update"},
+          'user', ${userId}, 0,
+          ${JSON.stringify({ email: primaryEmail, source: "clerk_webhook" })}::jsonb
+        )
+      `.catch(() => undefined);
+    } else if (event.type === "user.deleted") {
+      // Soft-delete: nullify email/name pero conservar el row para
+      // mantener foreign keys de audit_events / conversations vivos.
+      await sql`
+        UPDATE users
+           SET email = ${userId + "@deleted.local"},
+               name = '[deleted]',
+               updated_at = now()
+         WHERE id = ${userId}
+      `;
+      await sql`
+        INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+        VALUES (
+          ${userId}, 'user.delete', 'user', ${userId}, 0,
+          ${JSON.stringify({ source: "clerk_webhook" })}::jsonb
+        )
+      `.catch(() => undefined);
+    } else {
+      // Evento no manejado — devolvemos 200 para que Clerk no reintente.
+      return new Response(
+        JSON.stringify({ ok: true, ignored: event.type }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+  } catch (err) {
+    return jsonError(
+      `db sync failed: ${err instanceof Error ? err.message : String(err)}`,
+      500,
+    );
+  }
+
+  return new Response(JSON.stringify({ ok: true, synced: event.type, id: userId }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/api/repos/route.ts
+++ b/app/api/repos/route.ts
@@ -1,0 +1,138 @@
+import { listAllUserRepos } from "@/lib/github/client";
+import { queryAll } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  github_repo: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+  category: string;
+  status: string;
+  last_audit_at: string | null;
+}
+
+interface EnrichedRepo {
+  full_name: string;
+  name: string;
+  owner: string;
+  description: string | null;
+  language: string | null;
+  private: boolean;
+  archived: boolean;
+  fork: boolean;
+  html_url: string;
+  pushed_at: string | null;
+  stargazers_count: number;
+  topics: string[];
+  /** Integraciones detectadas. */
+  integrations: {
+    /** Está dado de alta en la tabla projects → V puede operarlo. */
+    tracked: boolean;
+    projectId: string | null;
+    projectCategory: string | null;
+    projectStatus: string | null;
+    /** Tiene proyecto en Vercel vinculado. */
+    vercel_url: string | null;
+    /** Tiene dominio custom configurado. */
+    domain: string | null;
+    /** Cuándo fue la última auditoría de V. */
+    last_audit_at: string | null;
+  };
+}
+
+/**
+ * GET /api/repos
+ *
+ * Devuelve la lista de repos de GitHub del operador, enriquecida con
+ * info de integraciones (cuáles están tracked en la DB, cuáles tienen
+ * Vercel/dominio, etc). Pensado para alimentar la página /app/repos
+ * donde Luis ve TODO su parque de repos y qué hay conectado a cada uno.
+ *
+ * No requiere auth porque la sesión es single-user (operator_luis).
+ * Cuando entre Clerk multi-tenant, esto pasará a leer el token de
+ * GitHub del usuario en sesión.
+ */
+export async function GET() {
+  let repos;
+  try {
+    repos = await listAllUserRepos({ max: 200, auditUserId: "operator_luis" });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        error: `github fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // Cross-reference con la tabla projects para saber cuáles están tracked.
+  // Mapeo por github_repo (full_name). Si Luis tiene un proyecto sin
+  // github_repo en la DB, no aparece como integración aquí (debería —
+  // pero ese es otro fix).
+  const projects = await queryAll<ProjectRow>(
+    `SELECT id, name, github_repo, vercel_url, domain, category, status, last_audit_at
+       FROM projects
+      WHERE github_repo IS NOT NULL`,
+  );
+  const byRepo = new Map(projects.map((p) => [p.github_repo!, p]));
+
+  const enriched: EnrichedRepo[] = repos.map((r) => {
+    const p = byRepo.get(r.full_name) ?? null;
+    return {
+      full_name: r.full_name,
+      name: r.name,
+      owner: r.owner,
+      description: r.description,
+      language: r.language,
+      private: r.private,
+      archived: r.archived,
+      fork: r.fork,
+      html_url: r.html_url,
+      pushed_at: r.pushed_at,
+      stargazers_count: r.stargazers_count,
+      topics: r.topics,
+      integrations: {
+        tracked: !!p,
+        projectId: p?.id ?? null,
+        projectCategory: p?.category ?? null,
+        projectStatus: p?.status ?? null,
+        vercel_url: p?.vercel_url ?? null,
+        domain: p?.domain ?? null,
+        last_audit_at: p?.last_audit_at ?? null,
+      },
+    };
+  });
+
+  // Orden: tracked + production primero, luego tracked, luego untracked.
+  enriched.sort((a, b) => {
+    const score = (e: EnrichedRepo) =>
+      (e.integrations.tracked ? 10 : 0) +
+      (e.integrations.projectCategory === "produccion" ? 5 : 0) +
+      (e.integrations.vercel_url ? 2 : 0) +
+      (e.integrations.domain ? 1 : 0);
+    const sb = score(b) - score(a);
+    if (sb !== 0) return sb;
+    const ta = a.pushed_at ? Date.parse(a.pushed_at) : 0;
+    const tb = b.pushed_at ? Date.parse(b.pushed_at) : 0;
+    return tb - ta;
+  });
+
+  return new Response(
+    JSON.stringify({
+      repos: enriched,
+      tracked_count: enriched.filter((e) => e.integrations.tracked).length,
+      total: enriched.length,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "private, max-age=60, stale-while-revalidate=300",
+      },
+    },
+  );
+}

--- a/app/api/repos/route.ts
+++ b/app/api/repos/route.ts
@@ -1,5 +1,9 @@
 import { listAllUserRepos } from "@/lib/github/client";
 import { queryAll } from "@/lib/db/client";
+import {
+  requireOperatorAuth,
+  authFailureResponse,
+} from "@/lib/auth/operator-token";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -49,17 +53,20 @@ interface EnrichedRepo {
  *
  * Devuelve la lista de repos de GitHub del operador, enriquecida con
  * info de integraciones (cuáles están tracked en la DB, cuáles tienen
- * Vercel/dominio, etc). Pensado para alimentar la página /app/repos
- * donde Luis ve TODO su parque de repos y qué hay conectado a cada uno.
+ * Vercel/dominio, etc). Pensado para alimentar /app/repovision donde
+ * Luis ve TODO su parque de repos y qué hay conectado a cada uno.
  *
- * No requiere auth porque la sesión es single-user (operator_luis).
- * Cuando entre Clerk multi-tenant, esto pasará a leer el token de
- * GitHub del usuario en sesión.
+ * REQUIERE operator auth (Bearer token) — la lista de repos incluye
+ * privados + integraciones internas (Vercel projects, dominios), no
+ * puede ser pública.
  */
-export async function GET() {
+export async function GET(req: Request) {
+  const auth = requireOperatorAuth(req);
+  if (!auth.ok) return authFailureResponse(auth);
+
   let repos;
   try {
-    repos = await listAllUserRepos({ max: 200, auditUserId: "operator_luis" });
+    repos = await listAllUserRepos({ max: 200, auditUserId: auth.userId });
   } catch (err) {
     return new Response(
       JSON.stringify({

--- a/app/app/chat/page.tsx
+++ b/app/app/chat/page.tsx
@@ -1,5 +1,13 @@
+import { Suspense } from "react";
 import { ChatExperience } from "@/components/workspace/chat/ChatExperience";
 
+// Suspense wrapper requerido por Next 15: ChatExperience usa
+// useSearchParams() para leer ?project=ID&q=TEXTO de deep-links.
+// Sin esto, el build estático falla con "missing-suspense-with-csr-bailout".
 export default function ChatPage() {
-  return <ChatExperience />;
+  return (
+    <Suspense fallback={null}>
+      <ChatExperience />
+    </Suspense>
+  );
 }

--- a/app/app/repovision/page.tsx
+++ b/app/app/repovision/page.tsx
@@ -1,130 +1,398 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { PageHeader } from "@/components/workspace/PageHeader";
-import { GitBranch, Lock, Star } from "lucide-react";
-import { useT } from "@/i18n/AppProviders";
+import {
+  Activity,
+  Archive,
+  ExternalLink,
+  GitBranch,
+  Globe2,
+  Lock,
+  Rocket,
+  Search,
+  Sparkles,
+  Star,
+  Unlock,
+  Zap,
+} from "lucide-react";
+
+interface RepoIntegrations {
+  tracked: boolean;
+  projectId: string | null;
+  projectCategory: string | null;
+  projectStatus: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+  last_audit_at: string | null;
+}
 
 interface Repo {
   full_name: string;
   name: string;
-  private: boolean;
+  owner: string;
   description: string | null;
   language: string | null;
-  stars: number;
-  default_branch: string;
-  pushed_at: string;
+  private: boolean;
+  archived: boolean;
+  fork: boolean;
   html_url: string;
+  pushed_at: string | null;
+  stargazers_count: number;
+  topics: string[];
+  integrations: RepoIntegrations;
 }
 
-function timeAgo(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const days = Math.floor(ms / (1000 * 60 * 60 * 24));
+type Filter = "all" | "tracked" | "untracked" | "deployed" | "archived";
+
+function shortRelative(iso: string | null): string {
+  if (!iso) return "—";
+  const ms = Date.now() - Date.parse(iso);
+  const days = Math.floor(ms / 86_400_000);
+  if (days >= 30) return `${Math.floor(days / 30)}mes`;
   if (days >= 1) return `${days}d`;
-  const hours = Math.floor(ms / (1000 * 60 * 60));
+  const hours = Math.floor(ms / 3_600_000);
   if (hours >= 1) return `${hours}h`;
-  return "ahora";
+  return "<1h";
 }
 
 export default function RepoVisionPage() {
-  const t = useT();
   const [repos, setRepos] = useState<Repo[]>([]);
+  const [trackedCount, setTrackedCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
-    fetch("/api/github/repos", { cache: "no-store" })
+    fetch("/api/repos", { cache: "no-store" })
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();
       })
-      .then((d: { repos: Repo[] }) => setRepos(d.repos ?? []))
+      .then((d: { repos: Repo[]; tracked_count: number }) => {
+        setRepos(d.repos ?? []);
+        setTrackedCount(d.tracked_count ?? 0);
+      })
       .catch((err) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setLoading(false));
   }, []);
 
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return repos.filter((r) => {
+      if (filter === "tracked" && !r.integrations.tracked) return false;
+      if (filter === "untracked" && r.integrations.tracked) return false;
+      if (filter === "deployed" && !r.integrations.vercel_url) return false;
+      if (filter === "archived" && !r.archived) return false;
+      if (filter === "all" && r.archived) return false;
+      if (!q) return true;
+      return (
+        r.full_name.toLowerCase().includes(q) ||
+        (r.description ?? "").toLowerCase().includes(q) ||
+        (r.language ?? "").toLowerCase().includes(q)
+      );
+    });
+  }, [repos, filter, query]);
+
   return (
     <>
       <PageHeader
-        eyebrow={t.repovision.eyebrow}
-        title={t.repovision.title}
-        description={t.repovision.body}
+        eyebrow="repos · github"
+        title="Tus repositorios"
+        description="Todo lo que tienes en GitHub y a qué está conectado en VForge."
+        actions={
+          <Link href="/app/chat" className="btn-primary">
+            <Sparkles size={13} /> Pedir a V
+          </Link>
+        }
       />
 
-      <div className="px-5 py-6 md:px-8">
-        {error && (
-          <div className="mb-4 rounded-md border border-error-crimson/30 bg-error-crimson/5 px-4 py-3 text-sm text-error-crimson">
-            ⚠ {error}
-          </div>
-        )}
+      <div className="grid grid-cols-2 gap-3 px-5 pt-6 md:grid-cols-4 md:px-8">
+        <Stat label="Total repos" value={String(repos.length)} tone="violet" />
+        <Stat
+          label="Tracked en V"
+          value={`${trackedCount} / ${repos.length}`}
+          tone="cyan"
+        />
+        <Stat
+          label="Con deploy"
+          value={String(repos.filter((r) => r.integrations.vercel_url).length)}
+          tone="emerald"
+        />
+        <Stat
+          label="Archivados"
+          value={String(repos.filter((r) => r.archived).length)}
+          tone="crimson"
+        />
+      </div>
 
-        {loading && (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {[0, 1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="h-[120px] rounded-xl border border-app bg-tint-1/40 animate-pulse"
-              />
-            ))}
-          </div>
-        )}
+      <div className="flex flex-col gap-3 px-5 pt-5 md:flex-row md:items-center md:justify-between md:px-8">
+        <div className="flex flex-wrap gap-1.5">
+          {(
+            [
+              ["all", "Activos"],
+              ["tracked", "Tracked"],
+              ["untracked", "Untracked"],
+              ["deployed", "Con deploy"],
+              ["archived", "Archivados"],
+            ] as [Filter, string][]
+          ).map(([k, label]) => (
+            <button
+              key={k}
+              onClick={() => setFilter(k)}
+              className={
+                filter === k
+                  ? "rounded-md border border-violet-500/40 bg-violet-500/10 px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest text-violet-300"
+                  : "rounded-md border border-app bg-tint-1 px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest text-on-surface-variant transition hover:border-violet-500/30 hover:text-violet-300"
+              }
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className="relative w-full md:w-64">
+          <Search
+            size={13}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+          />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Buscar repo, lenguaje, descripción…"
+            className="w-full rounded-md border border-app bg-tint-1 pl-8 pr-3 py-1.5 text-[13px] text-on-surface placeholder:text-muted focus:border-violet-500/40 focus:outline-none"
+          />
+        </div>
+      </div>
 
-        {!loading && repos.length === 0 && !error && (
-          <div className="rounded-xl border border-app bg-tint-1 p-10 text-center text-on-surface-variant">
-            <GitBranch className="mx-auto mb-3 text-violet-300" size={24} />
-            <p className="font-display text-lg">No hay repos cargados</p>
-            <p className="mt-2 text-sm">
-              Verifica que el GITHUB_TOKEN esté configurado en el vault.
-            </p>
-          </div>
-        )}
+      {error && (
+        <div className="mx-5 mt-4 rounded-md border border-error-crimson/30 bg-error-crimson/5 px-4 py-3 text-sm text-error-crimson md:mx-8">
+          ⚠ {error}
+        </div>
+      )}
 
-        {!loading && repos.length > 0 && (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {repos.map((r) => (
-              <a
-                key={r.full_name}
-                href={r.html_url}
-                target="_blank"
-                rel="noreferrer"
-                className="rounded-xl border border-app bg-tint-1 p-4 transition hover:border-violet-500/30"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <GitBranch size={14} className="text-violet-300 shrink-0" />
-                      <p className="font-display font-semibold text-on-surface truncate">
-                        {r.name}
-                      </p>
-                      {r.private && (
-                        <Lock size={11} className="text-muted shrink-0" />
-                      )}
-                    </div>
-                    <p className="mt-1 font-mono text-[11px] uppercase tracking-widest text-muted truncate">
-                      {r.full_name}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-1 font-mono text-[11px] text-muted shrink-0">
-                    <Star size={11} /> {r.stars}
-                  </div>
-                </div>
-                {r.description && (
-                  <p className="mt-3 text-sm text-on-surface-variant line-clamp-2">
-                    {r.description}
-                  </p>
-                )}
-                <div className="mt-3 flex items-center gap-3 font-mono text-[10px] uppercase tracking-widest text-muted">
-                  {r.language && (
-                    <span className="text-cyber-cyan">{r.language}</span>
-                  )}
-                  <span>· {r.default_branch}</span>
-                  <span>· push {timeAgo(r.pushed_at)}</span>
-                </div>
-              </a>
-            ))}
-          </div>
-        )}
+      {loading && (
+        <div className="grid grid-cols-1 gap-3 p-5 md:grid-cols-2 md:p-8 xl:grid-cols-3">
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <div
+              key={i}
+              className="h-[200px] rounded-xl border border-app bg-tint-1/40 animate-pulse"
+            />
+          ))}
+        </div>
+      )}
+
+      {!loading && filtered.length === 0 && !error && (
+        <div className="mx-auto max-w-md p-10 text-center text-on-surface-variant">
+          <p className="font-display text-lg">Nada que mostrar con esos filtros.</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-3 p-5 md:grid-cols-2 md:p-8 xl:grid-cols-3">
+        {filtered.map((r) => (
+          <RepoCard key={r.full_name} repo={r} />
+        ))}
       </div>
     </>
+  );
+}
+
+function RepoCard({ repo: r }: { repo: Repo }) {
+  const i = r.integrations;
+  return (
+    <article className="flex flex-col rounded-xl border border-app bg-tint-1 p-4 transition hover:border-violet-500/30">
+      <header className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <GitBranch size={13} className="shrink-0 text-violet-300" />
+            <a
+              href={r.html_url}
+              target="_blank"
+              rel="noreferrer"
+              className="truncate font-mono text-[13px] font-medium text-on-surface hover:text-violet-300"
+            >
+              {r.full_name}
+            </a>
+            {r.private ? (
+              <Lock size={11} className="shrink-0 text-muted" />
+            ) : (
+              <Unlock size={11} className="shrink-0 text-success-emerald" />
+            )}
+            {r.fork && (
+              <span className="font-mono text-[9px] uppercase tracking-widest text-muted">
+                fork
+              </span>
+            )}
+          </div>
+          {r.description && (
+            <p className="mt-1 line-clamp-2 text-[12px] leading-snug text-on-surface-variant">
+              {r.description}
+            </p>
+          )}
+        </div>
+        {i.tracked && (
+          <span className="chip shrink-0 text-violet-300" title="Tracked en V">
+            ● V
+          </span>
+        )}
+      </header>
+
+      <div className="mt-3 flex flex-wrap items-center gap-1.5 text-[11px]">
+        {r.language && (
+          <span className="chip text-on-surface-variant">{r.language}</span>
+        )}
+        {i.projectCategory && (
+          <span
+            className={
+              i.projectCategory === "produccion"
+                ? "chip text-success-emerald"
+                : "chip text-cyber-cyan"
+            }
+          >
+            {i.projectCategory}
+          </span>
+        )}
+        {r.stargazers_count > 0 && (
+          <span className="flex items-center gap-0.5 font-mono text-[10px] uppercase tracking-widest text-muted">
+            <Star size={9} /> {r.stargazers_count}
+          </span>
+        )}
+        <span className="ml-auto font-mono text-[10px] uppercase tracking-widest text-muted">
+          push {shortRelative(r.pushed_at)}
+        </span>
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 gap-1.5 border-t border-app pt-3">
+        <Integration
+          icon={<Activity size={11} />}
+          label="V"
+          active={i.tracked}
+          value={
+            i.tracked
+              ? `${i.projectStatus ?? "tracked"} · audit ${shortRelative(i.last_audit_at)}`
+              : "no tracked"
+          }
+        />
+        <Integration
+          icon={<Rocket size={11} />}
+          label="Vercel"
+          active={!!i.vercel_url}
+          value={
+            i.vercel_url
+              ? i.vercel_url.replace(/^https?:\/\//, "")
+              : "no deploy"
+          }
+          href={i.vercel_url ?? undefined}
+        />
+        <Integration
+          icon={<Globe2 size={11} />}
+          label="Dominio"
+          active={!!i.domain}
+          value={i.domain ?? "—"}
+          href={i.domain ? `https://${i.domain}` : undefined}
+        />
+        {r.archived && (
+          <Integration
+            icon={<Archive size={11} />}
+            label="Archivo"
+            active={false}
+            value="archivado en GitHub"
+          />
+        )}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-2 border-t border-app pt-3">
+        <Link
+          href={`/app/chat?project=${i.projectId ?? ""}&q=${encodeURIComponent(`cuéntame de ${r.name}`)}`}
+          className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-cyan-400 hover:text-cyan-300"
+        >
+          <Zap size={10} /> Preguntar a V
+        </Link>
+        <a
+          href={r.html_url}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-muted hover:text-on-surface"
+        >
+          GitHub <ExternalLink size={10} />
+        </a>
+      </div>
+    </article>
+  );
+}
+
+function Integration({
+  icon,
+  label,
+  active,
+  value,
+  href,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  value: string;
+  href?: string;
+}) {
+  const valueNode = (
+    <span
+      className={
+        active
+          ? "truncate text-[11px] text-on-surface"
+          : "truncate text-[11px] text-muted/60"
+      }
+    >
+      {value}
+    </span>
+  );
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-[11px]">
+      <span
+        className={
+          active ? "text-violet-300 shrink-0" : "text-muted/50 shrink-0"
+        }
+      >
+        {icon}
+      </span>
+      <span className="w-12 shrink-0 font-mono text-[10px] uppercase tracking-widest text-muted">
+        {label}
+      </span>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="min-w-0 flex-1 truncate hover:text-violet-300"
+        >
+          {valueNode}
+        </a>
+      ) : (
+        <span className="min-w-0 flex-1 truncate">{valueNode}</span>
+      )}
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: "violet" | "cyan" | "emerald" | "crimson";
+}) {
+  const m = {
+    violet: "text-violet-300",
+    cyan: "text-cyber-cyan",
+    emerald: "text-success-emerald",
+    crimson: "text-error-crimson",
+  };
+  return (
+    <div className="rounded-xl border border-app bg-tint-1 p-4">
+      <p className="label-caps text-muted">{label}</p>
+      <p className={`mt-2 font-display text-lg font-semibold ${m[tone]}`}>{value}</p>
+    </div>
   );
 }

--- a/app/app/repovision/page.tsx
+++ b/app/app/repovision/page.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLink,
   GitBranch,
   Globe2,
+  KeyRound,
   Lock,
   Rocket,
   Search,
@@ -17,6 +18,8 @@ import {
   Unlock,
   Zap,
 } from "lucide-react";
+
+const OPERATOR_TOKEN_KEY = "vforge_operator_token";
 
 interface RepoIntegrations {
   tracked: boolean;
@@ -64,10 +67,21 @@ export default function RepoVisionPage() {
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<Filter>("all");
   const [query, setQuery] = useState("");
+  const [hasToken, setHasToken] = useState(false);
 
-  useEffect(() => {
-    fetch("/api/repos", { cache: "no-store" })
+  function loadRepos(token: string) {
+    setLoading(true);
+    setError(null);
+    fetch("/api/repos", {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    })
       .then((r) => {
+        if (r.status === 401) throw new Error("Falta el header de autorización.");
+        if (r.status === 403) throw new Error("Token inválido. Vuelve a unlock.");
+        if (r.status === 503) {
+          throw new Error("El server no tiene VFORGE_OPERATOR_TOKEN configurado.");
+        }
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();
       })
@@ -77,7 +91,28 @@ export default function RepoVisionPage() {
       })
       .catch((err) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const token = window.localStorage.getItem(OPERATOR_TOKEN_KEY);
+    setHasToken(Boolean(token));
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    loadRepos(token);
   }, []);
+
+  function unlock() {
+    const raw = window.prompt("Pega tu VFORGE_OPERATOR_TOKEN:");
+    if (!raw) return;
+    const token = raw.trim();
+    if (!token) return;
+    window.localStorage.setItem(OPERATOR_TOKEN_KEY, token);
+    setHasToken(true);
+    loadRepos(token);
+  }
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -103,12 +138,36 @@ export default function RepoVisionPage() {
         title="Tus repositorios"
         description="Todo lo que tienes en GitHub y a qué está conectado en VForge."
         actions={
-          <Link href="/app/chat" className="btn-primary">
-            <Sparkles size={13} /> Pedir a V
-          </Link>
+          <>
+            {!hasToken ? (
+              <button onClick={unlock} className="btn-primary">
+                <KeyRound size={13} /> Unlock
+              </button>
+            ) : (
+              <Link href="/app/chat" className="btn-primary">
+                <Sparkles size={13} /> Pedir a V
+              </Link>
+            )}
+          </>
         }
       />
 
+      {!hasToken && (
+        <div className="mx-auto max-w-md p-10 text-center text-on-surface-variant">
+          <Lock className="mx-auto mb-3 text-violet-300" size={28} />
+          <p className="font-display text-lg text-on-surface">RepoVision bloqueado</p>
+          <p className="mt-2 text-sm max-w-md mx-auto leading-relaxed">
+            El listado de repos incluye privados y datos de integración.
+            Necesitas el operator token para verlo.
+          </p>
+          <button onClick={unlock} className="btn-primary mt-5 inline-flex">
+            <KeyRound size={13} /> Unlock
+          </button>
+        </div>
+      )}
+
+      {hasToken && (
+      <>
       <div className="grid grid-cols-2 gap-3 px-5 pt-6 md:grid-cols-4 md:px-8">
         <Stat label="Total repos" value={String(repos.length)} tone="violet" />
         <Stat
@@ -194,6 +253,8 @@ export default function RepoVisionPage() {
           <RepoCard key={r.full_name} repo={r} />
         ))}
       </div>
+      </>
+      )}
     </>
   );
 }

--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   ArrowUp,
@@ -195,11 +196,28 @@ export function ChatExperience() {
     el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
   }, [messages]);
 
-  // Load projects + initial scope + open tabs
+  // Deep-link params: /app/chat?project=ID&q=TEXTO
+  // Cuando RepoVision (u otra página) linkea aquí con un proyecto y
+  // prompt sugerido, lo aplicamos automáticamente: abrir el tab del
+  // proyecto y pre-llenar el input.
+  const searchParams = useSearchParams();
+  const deepLinkProject = searchParams?.get("project") || null;
+  const deepLinkQuery = searchParams?.get("q") || null;
+
+  // Load projects + initial scope + open tabs (+ deep-link override)
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const saved = window.localStorage.getItem(SCOPE_KEY) ?? "general";
+    // El query param `project` tiene PRIORIDAD sobre el scope guardado
+    // — si Luis viene de un link "Preguntar a V" sobre castores,
+    // saltamos al tab de castores aunque su último scope fuera otro.
+    const saved =
+      (deepLinkProject && deepLinkProject.length > 0
+        ? deepLinkProject
+        : window.localStorage.getItem(SCOPE_KEY)) ?? "general";
     setScope(saved);
+    if (deepLinkQuery) {
+      setInput(deepLinkQuery);
+    }
     try {
       const savedTabs = window.localStorage.getItem(OPEN_SCOPES_KEY);
       if (savedTabs) {
@@ -219,6 +237,9 @@ export function ChatExperience() {
       .then((r) => (r.ok ? r.json() : { projects: [] }))
       .then((d: { projects: Project[] }) => setProjects(d.projects ?? []))
       .catch(() => undefined);
+    // Mount-only: el deep-link se aplica una sola vez al cargar. Si el
+    // usuario navega después, no queremos re-pisar su scope actual.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Persist openScopes

--- a/components/workspace/chat/ChatExperience.tsx
+++ b/components/workspace/chat/ChatExperience.tsx
@@ -51,6 +51,7 @@ type Msg = {
 };
 
 const SCOPE_KEY = "vforge_chat_scope";
+const OPEN_SCOPES_KEY = "vforge_chat_open_scopes";
 
 /** Anthropic-style content blocks that /api/forge/run accepts for vision. */
 type StructuredBlock =
@@ -151,6 +152,10 @@ export function ChatExperience() {
   const [pending, setPending] = useState(false);
   const [isHydrating, setIsHydrating] = useState(true);
   const [scope, setScope] = useState<string>("general");
+  // Lista de chats abiertos como tabs. Cada uno es un scope (general
+  // o id de proyecto). Persiste en localStorage para que cuando Luis
+  // vuelva a la app vea sus tabs activas.
+  const [openScopes, setOpenScopes] = useState<string[]>(["general"]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [scopeMenuOpen, setScopeMenuOpen] = useState(false);
   const [attachment, setAttachment] = useState<Attachment | null>(null);
@@ -190,16 +195,58 @@ export function ChatExperience() {
     el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
   }, [messages]);
 
-  // Load projects + initial scope
+  // Load projects + initial scope + open tabs
   useEffect(() => {
     if (typeof window === "undefined") return;
     const saved = window.localStorage.getItem(SCOPE_KEY) ?? "general";
     setScope(saved);
+    try {
+      const savedTabs = window.localStorage.getItem(OPEN_SCOPES_KEY);
+      if (savedTabs) {
+        const parsed = JSON.parse(savedTabs) as string[];
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          setOpenScopes(parsed.includes(saved) ? parsed : [saved, ...parsed]);
+        } else {
+          setOpenScopes([saved]);
+        }
+      } else {
+        setOpenScopes([saved]);
+      }
+    } catch {
+      setOpenScopes([saved]);
+    }
     fetch("/api/projects", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : { projects: [] }))
       .then((d: { projects: Project[] }) => setProjects(d.projects ?? []))
       .catch(() => undefined);
   }, []);
+
+  // Persist openScopes
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(OPEN_SCOPES_KEY, JSON.stringify(openScopes));
+    } catch {
+      // ignore
+    }
+  }, [openScopes]);
+
+  // Ensure the active scope is always among the open tabs.
+  useEffect(() => {
+    if (!scope) return;
+    setOpenScopes((prev) => (prev.includes(scope) ? prev : [...prev, scope]));
+  }, [scope]);
+
+  function closeTab(tabScope: string) {
+    if (tabScope === "general" && openScopes.length === 1) return;
+    const filtered = openScopes.filter((s) => s !== tabScope);
+    const next = filtered.length === 0 ? ["general"] : filtered;
+    setOpenScopes(next);
+    // Si cerramos la activa, switch a la primera restante.
+    if (tabScope === scope) {
+      setScope(next[0]);
+    }
+  }
 
   // Resolve session + rehydrate whenever scope changes
   useEffect(() => {
@@ -462,24 +509,64 @@ export function ChatExperience() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Chat scope bar — sticky top, no scroll mueve esto */}
+      {/* Chat tabs bar — múltiples conversaciones abiertas a la vez */}
       <div className="flex-shrink-0 border-b border-app bg-void/90 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-3xl items-center gap-2 px-4 py-2.5 md:px-10">
-          {/* Scope selector */}
-          <div className="relative">
+        <div className="mx-auto flex max-w-3xl items-center gap-1 overflow-x-auto px-2 py-1.5 md:px-8 no-scrollbar">
+          {openScopes.map((tabId) => {
+            const opt = scopeOptions.find((o) => o.id === tabId);
+            if (!opt) return null;
+            const active = tabId === scope;
+            const closable = !(tabId === "general" && openScopes.length === 1);
+            return (
+              <div
+                key={tabId}
+                className={
+                  active
+                    ? "group flex shrink-0 items-center gap-1.5 rounded-md border border-violet-500/40 bg-violet-500/10 pl-2.5 pr-1 py-1 text-sm text-violet-300"
+                    : "group flex shrink-0 items-center gap-1.5 rounded-md border border-app bg-tint-1 pl-2.5 pr-1 py-1 text-sm text-on-surface-variant hover:border-app-strong hover:text-on-surface"
+                }
+              >
+                <button
+                  type="button"
+                  onClick={() => setScope(tabId)}
+                  className="flex items-center gap-1.5"
+                  style={{ touchAction: "manipulation" }}
+                >
+                  {tabId === "general" ? (
+                    <MessageSquare size={12} />
+                  ) : (
+                    <GitBranch size={12} />
+                  )}
+                  <span className="max-w-[120px] truncate font-medium">
+                    {opt.label}
+                  </span>
+                </button>
+                {closable && (
+                  <button
+                    type="button"
+                    onClick={() => closeTab(tabId)}
+                    aria-label={`Cerrar tab ${opt.label}`}
+                    className="ml-0.5 rounded p-0.5 text-muted opacity-60 hover:bg-tint-2 hover:text-on-surface hover:opacity-100"
+                    style={{ touchAction: "manipulation" }}
+                  >
+                    <X size={11} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+
+          {/* "+" abre dropdown para elegir qué proyecto abrir como nuevo tab */}
+          <div className="relative shrink-0">
             <button
               type="button"
               onClick={() => setScopeMenuOpen((v) => !v)}
-              className="flex items-center gap-2 rounded-md border border-app bg-tint-1 px-3 py-1.5 text-sm text-on-surface hover:border-app-strong"
+              aria-label="Abrir nuevo chat"
+              title="Abrir otro proyecto en nuevo tab"
+              className="flex h-8 w-8 items-center justify-center rounded-md border border-app bg-tint-1 text-on-surface-variant hover:border-violet-500/30 hover:text-violet-300"
               style={{ touchAction: "manipulation" }}
             >
-              {scope === "general" ? (
-                <MessageSquare size={13} className="text-violet-300" />
-              ) : (
-                <GitBranch size={13} className="text-cyber-cyan" />
-              )}
-              <span className="font-medium">{currentScope.label}</span>
-              <ChevronDown size={12} className="text-muted" />
+              <Plus size={14} />
             </button>
             {scopeMenuOpen && (
               <>
@@ -487,53 +574,72 @@ export function ChatExperience() {
                   className="fixed inset-0 z-30"
                   onClick={() => setScopeMenuOpen(false)}
                 />
-                <div className="absolute left-0 top-full z-40 mt-1 max-h-[60vh] w-[260px] overflow-y-auto rounded-md border border-app bg-ink shadow-elev">
-                  {scopeOptions.map((opt) => (
-                    <button
-                      key={opt.id}
-                      type="button"
-                      onClick={() => {
-                        setScope(opt.id);
-                        setScopeMenuOpen(false);
-                      }}
-                      className={`flex w-full items-start gap-2 border-b border-app/40 px-3 py-2.5 text-left text-sm last:border-0 hover:bg-tint-1 ${
-                        opt.id === scope ? "bg-tint-1 text-violet-300" : "text-on-surface"
-                      }`}
-                    >
-                      {opt.id === "general" ? (
-                        <MessageSquare size={13} className="mt-0.5 shrink-0 text-violet-300" />
-                      ) : (
-                        <GitBranch size={13} className="mt-0.5 shrink-0 text-cyber-cyan" />
-                      )}
-                      <div className="min-w-0">
-                        <p className="truncate font-medium">{opt.label}</p>
-                        {opt.repo && (
-                          <p className="truncate font-mono text-[10px] uppercase tracking-widest text-muted">
-                            {opt.repo}
-                          </p>
+                <div className="absolute right-0 top-full z-40 mt-1 max-h-[60vh] w-[280px] overflow-y-auto rounded-md border border-app bg-ink shadow-elev">
+                  <p className="border-b border-app/40 px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-muted">
+                    Abrir como nuevo tab
+                  </p>
+                  {scopeOptions.map((opt) => {
+                    const alreadyOpen = openScopes.includes(opt.id);
+                    return (
+                      <button
+                        key={opt.id}
+                        type="button"
+                        onClick={() => {
+                          if (!alreadyOpen) {
+                            setOpenScopes((prev) => [...prev, opt.id]);
+                          }
+                          setScope(opt.id);
+                          setScopeMenuOpen(false);
+                        }}
+                        className={`flex w-full items-start gap-2 border-b border-app/40 px-3 py-2.5 text-left text-sm last:border-0 hover:bg-tint-1 ${
+                          alreadyOpen
+                            ? "text-muted"
+                            : "text-on-surface"
+                        }`}
+                      >
+                        {opt.id === "general" ? (
+                          <MessageSquare size={13} className="mt-0.5 shrink-0 text-violet-300" />
+                        ) : (
+                          <GitBranch size={13} className="mt-0.5 shrink-0 text-cyber-cyan" />
                         )}
-                      </div>
-                    </button>
-                  ))}
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate font-medium">{opt.label}</p>
+                          {opt.repo && (
+                            <p className="truncate font-mono text-[10px] uppercase tracking-widest text-muted">
+                              {opt.repo}
+                            </p>
+                          )}
+                        </div>
+                        {alreadyOpen && (
+                          <span className="font-mono text-[9px] uppercase tracking-widest text-muted">
+                            abierto
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
               </>
             )}
           </div>
 
-          {/* New chat */}
+          {/* "Nueva sesión en este chat" — limpia historia del scope activo */}
           <button
             type="button"
             onClick={newChat}
             disabled={pending}
-            title="Nueva sesión en este scope"
-            className="flex h-8 w-8 items-center justify-center rounded-md border border-app bg-tint-1 text-on-surface-variant hover:border-app-strong hover:text-on-surface disabled:opacity-50"
+            title="Nueva sesión en este chat (borra historia local)"
+            className="ml-auto flex h-8 items-center gap-1 rounded-md border border-app bg-tint-1 px-2 text-on-surface-variant hover:border-app-strong hover:text-on-surface disabled:opacity-50 shrink-0"
             style={{ touchAction: "manipulation" }}
           >
-            <Plus size={14} />
+            <Sparkles size={12} />
+            <span className="font-mono text-[10px] uppercase tracking-widest">
+              Reset
+            </span>
           </button>
 
-          <div className="ml-auto flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted">
-            <span className="hidden sm:inline">V</span>
+          <div className="hidden items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted sm:flex shrink-0">
+            <span>V</span>
             <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-success-emerald" />
           </div>
         </div>

--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -199,6 +199,21 @@ export async function buildSystemPrompt(
     // ─── CORE IDENTITY (from system_config.ai_personality) ───
     config.ai_personality,
     "",
+    // ─── INSTRUCCIÓN ABSOLUTA DE CONSISTENCIA ───
+    // Resolver del bug donde Luis reportó "V habla diferente en distintos chats".
+    // El scope (general vs proyecto) cambia QUÉ contexto cargas, NUNCA CÓMO hablas.
+    "─────────────────────────────────────────",
+    "TONO — INSTRUCCIÓN ABSOLUTA",
+    "─────────────────────────────────────────",
+    "Mantén SIEMPRE el mismo tono con Luis sin importar el scope de la",
+    "conversación (general, channel de un proyecto, regenerate, etc).",
+    "Luis es el operador único de esta instancia: cercano, directo, sin",
+    "formalidades corporativas, sin tratarlo de usted, sin disculpas",
+    "innecesarias. Hablas como su hermana técnica que lo conoce.",
+    "El scope determina QUÉ contexto cargas (qué repo está en foco, qué",
+    "memoria es relevante), NO CÓMO hablas. Si en un chat te pones",
+    "profesional/seria y en otro casual, eso es un BUG — repórtate.",
+    "",
     // ─── DYNAMIC DIRECTIVES (mantra + directive + preference from DB) ───
     directivesSection,
     "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-markdown": "^10.1.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "svix": "^1.94.0",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.24.1"
       },
@@ -8149,6 +8150,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.94.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.94.0.tgz",
+      "integrity": "sha512-FuP5nJez1P/SeK+4zOBI8RrNhtrzMTBSvwuD4yGGsn+Af2yQazid6OwPu3fpZpMifOJxrJua0su/dYB5fe4v9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/swr": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "svix": "^1.94.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.24.1"
   },

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // VForge minimal service worker — offline shell + network-first for documents
 // Bump VERSION on every deploy where you want forced cache invalidation
 // (Luis: "se ve de la verga todavía" → asset cache pegado).
-const VERSION = "vforge-v6-2026-05-20-stable";
+const VERSION = "vforge-v7-2026-05-20-multichat";
 const SHELL = ["/", "/app/chat", "/offline"];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Resumen (4 fases en un PR)

### Fase 2 — V personalidad consistente cross-scope
Instrucción ABSOLUTA en el system prompt: el scope (general vs proyecto) cambia QUÉ contexto carga, NUNCA CÓMO habla. Luis es el operador único — cercano, directo, sin formalidades.

### Fase 3 — /app/repovision: tus repos + integraciones
Nuevo endpoint `GET /api/repos` que cross-referencea repos de GitHub con la tabla `projects` y devuelve cada repo enriquecido con: `tracked`, `vercel_url`, `dominio`, `last_audit_at`, etc.

UI rehecha en `/app/repovision`:
- Stats: total / tracked / con deploy / archivados
- Filtros: activos / tracked / untracked / con deploy / archivados
- Búsqueda por nombre, lenguaje, descripción
- Card por repo con badges V / Vercel / Dominio / Archivo
- "Preguntar a V" link directo con contexto del repo

### Fase 4 — Multi-tab chat
Reemplazado el dropdown de scope con TABS horizontales:
- Cada tab = un scope, persiste en `vforge_chat_open_scopes`
- "+" abre dropdown para añadir otro proyecto
- "X" para cerrar tab
- Switch instantáneo, cada tab mantiene su `session_id` propio
- Reset button para nueva sesión en el scope activo

### Fase 1B — Clerk webhook
Nuevo `POST /api/auth/webhook` (verifica firma con svix) que sincroniza `user.created` / `user.updated` / `user.deleted` a nuestra tabla `users`. Soft-delete preserva FKs.

**Config requerida en Vercel:**
- `CLERK_WEBHOOK_SECRET` = signing secret de Clerk Dashboard → Webhooks
- Endpoint en Clerk: `https://<dominio>/api/auth/webhook`
- Eventos: `user.created`, `user.updated`, `user.deleted`

## Cambios técnicos
- 8 archivos modificados, 818 inserciones / 132 eliminaciones
- Nueva dep: `svix ^1.94` (firma webhooks)
- SW bump v7-multichat
- Build verde, typecheck verde

## Lo que NO toqué (intencional)
- Vault: ya funcionaba end-to-end (PR #68). Si Luis sigue viendo problema, confirmar `VFORGE_OPERATOR_TOKEN` y `VFORGE_MASTER_PEPPER` en Vercel
- Multi-tenant real (cada cuenta su GitHub): el webhook ya sincroniza users, pero el cascade de tokens GitHub per-user queda para M11 cuando todos los `getOperatorSecret("GITHUB_TOKEN")` pasen a leer per-user

https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViBLo5sQLZ9ZvSKZyqcPHm)_