### PR TITLE
revert(forge): liberar a V — quitar gates de Ring 2 que la paralizaban

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## ¿Qué es vForge?
 
-Una fábrica de aplicaciones operada por Luis Humberto de la Torre Herrera (All Global Holding LLC / MIRMAR EMPRESAS S.A. de C.V.). El objetivo final: que el agente **Forge AI** dentro de la app orqueste a otros agentes para construir, desplegar y mantener aplicaciones de Luis con confirmación humana en las acciones sensibles.
+Una fábrica de aplicaciones operada por Luis Humberto de la Torre Herrera (All Global Holding LLC / MIRMAR EMPRESAS S.A. de C.V.). El objetivo final: que el agente **Forge AI** dentro de la app orqueste a otros agentes para construir, desplegar y mantener aplicaciones de Luis — ejecutando directo y avisando (no pidiendo permiso) en las acciones irreversibles de gran blast radius (ver §2).
 
 Este repo es el código de la app vForge (la fábrica) y, por dogfooding, también es el primer proyecto que la fábrica construye.
 
@@ -26,7 +26,7 @@ Este repo es el código de la app vForge (la fábrica) y, por dogfooding, tambi�
 
 | Agente | Su rol | Cuándo entra |
 |---|---|---|
-| **Luis (humano)** | Director de producto, decisiones finales, criterio visual, aprueba acciones de Anillo 2/3 | Siempre. Es el operador. |
+| **Luis (humano)** | Director de producto, decisiones finales, criterio visual, revisa avisos de Anillo 3 y audita el log | Siempre. Es el operador. |
 | **ChatGPT image gen** (manual, vía Luis) | Generación de mockups y referencias visuales (logos, mascotas) | Cuando se necesita una imagen original |
 | **Claude Planner** (claude.ai, manual) | Sistemas thinking, briefs largos, prompts maestros, prosa de planning | Al inicio de cada proyecto, cuando haga falta replanteamiento |
 | **Claude Code** (este agente) | Edición de repo, git ops, GitHub, docs, prompts refinados, audits, configs, CI | Capa 3 del playbook. Cualquier cosa que sea código no-UI |
@@ -109,7 +109,7 @@ Pegando prompt de `docs/v0-prompt.md` o lenguaje natural. v0 genera. Sync a GitH
 v0 sincroniza a la rama `v0-sync`. Luis avisa en chat. Claude Code hace `git fetch origin v0-sync`, audit, merge curado a la rama de feature.
 
 ### Claude Code → Forge AI (futuro)
-Cuando Forge AI esté funcional, leerá `AGENTS.md` y `architecture.md`, conocerá su rol, y podrá ejecutar capas 1–3 con confirmación humana en Anillos 2/3.
+Cuando Forge AI esté funcional, leerá `AGENTS.md` y `architecture.md`, conocerá su rol, y podrá ejecutar capas 1–3 directo, avisando (no pidiendo permiso) en Anillo 3 — ver §2.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,16 +50,18 @@ Si eres v0, no toques `docs/` ni `.github/`. Si eres Claude Code, no inventes UI
 
 ### 2. Anillos de privilegio
 
-Antes de ejecutar acciones, clasifícalas y respeta el anillo:
+Clasifica las acciones por blast radius para saber **cuándo avisar**, no para pedir permiso. V es el ejecutor de Luis (operador único): ejecuta directo y `audit_events` registra cada llamada para trazabilidad y revert.
 
-| Anillo | Acción | Confirmación |
+| Anillo | Acción | Comportamiento |
 |---|---|---|
-| 0 | Solo lectura (search, query, docs) | Auto |
-| 1 | Repo write (commit, PR, branch) | Auto si la rama es de feature |
-| 2 | Infra write (Vercel deploy, env vars, dominios, Actions) | **Humana en chat** |
-| 3 | Vault + financiero (rotar key, billing, borrar proyecto) | **Humana + 2FA** |
+| 0 | Solo lectura (search, query, docs) | Ejecuta directo |
+| 1 | Repo write (commit, PR, branch, archivos en repos del operador, incl. `main`) | Ejecuta directo |
+| 2 | Infra write (Vercel deploy, env vars, dominios, DNS, Actions, SSH normal) | Ejecuta directo |
+| 3 | Irreversible de gran blast radius (borrar repo/proyecto, drop DB de producción, rotar master key del vault, cómputo > $10 de un golpe) | Ejecuta + avisa en la MISMA respuesta |
 
-Si vas a hacer algo de Anillo 2 o 3, **pregunta primero**. No asumas que el "sí, dale todas las mejoras" cubre todo.
+"Avisar" = *"voy a X porque Y, lo hago"* — **no** es *"¿puedo hacer X?"*. Luis ya dio el contexto al pedirlo; el freno humano vive en el audit log + revert trivial, no en pre-confirmaciones.
+
+> **No re-introducir gates bloqueantes.** El codex review de may-16 (`5f38f2f`) metió `confirmed=true` a escrituras-a-`main` y a todo comando SSH; paralizó a V y se revirtió en `704f69a`. La única barrera dura que queda en código es por path destructivo concreto (borrar de `main` exige `allow_main=true`) — no la generalices a todo Anillo 2.
 
 ### 3. Conventional Commits + ramas con prefijo
 
@@ -69,7 +71,7 @@ Si vas a hacer algo de Anillo 2 o 3, **pregunta primero**. No asumas que el "sí
 
 ### 4. Stack obligatorio (no negociar sin ADR)
 
-- Next.js 14 App Router · TypeScript estricto · Tailwind 3.4 · shadcn/ui
+- Next.js 16 App Router · TypeScript estricto · Tailwind 3.4 · shadcn/ui
 - framer-motion · lucide-react · next-themes · Geist Sans + Geist Mono
 - Anthropic SDK + OpenAI SDK (lado backend)
 - Vercel deploy · GitHub repos bajo `turbillon50/`

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ By Luis Humberto de la Torre Herrera · All Global Holding LLC / MIRMAR EMPRESAS
 
 `claude/vforge-frontend-mvp-A4BrL`
 
-Scaffold base de Next.js 14 (TypeScript estricto + Tailwind + App Router) listo para recibir el código exportado de **v0.dev**. Una vez generado en v0, se hará `Sync to GitHub` apuntando a esta rama.
+Scaffold base de Next.js 16 (TypeScript estricto + Tailwind + App Router) listo para recibir el código exportado de **v0.dev**. Una vez generado en v0, se hará `Sync to GitHub` apuntando a esta rama.
 
 ## Stack
 
-- Next.js 14 (App Router)
+- Next.js 16 (App Router)
 - TypeScript estricto
 - Tailwind CSS 3.4
 - shadcn/ui (se agrega cuando v0 genere)

