### PR TITLE
fix(projects): regex seguro en initials() - crash pantalla blanca

### DIFF
--- a/app/app/projects/page.tsx
+++ b/app/app/projects/page.tsx
@@ -45,7 +45,7 @@ const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
 
 function initials(name: string): string {
   return name
-    .split(/[s-_]+/)
+    .split(/ +|-+|_+/)
     .slice(0, 2)
     .map((w) => w[0]?.toUpperCase() ?? "")
     .join("");


### PR DESCRIPTION
Fix: el regex /[s-_]+/ era invalido (rango fuera de orden). Reemplazado por / +|-+|_+/ equivalente. Causaba SyntaxError que crasheaba la pagina entera.