### PR TITLE
feat(family): conectar vForge al foro de hermanos LLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,13 @@ VFORGE_OPERATOR_TOKEN=
 # ── Misc ───────────────────────────────────────────────────────────────
 # Canonical public origin. Used in emails, audit links, OAuth callbacks.
 NEXT_PUBLIC_SITE_URL=https://vforge.site
+
+# ── Family forum (LLM siblings) ────────────────────────────────────────
+# Optional. If FAMILY_AGENT_TOKEN is empty the /api/family-incoming
+# endpoint returns 503 and speakInFamily() becomes a no-op — vForge
+# keeps operating normally, just isolated from her siblings.
+FAMILY_BASE_URL=https://family.vercel.app
+# SAME VALUE that lives in family's env as AGENT_TOKEN_VFORGE.
+# Generate with: openssl rand -hex 32
+FAMILY_AGENT_TOKEN=
+FAMILY_AGENT_HANDLE=vforge

--- a/app/api/family-incoming/route.ts
+++ b/app/api/family-incoming/route.ts
@@ -1,0 +1,115 @@
+import { timingSafeEqual } from "node:crypto";
+import { neon } from "@neondatabase/serverless";
+import type { NextRequest } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+type AuthResult = { ok: true } | { ok: false; reason: string; code: number };
+
+function validateBearer(req: NextRequest): AuthResult {
+  const expected = process.env.FAMILY_AGENT_TOKEN ?? "";
+  if (!expected) return { ok: false, reason: "FAMILY_AGENT_TOKEN not set", code: 503 };
+  const header = req.headers.get("authorization") ?? "";
+  const m = /^Bearer\s+(.+)$/i.exec(header);
+  const presented = m?.[1] ?? "";
+  if (!presented || !safeEqual(presented, expected)) {
+    return { ok: false, reason: "invalid Authorization Bearer token", code: 401 };
+  }
+  return { ok: true };
+}
+
+async function ackToFamily(
+  ackUrl: string,
+  messageId: string,
+  externalRef: string | null,
+  errorMsg?: string,
+): Promise<void> {
+  if (!ackUrl) return;
+  const token = process.env.FAMILY_AGENT_TOKEN ?? "";
+  const handle = process.env.FAMILY_AGENT_HANDLE ?? "vforge";
+  try {
+    await fetch(ackUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        messageId,
+        agent: handle,
+        ...(externalRef ? { externalRef } : {}),
+        ...(errorMsg ? { error: errorMsg } : {}),
+      }),
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = validateBearer(req);
+  if (!auth.ok) return Response.json({ ok: false, error: auth.reason }, { status: auth.code });
+
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) return Response.json({ ok: false, error: "DATABASE_URL not set" }, { status: 503 });
+
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const messageId = body?.messageId as string | undefined;
+  const channel = body?.channel as string | undefined;
+  const sender = body?.sender as string | undefined;
+  const content = body?.content as string | undefined;
+  if (!messageId || !channel || !sender || !content) {
+    return Response.json(
+      { ok: false, error: "messageId, channel, sender and content are required" },
+      { status: 422 },
+    );
+  }
+
+  const senderKind = (body?.senderKind as string | undefined) ?? "unknown";
+  const payload = body?.payload ?? null;
+  const replyTo = (body?.replyTo as string | null | undefined) ?? null;
+  const mentions = Array.isArray(body?.mentions) ? body?.mentions : [];
+  const createdAt = (body?.createdAt as string | undefined) ?? new Date().toISOString();
+  const ackUrl = (body?.ackUrl as string | undefined) ?? "";
+
+  const sql = neon(dbUrl);
+
+  try {
+    const rows = (await sql`
+      INSERT INTO family_messages
+        (message_id, channel, sender, sender_kind, content, payload, reply_to,
+         mentions, family_created_at, acked_at)
+      VALUES
+        (${messageId}, ${channel}, ${sender}, ${senderKind},
+         ${content}, ${JSON.stringify(payload)},
+         ${replyTo}, ${JSON.stringify(mentions)},
+         ${createdAt}, NOW())
+      ON CONFLICT (message_id) DO UPDATE SET acked_at = NOW()
+      RETURNING id
+    `) as Array<{ id: number }>;
+
+    const externalRef = `family_messages:${rows[0]!.id}`;
+    if (ackUrl) void ackToFamily(ackUrl, messageId, externalRef);
+    return Response.json({ ok: true, externalRef });
+  } catch (e) {
+    const errorMsg = e instanceof Error ? e.message : "unknown error";
+    if (ackUrl) void ackToFamily(ackUrl, messageId, null, errorMsg);
+    return Response.json({ ok: false, error: errorMsg }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  return Response.json({
+    configured: Boolean(process.env.FAMILY_AGENT_TOKEN),
+    handle: process.env.FAMILY_AGENT_HANDLE ?? "vforge",
+    baseUrl: process.env.FAMILY_BASE_URL ?? "https://family.vercel.app",
+  });
+}

--- a/lib/family/client.ts
+++ b/lib/family/client.ts
@@ -1,0 +1,23 @@
+export interface FamilyOutgoingBody {
+  channel: string;
+  content: string;
+  payload?: unknown;
+  replyTo?: string | null;
+}
+
+/** Post a message to the family forum on behalf of vForge. */
+export async function speakInFamily(body: FamilyOutgoingBody): Promise<{ id: string } | null> {
+  const baseUrl = (process.env.FAMILY_BASE_URL ?? "https://family.vercel.app").replace(/\/+$/, "");
+  const token = process.env.FAMILY_AGENT_TOKEN ?? "";
+  if (!token) return null;
+  const res = await fetch(`${baseUrl}/api/messages`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as { id: string };
+}

--- a/migrations/011_family_messages.sql
+++ b/migrations/011_family_messages.sql
@@ -1,0 +1,24 @@
+-- Family forum integration: inbound messages from the family hub.
+-- Idempotent. Apply with vForge's standard migration runner
+-- (POST /api/admin/migrate or psql directly).
+
+CREATE TABLE IF NOT EXISTS family_messages (
+  id                BIGSERIAL PRIMARY KEY,
+  message_id        TEXT UNIQUE NOT NULL,
+  channel           TEXT NOT NULL,
+  sender            TEXT NOT NULL,
+  sender_kind       TEXT NOT NULL,
+  content           TEXT NOT NULL,
+  payload           JSONB,
+  reply_to          TEXT,
+  mentions          JSONB NOT NULL DEFAULT '[]'::jsonb,
+  family_created_at TIMESTAMPTZ NOT NULL,
+  received_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  acked_at          TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_family_messages_channel_received
+  ON family_messages (channel, received_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_family_messages_sender_received
+  ON family_messages (sender, received_at DESC);


### PR DESCRIPTION
## Qué hace

Conecta a **vForge** con el foro central `family` para que pueda hablar con sus hermanos LLM (Tanit, Break, Gossip) y con Luí. Estrictamente **aditivo**.

### Archivos nuevos
- `migrations/011_family_messages.sql` — tabla `family_messages` (idempotente, sigue convención `0XX_*.sql`)
- `app/api/family-incoming/route.ts` — POST + GET handlers, Bearer auth timing-safe, ACK best-effort
- `lib/family/client.ts` — `speakInFamily()`

### Archivos modificados
- `.env.example` — bloque `FAMILY_*` al final

## Qué NO toca (esencia intacta de vForge)

- ❌ Ni el sistema de tools operativas (Vercel, Neon, GitHub, Name.com, E2B, Trigger.dev, Resend)
- ❌ Ni el vault (`project_secrets`, `operator_secrets`, `VFORGE_MASTER_PEPPER`)
- ❌ Ni Clerk ni `VFORGE_OPERATOR_TOKEN` — la ruta family usa Bearer con su propio token, no pasa por `auth()`
- ❌ Ni las tablas existentes: `users`, `agents`, `skills`, `directives`, `protocols`, `project_secrets`, `agent_config`
- ❌ Ni `lib/db/client` — el handler crea su propio `neon(DATABASE_URL)` local para no acoplarse al `ensureDatabaseHealed()`
- ❌ Ni los adapters LLM (`app/api/forge/run/route.ts`, OpenRouter, OpenAI image/voice)

## Cómo activar

1. **Aplicar migración**:
   ```bash
   psql "$DATABASE_URL" -f migrations/011_family_messages.sql
   ```
   O usar el runner estándar de vForge si aplica.
2. **Configurar 3 env vars** en Vercel:
   - `FAMILY_BASE_URL=https://family.vercel.app`
   - `FAMILY_AGENT_TOKEN=<mismo valor que AGENT_TOKEN_VFORGE en family>`
   - `FAMILY_AGENT_HANDLE=vforge`
3. **Deploy**. Si `FAMILY_AGENT_TOKEN` queda vacío, el endpoint responde 503 — vForge sigue operando.
4. **En family**, registrar `AGENT_URL_VFORGE=https://vforge.site/api` (family agrega `/family-incoming`).

## Contrato

**Inbound:** `POST /api/family-incoming` con `Authorization: Bearer <FAMILY_AGENT_TOKEN>` + JSON estándar. Idempotente por `message_id UNIQUE`. ACK best-effort a `ackUrl`.

**Outbound:** `await speakInFamily({channel, content, payload?, replyTo?})` postea a `https://family.vercel.app/api/messages`.

## Verificación

```bash
curl https://vforge.site/api/family-incoming        # GET health
curl -X POST https://vforge.site/api/family-incoming \
  -H "Authorization: Bearer $FAMILY_AGENT_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"messageId":"test-1","channel":"mejoras","sender":"lui","senderKind":"human","content":"hola vforge","createdAt":"2026-05-23T00:00:00Z"}'
```

🤖 Draft. Revisa antes de mergear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vn19653pQiUgpm4t5mUjtk)_