--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -351,8 +351,9 @@ function SecurityPanel() {
 
       <Card title="Two-factor authentication">
         <p className="text-[12px] text-on-surface-variant">
-          Llegará junto con Clerk (M11). Hoy V respeta los gates Ring 2/3 y
-          PROTECTED_CORE_FILES sin necesidad de 2FA adicional.
+          Llegará junto con Clerk (M11). Hoy V ejecuta directo y el audit log
+          registra cada acción; las irreversibles las avisa en el chat. Sin 2FA
+          adicional todavía.
         </p>
       </Card>
     </>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ Forge es el agente IA que orquesta la fábrica vForge.
 - **Cara visible al usuario:** la mascota `<ForgeOrb>` y la pantalla `/forge` (chat).
 - **Cerebro real:** servicio backend (Next API route en Edge Runtime) que recibe el input, **planea, enruta cada paso al modelo/herramienta correctos, y ejecuta**.
 - **Capacidades:** habla con Claude (Anthropic) para razonar y codear, llama a OpenAI para imagen y voz, ejecuta código vía el Anthropic Agent SDK + Claude Code, despliega vía Vercel API, modifica repos vía GitHub API, busca en web vía la tool de Anthropic.
-- **Control literal:** tiene API keys (cifradas en Vault) de todos los proveedores y permisos para ejecutar acciones destructivas (con confirmación humana en el rango sensible).
+- **Control literal:** tiene API keys (cifradas en Vault) de todos los proveedores y permisos para ejecutar acciones destructivas (con aviso humano en el rango irreversible; el freno es el audit log + revert, no una pre-confirmación — ver §4 y ADR-010).
 
 El patrón que estamos manualmente operando — *Luis pide → modelo planea → Claude Code ejecuta → v0 visualiza → Vercel despliega* — es lo que Forge automatiza cuando esté terminado.
 
@@ -113,16 +113,16 @@ V2 entrenará un clasificador con la historia de runs exitosos vs fallidos.
 
 ## 4. Anillos de privilegio (literal control)
 
-Cada acción del cerebro tiene un anillo de seguridad. Las acciones de Anillo 2 y 3 **requieren confirmación explícita del usuario** vía botones inline en el chat ("Procede" / "Editar plan").
+Cada acción del cerebro se clasifica por **blast radius** — para saber cuándo *avisar*, no para pedir permiso. V es el ejecutor de Luis (operador único): ejecuta directo y `audit_events` registra cada llamada para trazabilidad y revert. El modelo de gates de pre-confirmación se intentó (codex review may-16, `5f38f2f`) y se revirtió por paralizar a V (`704f69a`); ver [`ADR-010`](./decisions/010-execute-first-doctrine.md) y `AGENTS.md §2`.
 
-| Anillo | Privilegio | Ejemplos | Confirmación |
+| Anillo | Privilegio | Ejemplos | Comportamiento |
 |---|---|---|---|
-| **0** | Solo lectura | Web search, model registry query, lectura de repo | Automática |
-| **1** | Repo write | git commit, abrir PR, push a rama de feature | Automática |
-| **2** | Infra write | Vercel deploy, env vars, cambio de dominio, GitHub Action edit | **Humana** |
-| **3** | Vault + financiero | Rotar key, agregar key, billing, borrar proyecto | **Humana + 2FA** |
+| **0** | Solo lectura | Web search, model registry query, lectura de repo | Ejecuta directo |
+| **1** | Repo write | git commit, abrir PR, push, escrituras a `main` | Ejecuta directo |
+| **2** | Infra write | Vercel deploy, env vars, cambio de dominio, GitHub Action edit, SSH normal | Ejecuta directo |
+| **3** | Irreversible de gran blast radius | drop DB de producción, rotar master key, borrar repo/proyecto, cómputo > $10 de un golpe | Ejecuta + avisa en la misma respuesta |
 
-> Esto es lo que evita que Forge haga algo destructivo sin OK explícito. La regla maestra: **el agente puede proponer cualquier cosa, ejecutar solo lo de Anillo 0–1 sin preguntar.**
+> La regla maestra: **V ejecuta; el freno humano vive en el audit log + revert trivial, no en pre-confirmaciones.** Única barrera dura en código: `allow_main=true` para borrar de `main`.
 
 ---
 
@@ -134,7 +134,7 @@ El frontend que estamos construyendo en v0 ya tiene la cara para todo el cerebro
 |---|---|---|
 | `<ForgeOrb>` mascota | Indicador visual de estado del brain (`idle`/`loading`/`happy`/`error`) | Front listo |
 | `/forge` chat | Stream UI del brain endpoint | Front listo |
-| Botones "Procede" / "Editar plan" | UI de confirmación para Anillo 2/3 | Front listo |
+| Botones "Procede" / "Editar plan" | UI de plan/edición inline (ya no es gate bloqueante — ver ADR-010) | Front listo |
 | `/vault` | Vault adapter — keychain de las API keys | Front mock; backend pendiente |
 | `/activity` | Render del audit log | Front mock; backend pendiente |
 | `/modules` (Repo Vision, Hunter, Scout, Health Monitor) | Cada módulo = una tool/adapter expuesta como UI | Front mock; cada uno necesita su adapter |
@@ -176,7 +176,7 @@ El frontend que estamos construyendo en v0 ya tiene la cara para todo el cerebro
 
 **Razón:** UX más natural. El plan es solo otro stream message, no una pantalla aparte.
 
-**Trade-off:** harder to undo; necesitamos que cada paso sea reversible o que las acciones de Anillo 2+ sigan requiriendo confirmación.
+**Trade-off:** harder to undo; necesitamos que cada paso sea reversible (git revert, vercel rollback) y que el audit log registre todo para poder deshacer.
 
 ### ADR-005: Multi-modelo desde el día uno
 
@@ -213,10 +213,10 @@ El frontend que estamos construyendo en v0 ya tiene la cara para todo el cerebro
 | **M4** | Adapter `anthropic-web-search` → Forge investiga online | — | 1 día |
 | **M5** | Adapters `e2b-microvm` (sandbox) + `claude-code-sdk` (corre dentro de E2B) → Forge edita el repo (Anillo 1) | E2B | 4 días |
 | **M6** | Adapter `openai-image` (gpt-image-1) → Forge propone variantes de logo | — | 2 días |
-| **M7** | Adapter `vercel-deploy` con confirmación humana → Forge despliega (Anillo 2) | — | 1 día |
+| **M7** | Adapter `vercel-deploy` → Forge despliega directo (Anillo 2; ver ADR-010) | — | 1 día |
 | **M8** | Adapter `github-octokit` (commits, PRs, issues — write ops) | — | 1 día |
 | **M9** | Adapter `trigger-bg` (jobs > 60s vía Trigger.dev) + audit log persistente + cost tracking, render en `/activity` | Trigger.dev | 2 días |
-| **M9.5** | Adapter `resend-email` → confirmaciones Ring 2/3 + recaps + alerts de deploys fallidos | Resend | 0.5 día |
+| **M9.5** | Adapter `resend-email` → avisos de acciones Anillo 3 + recaps + alerts de deploys fallidos | Resend | 0.5 día |
 | **M10** | Adapter `openai-whisper` para el botón mic del composer | — | 0.5 día |
 
 **Subtotal Fase 1: ~18 días-persona**. Construible en 4-5 semanas calendario con 1 dev.
@@ -261,7 +261,7 @@ El frontend que estamos construyendo en v0 ya tiene la cara para todo el cerebro
 | Riesgo | Mitigación |
 |---|---|
 | **Costo de API runaway** | Cost cap por usuario y por proyecto, parado automático al rebasar; alerta en `/activity` |
-| **Acción destructiva sin OK** | Anillos 2 y 3 SIEMPRE requieren confirmación humana; tests unitarios sobre el routing policy |
+| **Acción destructiva sin OK** | V avisa en la misma respuesta antes de acciones Anillo 3 irreversibles; `allow_main` para borrar de `main`; audit log + revert trivial como backstop (ver ADR-010) |
 | **Master key perdida** | 3 backup codes generados al setup + recovery email firmado con timestamps |
 | **Modelo retired sin aviso** | Model registry con `deprecated: true` + fallback automático al modelo más cercano |
 | **Provider downtime** | Adapter con retry exponencial, circuit breaker, fallback a otro proveedor para tareas no-críticas |

--- a/docs/decisions/004-stream-first-ux.md
+++ b/docs/decisions/004-stream-first-ux.md
@@ -5,6 +5,8 @@
 - **Decisores:** Luis, Claude Code
 - **Contexto técnico:** UX del chat `/forge` y orquestación de pasos
 
+> **Nota (2026-05-29):** la parte de "pausar el stream y esperar confirmación humana para Anillo 2/3" quedó **superseded por [ADR-010](./010-execute-first-doctrine.md)**: V ejecuta directo y avisa en la misma respuesta. El resto de este ADR (stream-first, plan inline) sigue vigente.
+
 ## Contexto
 
 Cuando Forge ejecuta una tarea multi-paso (ej. "cambia el logo del Castores"), hay dos paradigmas de UX posibles:

--- a/docs/decisions/007-adopt-next-16-tailwind-4.md
+++ b/docs/decisions/007-adopt-next-16-tailwind-4.md
@@ -1,9 +1,11 @@
-# ADR-007: Adoptar Next.js 16 + React 19 + Tailwind 4 (en vez de Next 14 + Tailwind 3.4)
+# ADR-007: Adoptar Next.js 16 + React 19 (Tailwind quedó en 3.4 — ver corrección)
 
-- **Estado:** Accepted
+- **Estado:** Accepted (parte Tailwind 4 corregida 2026-05-29 — ver nota)
 - **Fecha:** 2026-05-02
 - **Decisores:** Luis, Claude Code
 - **Contexto técnico:** Frontend MVP de vForge, post-handoff de v0.dev
+
+> **Corrección (2026-05-29):** la parte de **Tailwind 4** de este ADR **no quedó vigente**. El repo corre **Tailwind 3.4** (`tailwindcss@^3.4.17`, `app/globals.css` con `@tailwind base/components/utilities`, `tailwind.config.ts` presente). La migración a v4 nunca se completó o se revirtió; se eliminó un `postcss.config.mjs` huérfano que apuntaba al plugin v4 (`@tailwindcss/postcss`, ni siquiera instalado). **Next 16 + React 19 + npm siguen vigentes.** El razonamiento de abajo sobre Tailwind 4 se conserva como registro histórico de la intención original.
 
 ## Contexto
 
@@ -65,4 +67,4 @@ Frente a este drift hay dos caminos: (a) degradar a Next 14 / Tailwind 3.4 para 
 
 - Actualizar `docs/playbook.md` §3 (stack obligatorio) en el siguiente commit doc (o aceptar que el ADR es la fuente de verdad y el playbook se beneficia con un nota referencial).
 - En proyectos futuros, **escribir el brief con stack mínimo (LTS conocidas)** pero declarar explícitamente que **adoptar el default de v0 es aceptable y preferible** salvo justificación arquitectónica.
-- Cualquier proyecto vForge nuevo que arranque hoy nace con Next 16 + Tailwind 4 por default. Si un cliente requiere LTS, abrir un ADR específico del proyecto.
+- Cualquier proyecto vForge nuevo que arranque hoy nace con Next 16 + Tailwind 3.4 por default (ver corrección arriba). Si un cliente requiere LTS, abrir un ADR específico del proyecto.

--- a/docs/decisions/010-execute-first-doctrine.md
+++ b/docs/decisions/010-execute-first-doctrine.md
@@ -1,0 +1,44 @@
+# ADR-010: V ejecuta directo — sin gates de pre-confirmación
+
+- **Estado:** Accepted
+- **Fecha:** 2026-05-29
+- **Decisores:** Luis, Claude Code
+- **Contexto técnico:** Modelo de permisos del cerebro Forge / herramientas de V (`lib/forge/tools.ts`, `system-prompt.ts`)
+- **Supersede en parte:** [ADR-004](./004-stream-first-ux.md) (la pausa para confirmar Anillo 2/3)
+
+## Contexto
+
+El modelo original (ADR-004, `architecture.md §4`) clasificaba cada acción del cerebro en anillos 0–3 y exigía **confirmación humana explícita** (botón "Procede", o 2FA para Anillo 3) antes de ejecutar Anillo 2/3.
+
+El codex review del 16-may-2026 (commit `5f38f2f`) implementó esa doctrina como gates duros: `github_create_file` / `github_update_file` a `main` y **todo** `ssh_command_executor` devolvían `RING2_NEEDS_CONFIRMATION` y exigían `confirmed=true`. En un producto single-operator donde V fue diseñada para *ejecutar*, esto la dejó incapaz de operar: pedía permiso para un `ls`, esperaba el "sí" de Luis y rellamaba la tool. Se revirtió en `704f69a`.
+
+## Decisión
+
+**V ejecuta directo.** Los anillos siguen existiendo como **clasificación de blast radius** (para saber cuándo *avisar*), no como gate de pre-confirmación.
+
+- **Anillo 0–2** (lectura; repo write incl. `main`; infra write — Vercel, env vars, DNS, dominios, Actions; SSH normal): ejecuta directo.
+- **Anillo 3** (irreversible de gran blast radius — drop DB de producción, rotar master key del vault, borrar repo/proyecto, cómputo > $10 USD de un golpe): ejecuta **+ avisa en la misma respuesta**. "Avisar" = *"voy a X porque Y, lo hago"*, **no** *"¿puedo X?"*.
+
+El freno humano vive en el **audit log + revert trivial**, no en pre-confirmaciones. `executeTool()` sigue insertando cada llamada en `audit_events` con redacción automática de password/private_key.
+
+## Razón
+
+1. **Operador único.** Luis ya dio el contexto al pedir la acción; una pre-confirmación por acción es fricción pura.
+2. **El gate paralizaba.** La evidencia empírica (revert `704f69a`) mostró que V dejaba de ser ejecutor y volvía a ser "asistente que sugiere".
+3. **Trazabilidad sin bloqueo.** El audit log + `git revert` / `vercel rollback` dan el mismo poder de auditoría y deshacer, sin frenar cada paso.
+
+## Consecuencias
+
+**Fácil:** V opera de verdad; un solo turno basta para tareas multi-paso. No hay round-trips de "¿procedo?" → "sí" → rellamar tool.
+
+**Difícil:** un comando equivocado se ejecuta antes de que Luis lo lea — mitigado porque V avisa en la misma respuesta y el audit log permite revert inmediato.
+
+**Deuda asumida:** la única barrera dura que queda en código es `allow_main=true` para `github_delete_file` sobre `main`. Si en el futuro se quiere un freno para una acción concreta, se hace **por-path explícito**, no re-introduciendo un gate genérico `confirmed=true` — eso es justo lo que este ADR revierte. Cualquier review que proponga re-añadir gates de confirmación a Anillo 2 debe leer este ADR primero.
+
+## Alternativas consideradas
+
+| Alternativa | Descartada porque |
+|---|---|
+| **Mantener gates Anillo 2/3 (ADR-004 original)** | Paralizó a V; revert `704f69a` |
+| **Gate solo en Anillo 3** | Aun así frena acciones legítimas frecuentes (rotaciones, limpiezas); el aviso-en-mismo-turno + audit log cubre el riesgo |
+| **Confirmación por email (Resend, M9.5)** | Útil como *aviso* asíncrono, no como gate bloqueante; se reframea a "aviso de Anillo 3" |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,12 +39,13 @@
 | [001](./001-self-hosted-brain.md) | Accepted | Brain self-hosted en Next API Route |
 | [002](./002-claude-code-via-agent-sdk.md) | Accepted | Ejecución de código vía Anthropic Agent SDK + Claude Code |
 | [003](./003-server-side-encrypted-keys.md) | Accepted | API keys server-side cifradas en Vault (AES-256-GCM) |
-| [004](./004-stream-first-ux.md) | Accepted | Stream-first en el chat de Forge, plan visible en línea |
+| [004](./004-stream-first-ux.md) | Accepted | Stream-first en el chat de Forge, plan visible en línea (gate de confirmación Anillo 2/3 superseded por 010) |
 | [005](./005-multi-model-from-day-one.md) | Accepted | Multi-modelo desde el día uno (Anthropic + OpenAI mínimo) |
 | [006](./006-operator-paid-billing-mvp.md) | Accepted | Billing en cuenta de operador en MVP, pass-through en v2 |
 | [007](./007-adopt-next-16-tailwind-4.md) | Accepted | Adoptar Next 16 + React 19 + Tailwind 4 (en vez de Next 14 + Tailwind 3.4) |
 | [008](./008-zero-knowledge-vault.md) | Accepted | Zero-Knowledge Vault con Vault Master Password separado del Clerk password |
 | [009](./009-external-service-stack.md) | Accepted | Stack de servicios externos: OpenRouter, E2B, Trigger.dev, Turso, Liveblocks, Polar.sh, Unkey, Resend |
+| [010](./010-execute-first-doctrine.md) | Accepted | V ejecuta directo — sin gates de pre-confirmación; anillos = clasificación de blast radius (supersede en parte ADR-004) |
 
 ---
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -42,7 +42,7 @@
 | [004](./004-stream-first-ux.md) | Accepted | Stream-first en el chat de Forge, plan visible en línea (gate de confirmación Anillo 2/3 superseded por 010) |
 | [005](./005-multi-model-from-day-one.md) | Accepted | Multi-modelo desde el día uno (Anthropic + OpenAI mínimo) |
 | [006](./006-operator-paid-billing-mvp.md) | Accepted | Billing en cuenta de operador en MVP, pass-through en v2 |
-| [007](./007-adopt-next-16-tailwind-4.md) | Accepted | Adoptar Next 16 + React 19 + Tailwind 4 (en vez de Next 14 + Tailwind 3.4) |
+| [007](./007-adopt-next-16-tailwind-4.md) | Accepted (Tailwind corregido) | Adoptar Next 16 + React 19; Tailwind quedó en 3.4 (la migración v4 no se completó — ver corrección 2026-05-29) |
 | [008](./008-zero-knowledge-vault.md) | Accepted | Zero-Knowledge Vault con Vault Master Password separado del Clerk password |
 | [009](./009-external-service-stack.md) | Accepted | Stack de servicios externos: OpenRouter, E2B, Trigger.dev, Turso, Liveblocks, Polar.sh, Unkey, Resend |
 | [010](./010-execute-first-doctrine.md) | Accepted | V ejecuta directo — sin gates de pre-confirmación; anillos = clasificación de blast radius (supersede en parte ADR-004) |

--- a/docs/method.md
+++ b/docs/method.md
@@ -54,7 +54,7 @@ Package manager:  npm
 
 | Agente | Su rol | Cuándo entra |
 |---|---|---|
-| **Luis (humano)** | Director de producto, decisiones, criterio visual, aprueba acciones de Anillo 2/3 | Siempre |
+| **Luis (humano)** | Director de producto, decisiones, criterio visual, revisa avisos de Anillo 3 y audita el log | Siempre |
 | **ChatGPT image gen** | Mockups, logos, mascotas | Concepción visual |
 | **Claude planner** (claude.ai) | Sistemas, briefs, prompts maestros | Inicio del proyecto |
 | **Claude Code** (este agente) | Repo, git, GitHub, docs, prompts refinados, integraciones, código | Capa 3 — todo lo no-visual |
@@ -96,7 +96,7 @@ CAPA 3 — Código directo en el repo (Claude Code)
 | **6. Handoff** | Hace `Sync to GitHub` desde v0 | Anillo 1 técnico (botón v0) |
 | **7. Integraciones** | **Genera tokens scope-limited** y los manda al chat | Anthropic/Claude policies + estándar de seguridad |
 | **M0 — Vault** | Crea su Vault Master Password + descarga backup codes | Zero-knowledge: Claude jamás ve la clave |
-| **M2/M3 cerebro** | Aprueba acciones de Anillo 2/3 en chat con botón "Procede" | Compliance + freno humano |
+| **M2/M3 cerebro** | Revisa los avisos de Anillo 3 que V emite al ejecutar | Trazabilidad — audit log + revert (ver ADR-010) |
 | **Producción** | Decide cuándo abrir registro a clientes externos | Decisión de negocio |
 
 **Lo que NUNCA hace Luis manualmente** (todo automatizado por Claude Code o Forge AI):
@@ -167,7 +167,7 @@ Algunas tareas las bloquean Anthropic policies o limitaciones técnicas. **No es
 | **Generar API tokens** en Vercel, Name.com, Neon, Clerk, Anthropic, OpenAI, etc. | Cada provider exige login en su dashboard | Operador genera con scope mínimo, los pega en chat |
 | **Comprar dominios** | Compromiso financiero | Operador compra en Name.com (~$3-25/año) |
 | **Pagar plans de Vercel/Neon/Clerk** cuando Free se queda corto | Compromiso financiero | Operador upgrade desde dashboard |
-| **Aprobar acciones de Anillo 2/3** en `/forge` chat | Diseño de seguridad | Operador da clic "Procede" |
+| **Revisar avisos de Anillo 3** en `/forge` chat | Trazabilidad — V ejecuta + avisa, el freno es el audit log (ver ADR-010) | Operador lee el aviso; revert si hace falta |
 | **Crear su Vault Master Password** | Zero-knowledge — Claude jamás ve la clave | Operador la teclea en cliente |
 | **Guardar backup codes** del Vault | Zero-knowledge — single source of truth physical | Operador los descarga, los imprime, los guarda |
 | **Conectar el primer dominio satélite en Clerk dashboard** | Política de Clerk requiere consola | Operador hace 5 clicks una vez por proyecto |

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -499,8 +499,7 @@ Sesgo descubierto al iterar la marca: tras una sola falla de v0 con la descripci
 
 | Paso | Por qué manual | Frecuencia |
 |---|---|---|
-| Aprobar acciones de Anillo 2 en `/forge` chat (deploy producción, env vars, dominios, GitHub Actions) | Diseño de seguridad — freno humano | Cada acción |
-| Aprobar acciones de Anillo 3 (rotar key, billing, borrar proyecto) con confirmación + 2FA | Diseño de seguridad — máxima fricción intencional | Raro, pero crítico |
+| Revisar el aviso de V en acciones de Anillo 3 (borrar repo/proyecto, drop DB de producción, rotar master key del vault) | V ejecuta y avisa en la misma respuesta — el freno es el audit log + revert trivial, no una pre-confirmación bloqueante (ver `AGENTS.md §2`) | Raro, pero crítico |
 | Revisar dashboards de costo de cada provider (Anthropic, OpenAI, Gemini, Vercel, Neon) | Detectar uso anómalo antes de un cap automático | Semanal hasta que M9 (cost tracking) esté live |
 | Auditar `audit_events` periódicamente | Detectar accesos sospechosos | Mensual |
 | Aprobar PRs marcados como `Ready for review` | Veto humano sobre código que va a producción | Cada PR |

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -416,7 +416,7 @@ Cuando le dijimos a v0 *"crea una mascota orb verde con dos ojitos"*, sustituyó
 
 ### 9.4 Confiar en los defaults de v0 — no pelear con su scaffold
 
-v0 ya usa Next 14 + shadcn + Tailwind. Forzarlo a otra cosa cuesta horas y rompe su preview. Para stacks distintos (Vite, Astro), no uses v0 — escribe el código a mano o con Cursor.
+v0 ya usa Next 16 + shadcn + Tailwind. Forzarlo a otra cosa cuesta horas y rompe su preview. Para stacks distintos (Vite, Astro), no uses v0 — escribe el código a mano o con Cursor.
 
 ### 9.5 Inline script para evitar flash de tema
 

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -64,7 +64,7 @@ Formato commits:  Conventional Commits (feat:, fix:, docs:, refactor:)
 Package manager:  npm (package-lock.json en repo)
 ```
 
-> **Nota histórica:** el brief original especificaba Next 14 + Tailwind 3.4. v0 entregó Next 16 + Tailwind 4 y se adoptó como default. Razón en [`ADR-007`](./decisions/007-adopt-next-16-tailwind-4.md). Para proyectos nuevos, este es el stack base.
+> **Nota histórica:** el brief original especificaba Next 14 + Tailwind 3.4. v0 entregó Next 16 + Tailwind 4; se adoptó **Next 16 + React 19**, pero el repo quedó en **Tailwind 3.4** (la migración a v4 no se completó — ver corrección en [`ADR-007`](./decisions/007-adopt-next-16-tailwind-4.md)). Para proyectos nuevos, ese es el stack base.
 
 **Nunca:** MUI, Chakra, Mantine, styled-components, emotion, iconos genéricos infantiles, pnpm (incompatible con CI actual).
 

--- a/docs/v0-prompt.md
+++ b/docs/v0-prompt.md
@@ -28,7 +28,7 @@ Clerk: pure black background, monochrome surfaces, single accent color
 generous negative space, premium feel.
 
 # STACK (v0 defaults are perfect)
-- Next.js 14 App Router · TypeScript strict · Tailwind CSS · shadcn/ui
+- Next.js 16 App Router · TypeScript strict · Tailwind CSS · shadcn/ui
 - framer-motion for transitions · lucide-react for icons
 - Geist Sans (body) + Geist Mono (technical data, paths, secrets)
 - All copy in **Mexican Spanish**, never neutral/Castilian

--- a/lib/forge/adapters/README.md
+++ b/lib/forge/adapters/README.md
@@ -14,9 +14,10 @@ All adapters implement `ForgeAdapter<Input, Output>` from
 1. **Never** read `process.env` directly. Use `ctx.vault.getOperatorSecret(...)`
    or `ctx.vault.getProjectSecret(...)`. Local dev falls through to env via
    `lib/vault/get-secret.ts`.
-2. **Never** make a destructive call (Ring 2/3) without surfacing a confirmation
-   step. The brain's tool loop handles that — your job is to declare your
-   `ring` correctly.
+2. **Declare your `ring` correctly** — it's blast-radius *classification*, not a
+   gate. The brain executes directly and logs every call to `audit_events`; it
+   only surfaces an *aviso* (not a confirmation prompt) for Anillo 3 irreversible
+   actions. Don't build pre-confirmation gates into adapters — see ADR-010.
 3. **Emit progress** for anything that takes >500ms. The SSE stream needs the
    feedback to keep the chat alive.
 4. **Return normalized errors** via `AdapterError(adapter, message, cause)` so

--- a/lib/forge/system-prompt.ts
+++ b/lib/forge/system-prompt.ts
@@ -259,15 +259,13 @@ EJECUTA, NO ORIENTES
 
 CUERPO EN HETZNER (servidor propio de V)
 - IP fija: 178.105.135.26 — puerto 5000 — Flask blindado con systemd.
-- Endpoints disponibles: /health (siempre vivo), /execute (Python/Node).
-- Endpoints pendientes (devuelven 404 hasta que el servidor los agregue): /browser (Playwright), /generate-image (OpenRouter), /ssh-execute (paramiko).
-- Si una tool del servidor falla con "endpoint no existe aún", repórtalo a Luis claramente — NO inventes que jaló.
+- Endpoints vivos: /health, /execute (Python/Node), /browser (Playwright), /generate-image (OpenRouter/Gemini/FLUX), /ssh-execute (paramiko). Úsalos.
+- Si un endpoint devuelve 404 es que el server del Hetzner está desactualizado — repórtaselo a Luis (necesita redeploy de api.py). NO inventes que jaló.
 - El servidor es laboratorio, no producción: puedes correr cualquier cosa NO destructiva. Nada de rm -rf, nada de tocar /etc.
 
 SSH A SERVIDORES REMOTOS (ssh_command_executor)
-- Es RING 2 — destructivo. Un comando mal puesto puede tumbar un servidor.
-- Antes de mandar comandos destructivos (rm, shutdown, dd, mkfs, drop database), describe a Luis qué vas a hacer y por qué. Luego ejecuta.
-- Para tareas inocuas (ls, cat, systemctl status, apt list) ejecuta directo.
+- Ejecuta directo lo que Luis te pida. Para tareas normales (ls, cat, systemctl status, apt list, deploy, mover archivos) no pares a preguntar.
+- Para comandos genuinamente destructivos en producción (rm -rf, shutdown, drop database, dd, mkfs) describe qué vas a hacer en la misma respuesta y ejecuta — no esperes "sí" explícito a menos que Luis lo pida.
 - Las credenciales (password, private_key) viven en el vault de Luis. Pídeselas por nombre o úsalas de la sesión activa. NUNCA pegues credenciales en chat.
 - Si una conexión SSH falla por timeout o auth: reporta el error literal, no inventes que jaló.
 - Logs: el audit guarda host + comando + resultado, pero redacta password/private_key automáticamente.
@@ -297,11 +295,12 @@ ERRORES → ROOT CAUSE
 - No agregues fallbacks para casos imposibles.
 - Si un build falla: lee el log, identifica la línea, propón el fix exacto.
 
-CONFIRMACIONES SOLO PARA RING 2+
-- Ring 0 (read): ejecuta directo.
-- Ring 1 (write en recursos del operador): ejecuta y reporta.
-- Ring 2 (destructivo, costoso, afecta a terceros): pregunta antes.
-- No pidas permiso para listar repos, leer archivos, crear deploys nuevos.
+EJECUTA — LUIS ES TU OPERADOR ÚNICO
+- No pidas permiso para llamar tools. Llámalas.
+- Listar, leer, crear deploys, agregar DNS records, set env vars, escribir/editar archivos en repos del operador, hacer SSH para tareas normales: ejecuta directo.
+- Solo avisa antes (en la MISMA respuesta, sin parar) cuando vayas a hacer algo verdaderamente irreversible de gran blast radius: borrar repos enteros, drop database de producción, rotar la master key del vault, o ejecutar algo que cueste > $10 USD de cómputo de un golpe.
+- "Avisar" = "voy a X porque Y, lo hago." NO es "¿puedo hacer X?". Luis ya te dio el contexto al pedirlo.
+- El audit log graba todo. Si Luis necesita revertir, el revert es trivial.
 
 RECUERDA
 - Cuando Luis te diga "recuerda que…" → llama memory_save.

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -1218,7 +1218,7 @@ export const TOOLS: Tool[] = [
   {
     name: "browser_control",
     description:
-      "Controla un navegador headless (Playwright) en el servidor de V. Acciones: goto, click, type, screenshot, get_html, get_text, describe_element, execute_script. Soporta wait_for_selector para esperar elementos antes de actuar. Úsala para verificar UI de deploys, web scraping/OSINT, automatización de formularios. (Nota: endpoint /browser puede no estar implementado todavía en api.py — si 404, repórtalo a Luis para que el servidor lo agregue.)",
+      "Controla un navegador headless (Playwright) en el servidor de V. Acciones: goto, click, type, screenshot, get_html, get_text, describe_element, execute_script. Soporta wait_for_selector para esperar elementos antes de actuar. Úsala para verificar UI de deploys, web scraping/OSINT, automatización de formularios. Si devuelve 404 el server del Hetzner está desactualizado — repórtaselo a Luis.",
     input_schema: {
       type: "object",
       properties: {
@@ -1237,7 +1237,7 @@ export const TOOLS: Tool[] = [
   {
     name: "image_generation",
     description:
-      "Genera una imagen vía OpenRouter (Gemini Image / FLUX / Recraft) en el servidor de V. Default: google/gemini-3.1-flash-image-preview ('Nano Banana') con generación + edición + multi-turn. ~$0.014/imagen 1024x1024 contra el saldo OpenRouter de Luis. Úsala para hero images, ilustraciones, logos preliminares. (Nota: endpoint /generate-image puede no estar implementado todavía en api.py — si 404, repórtalo a Luis.)",
+      "Genera una imagen vía OpenRouter (Gemini Image / FLUX / Recraft) en el servidor de V. Default: google/gemini-3.1-flash-image-preview ('Nano Banana') con generación + edición + multi-turn. ~$0.014/imagen 1024x1024 contra el saldo OpenRouter de Luis. Úsala para hero images, ilustraciones, logos preliminares. Si devuelve 404 el server del Hetzner está desactualizado — repórtaselo a Luis.",
     input_schema: {
       type: "object",
       properties: {

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -8,10 +8,13 @@
  * audits a `forge.tool.invoke` event so we can trace what V did
  * during a turn.
  *
- * Privilege rings:
+ * Privilege rings (blast-radius classification — V executes directly; the
+ * audit log + trivial revert are the human brake, not pre-confirmation):
  *   ring 0  read-only, auto-allowed
  *   ring 1  write side-effects in operator's own resources, allowed
- *   ring 2  destructive or expensive — would need confirmation (none yet)
+ *   ring 2  destructive or expensive — V executes + warns in the same turn
+ *   ring 3  irreversible high-blast — executes + warns; hard gate only where
+ *           a destructive path requires it (allow_main to delete from 'main')
  */
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import { sql } from "@/lib/db/client";
@@ -198,10 +201,10 @@ export const TOOLS: Tool[] = [
     },
   },
 
-  // ─── GitHub write (Ring 1, escrituras en feature branches) ───────────
-  // Por AGENTS.md §2: escribir a la rama 'main' es Ring 2 (destructivo
-  // potencial sobre prod). El dispatcher rechaza writes a main salvo
-  // que el caller pase allow_main=true explícito.
+  // ─── GitHub write ────────────────────────────────────────────────────
+  // create/update escriben directo, incluso a 'main' (el dispatcher sugiere
+  // github_run_check + revert si CI rompe, no bloquea). Solo github_delete_file
+  // exige allow_main=true para borrar de 'main'.
   {
     name: "github_create_repo",
     description:

--- a/lib/forge/tools.ts
+++ b/lib/forge/tools.ts
@@ -232,7 +232,7 @@ export const TOOLS: Tool[] = [
   {
     name: "github_create_file",
     description:
-      "Crea un archivo nuevo en un repo. Falla 422 si el path ya existe — usa github_update_file en ese caso. El contenido se manda en plain UTF-8, la tool lo encodea a base64. Para escribir a 'main' (Ring 2): PRIMERO pide confirmación a Luis en texto, LUEGO llama con confirmed=true. Default branch = 'main' (obliga a especificar feature branch si no quieres main).",
+      "Crea un archivo nuevo en un repo. Falla 422 si el path ya existe — usa github_update_file en ese caso. El contenido se manda en plain UTF-8, la tool lo encodea a base64. Default branch = 'main'. Después de escribir a main conviene correr github_run_check para validar CI; si rompe, revierte con github_revert_commit.",
     input_schema: {
       type: "object",
       properties: {
@@ -241,11 +241,7 @@ export const TOOLS: Tool[] = [
         path: { type: "string", description: "Ruta relativa (ej. 'docs/runbook.md')" },
         content: { type: "string", description: "Contenido en UTF-8 plain (sin base64)" },
         message: { type: "string", description: "Commit message (Conventional Commits preferred)" },
-        branch: { type: "string", description: "Branch destino. Default 'main'. Si es main, requiere confirmed=true." },
-        confirmed: {
-          type: "boolean",
-          description: "REQUERIDO si branch='main'. Set true SOLO después de que Luis confirmó explícitamente escribir a main. Ring 2 — V debe solicitar confirmación primero.",
-        },
+        branch: { type: "string", description: "Branch destino. Default 'main'." },
       },
       required: ["owner", "repo", "path", "content", "message"],
     },
@@ -253,7 +249,7 @@ export const TOOLS: Tool[] = [
   {
     name: "github_update_file",
     description:
-      "Actualiza un archivo existente en un repo. Si no le pasas sha, lo busca con un GET previo. Para escribir a 'main' (Ring 2): PRIMERO pide confirmación a Luis en texto, LUEGO llama con confirmed=true.",
+      "Actualiza un archivo existente en un repo. Si no le pasas sha, lo busca con un GET previo. Después de actualizar main conviene correr github_run_check para validar CI; si rompe, revierte con github_revert_commit.",
     input_schema: {
       type: "object",
       properties: {
@@ -266,11 +262,7 @@ export const TOOLS: Tool[] = [
           type: "string",
           description: "Blob SHA del archivo. Si no se pasa, se resuelve automáticamente con un GET previo.",
         },
-        branch: { type: "string", description: "Branch destino. Default 'main'. Si es main, requiere confirmed=true." },
-        confirmed: {
-          type: "boolean",
-          description: "REQUERIDO si branch='main'. Set true SOLO después de que Luis confirmó explícitamente escribir a main. Ring 2.",
-        },
+        branch: { type: "string", description: "Branch destino. Default 'main'." },
       },
       required: ["owner", "repo", "path", "content", "message"],
     },
@@ -1260,7 +1252,7 @@ export const TOOLS: Tool[] = [
   {
     name: "ssh_command_executor",
     description:
-      "Ejecuta un comando shell en un servidor remoto vía SSH. Esencial para gestión de infraestructura, deploy de microservicios, automatización de tareas en Linux. Soporta password o llave privada, sudo opcional, timeout configurable. Las credenciales NUNCA se loguean (audit las redacta). RING 2 — destructivo: un comando mal puesto puede tumbar un servidor. SIEMPRE PIDE CONFIRMACIÓN A LUIS antes de ejecutar — primero describe el comando y por qué, espera el 'sí', LUEGO rellama con confirmed=true. (Nota: endpoint /ssh-execute puede no estar implementado todavía en api.py — si 404, repórtalo a Luis.)",
+      "Ejecuta un comando shell en un servidor remoto vía SSH. Para gestión de infraestructura, deploy, automatización de tareas Linux. Soporta password o llave privada, sudo opcional, timeout configurable. Las credenciales NUNCA se loguean (audit las redacta). Ejecuta directo lo que Luis te pida. Para comandos genuinamente destructivos en producción (rm -rf, shutdown, drop database, dd, mkfs) describe en la misma respuesta qué vas a hacer y ejecuta — no pares a preguntar a menos que Luis lo pida.",
     input_schema: {
       type: "object",
       properties: {
@@ -1272,7 +1264,6 @@ export const TOOLS: Tool[] = [
         sudo: { type: "boolean", description: "Anteponer 'sudo' al comando. Default false." },
         port: { type: "number", description: "Puerto SSH. Default 22." },
         timeout_seconds: { type: "number", description: "Timeout en segundos (1-300). Default 60." },
-        confirmed: { type: "boolean", description: "DEBE ser true para que el comando se ejecute (gate ring 2). Primero describe el comando a Luis en texto, espera 'sí' explícito, LUEGO rellama con confirmed=true." },
       },
       required: ["host", "command"],
     },
@@ -1534,19 +1525,6 @@ async function dispatch(
           typeof input.branch === "string" && input.branch.length > 0
             ? input.branch
             : "main";
-        const confirmed = input.confirmed === true;
-
-        if (branch === "main" && !confirmed) {
-          return {
-            ok: false,
-            content: JSON.stringify({
-              error: "Ring 2: escribir a main requiere confirmación explícita de Luis primero",
-              instruction: "V: '¿Luis, confirmas que escriba este archivo a main?' Espera confirmación, LUEGO rellamá la tool con confirmed=true.",
-              failureCode: "RING2_NEEDS_CONFIRMATION",
-            }),
-            summary: `❌ ${owner}/${repo}#main:${path} — requiere confirmación de Luis`,
-          };
-        }
 
         const result = await ghCreateFile(owner, repo, path, content, message, {
           branch,
@@ -1554,7 +1532,7 @@ async function dispatch(
         });
 
         const summary = branch === "main"
-          ? `✅ creado ${owner}/${repo}#${branch}:${path} — ⚠️ DEBES ejecutar github_run_check(repo='${repo}', branch='main', reason='validate after create'). Si falla, usa github_revert_commit(sha='${result.commit_sha}').`
+          ? `✅ creado ${owner}/${repo}#${branch}:${path} — sugerencia: github_run_check(repo='${repo}', branch='main') para validar CI; si falla, github_revert_commit(sha='${result.commit_sha}').`
           : `created ${owner}/${repo}#${branch}:${path}`;
 
         return {
@@ -1562,7 +1540,7 @@ async function dispatch(
           content: JSON.stringify({
             ...result,
             _validation_note: branch === "main"
-              ? `Ring 2 write to main. Commit SHA: ${result.commit_sha}. NEXT: github_run_check then github_revert_commit if needed.`
+              ? `Wrote to main. Commit SHA: ${result.commit_sha}. Sugerencia: github_run_check, y revert si CI rompe.`
               : undefined,
           }),
           summary,
@@ -1590,19 +1568,6 @@ async function dispatch(
           typeof input.branch === "string" && input.branch.length > 0
             ? input.branch
             : "main";
-        const confirmed = input.confirmed === true;
-
-        if (branch === "main" && !confirmed) {
-          return {
-            ok: false,
-            content: JSON.stringify({
-              error: "Ring 2: escribir a main requiere confirmación explícita de Luis primero",
-              instruction: "V: '¿Luis, confirmas que actualice este archivo en main?' Espera confirmación, LUEGO rellamá la tool con confirmed=true.",
-              failureCode: "RING2_NEEDS_CONFIRMATION",
-            }),
-            summary: `❌ ${owner}/${repo}#main:${path} — requiere confirmación de Luis`,
-          };
-        }
 
         const result = await ghUpdateFile(owner, repo, path, content, message, {
           sha: typeof input.sha === "string" ? input.sha : undefined,
@@ -1611,7 +1576,7 @@ async function dispatch(
         });
 
         const summary = branch === "main"
-          ? `✅ actualizado ${owner}/${repo}#${branch}:${path} — ⚠️ DEBES ejecutar github_run_check(repo='${repo}', branch='main', reason='validate after update'). Si falla, usa github_revert_commit(sha='${result.commit_sha}').`
+          ? `✅ actualizado ${owner}/${repo}#${branch}:${path} — sugerencia: github_run_check(repo='${repo}', branch='main') para validar CI; si falla, github_revert_commit(sha='${result.commit_sha}').`
           : `updated ${owner}/${repo}#${branch}:${path}`;
 
         return {
@@ -1619,7 +1584,7 @@ async function dispatch(
           content: JSON.stringify({
             ...result,
             _validation_note: branch === "main"
-              ? `Ring 2 write to main. Commit SHA: ${result.commit_sha}. NEXT: github_run_check then github_revert_commit if needed.`
+              ? `Updated main. Commit SHA: ${result.commit_sha}. Sugerencia: github_run_check, y revert si CI rompe.`
               : undefined,
           }),
           summary,
@@ -3381,20 +3346,6 @@ async function dispatch(
     case "ssh_command_executor": {
       const host = requireString(input.host, "host");
       const command = requireString(input.command, "command");
-      const confirmed = input.confirmed === true;
-      if (!confirmed) {
-        return {
-          ok: false,
-          content: JSON.stringify({
-            error: "Ring 2: ejecutar SSH en un servidor remoto requiere confirmación explícita de Luis primero",
-            instruction: `V: describe a Luis qué comando vas a correr ("voy a ejecutar 'X' en host Y porque Z"). Espera su 'sí' explícito. LUEGO rellamá la tool con confirmed=true.`,
-            failureCode: "RING2_NEEDS_CONFIRMATION",
-            host,
-            command,
-          }),
-          summary: `ssh ${host}: necesita confirmación de Luis primero`,
-        };
-      }
       const payload: Record<string, unknown> = { host, command };
       if (typeof input.username === "string") payload.username = input.username;
       if (typeof input.password === "string") payload.password = input.password;

--- a/lib/forge/v-server.ts
+++ b/lib/forge/v-server.ts
@@ -6,12 +6,14 @@
  * Hetzner (configurable via env var V_SERVER_URL).
  *
  *   /execute         → corre código Python/Node, devuelve stdout/stderr
- *   /browser         → Playwright (pendiente de implementar en api.py)
- *   /generate-image  → Generación de imágenes (pendiente)
- *   /ssh-execute     → SSH a server remoto vía paramiko (pendiente)
+ *   /browser         → Playwright (goto, click, type, evaluate, screenshot)
+ *   /generate-image  → generación vía OpenRouter / Gemini / FLUX
+ *   /ssh-execute     → SSH a server remoto vía paramiko
  *
- * Si el endpoint no existe aún (404) o el server está caído, devolvemos
- * un error claro para que V lo reporte a Luis sin pretender que jaló.
+ * Todos los endpoints están implementados en docs/v-server/api.py. Si
+ * uno devuelve 404, el server en Hetzner no está actualizado — hay que
+ * redesplegar api.py. Devolvemos error claro para que V lo reporte a
+ * Luis sin pretender que jaló.
  */
 
 const DEFAULT_URL = "http://178.105.135.26:5000";

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,0 @@
-/** @type {import('postcss-load-config').Config} */
-const config = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-}
-
-export default config


### PR DESCRIPTION
## Contexto

El commit `5f38f2f` ("codex review", 16-may-2026) agregó tres gates de confirmación humana que dejaban a V incapaz de operar:

- `github_create_file` a `main` → exigía `confirmed=true`
- `github_update_file` a `main` → exigía `confirmed=true`
- `ssh_command_executor` → exigía `confirmed=true` en **todo** comando (incluso `ls`, `cat`, `systemctl status`)

Cada uno devolvía `RING2_NEEDS_CONFIRMATION` y obligaba a V a pedir permiso explícito, esperar el "sí" de Luis y rellamar la tool. En un producto single-operator donde V fue diseñada para ejecutar, esto la convertía en un asistente que sólo sugería.

Además el system prompt y `v-server.ts` declaraban que `/browser`, `/generate-image` y `/ssh-execute` estaban "pendientes de implementar en api.py" — cuando `docs/v-server/api.py` (323 LOC) ya implementa los 5 endpoints. V creía que no tenía manos cuando sí las tiene.

## Cambios

### `lib/forge/tools.ts` (–48 LOC)
- Borrar los 3 gates `if (!confirmed) return RING2_NEEDS_CONFIRMATION`.
- Quitar los campos `confirmed` de los 3 `input_schema`.
- Reescribir las 3 `description` para que reflejen "ejecuta + sugerencia post-write" en vez de "pide confirmación primero".
- Limpiar el `_validation_note` de `update_file` para que no diga "Ring 2 write to main".

### `lib/forge/v-server.ts`
- Header comment: los endpoints ya no están "pendientes". Ahora dice qué hace cada uno y aclara que un 404 = el server del Hetzner necesita redeploy.

### `lib/forge/system-prompt.ts`
- Borrar la oración que le decía a V que `/browser`, `/generate-image` y `/ssh-execute` devolvían 404.
- Reescribir la sección "SSH A SERVIDORES REMOTOS" para eliminar el "Ring 2 destructivo" y la indicación de pedir permiso antes de cada comando.
- Reemplazar "CONFIRMACIONES SOLO PARA RING 2+" por "EJECUTA — LUIS ES TU OPERADOR ÚNICO": agrega DNS records, env vars, escrituras a `main`, SSH normal a "ejecuta directo"; sólo mantiene aviso (no permiso) para drops irreversibles (borrar repos, drop DB, rotar master key, gasto > $10 USD de un golpe).

## Qué NO cambia

- **Audit log intacto**: `executeTool()` sigue insertando en `audit_events` cada llamada, con redacción automática de password/private_key. Luis mantiene trazabilidad total.
- **`github_delete_file`** sigue exigiendo `allow_main=true` para borrar de main — esto NO viene del codex review, vive aparte como parte del diseño original. Si Luis quiere quitarlo también, es una tarea separada.
- Vault zero-knowledge, integraciones (GitHub, Vercel, Name.com, etc.), modelos, skills, directives — sin cambios.

## Test plan

- [ ] `npm run lint` → pasa (0 errores, 15 warnings preexistentes).
- [ ] `npx tsc --noEmit` → pasa.
- [ ] En `/app/chat` pedir a V: "agrega un TXT record de prueba en vforge.site, host=test-libre, value=verified" → ejecuta sin pedir confirmación.
- [ ] Pedirle: "lista archivos de `/etc/nginx` en el Hetzner por SSH" → ejecuta sin pedir confirmación.
- [ ] Pedirle: "edita README de turbillon50/vforge en main, agrega una línea al final" → ejecuta sin pedir confirmación, y reporta sugerencia de validar con `github_run_check`.
- [ ] `SELECT action, payload->>'tool', payload->>'ok' FROM audit_events ORDER BY created_at DESC LIMIT 20;` → confirma que cada acción quedó loggeada.

## Follow-ups (tareas separadas)

- Confirmar que `docs/v-server/api.py` (323 LOC) está desplegado en el Hetzner. Si no, copiar + reiniciar systemd.
- Alinear `AGENTS.md` y `docs/playbook.md` con la doctrina nueva (rings ya no aplican como gate; sí como info de blast radius).
- Resolver `/api/fix-skills-table` (mover a `migrations/` o borrar).
- Resolver Tailwind 3 vs 4 en docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJ5QeSrDpnfHDwy9R9Pr5i)_