### PR TITLE
Ensamblador: ship + verify-loop + /api/forja/loop (candado: unificar motor de publicación)

### DIFF
--- a/app/api/builder/route.ts
+++ b/app/api/builder/route.ts
@@ -5,8 +5,9 @@
  * GET  ?buildId=...           → { build, versions }
  * POST { action, ... }        → feedback | like | approve
  *
- * approve hoy solo marca approved_version y devuelve { next: 'ship-pending' };
- * el pipeline repo+vercel llega después.
+ * approve publica de verdad: push del snapshot de archivos al GitHub del
+ * usuario (repo nuevo o commit encima del existente) + deploy directo a
+ * su Vercel. Ver lib/builder/ship.ts.
  */
 import { auth } from "@clerk/nextjs/server";
 import {
@@ -18,6 +19,7 @@ import {
   setFeedback,
   approveVersion,
 } from "@/lib/builder/db";
+import { shipBuildVersion } from "@/lib/builder/ship";
 import { saveUserMemory } from "@/lib/forge/user-memory";
 
 export const runtime = "nodejs";
@@ -95,17 +97,26 @@ export async function POST(req: Request) {
       return Response.json({ ok: true, version: v });
     }
     case "approve": {
-      const version = body.versionId ? await getVersion(body.versionId) : null;
+      let version = body.versionId ? await getVersion(body.versionId) : null;
       const buildId = body.buildId ?? version?.build_id;
       const n = body.n ?? version?.n;
       if (!buildId || typeof n !== "number") {
         return jsonError("buildId + n (o versionId) required", 400);
       }
+      if (!version) {
+        version = (await listVersions(buildId)).find((v) => v.n === n) ?? null;
+      }
       const build = await approveVersion(buildId, n);
       if (!build) return jsonError("build not found", 404);
-      // El pipeline real (repo GitHub + deploy Vercel) llega después;
-      // por ahora dejamos el build aprobado y avisamos al cliente.
-      return Response.json({ ok: true, build, next: "ship-pending" });
+      if (!version?.files?.length) {
+        return Response.json({ ok: false, build, error: "no_files" }, { status: 400 });
+      }
+      // Publica de verdad: push a GitHub del usuario + deploy a su Vercel.
+      const ship = await shipBuildVersion(uid, build, version.files);
+      if (!ship.ok) {
+        return Response.json({ ok: false, build, error: ship.error, detail: ship.detail }, { status: 400 });
+      }
+      return Response.json({ ok: true, build, repo: ship.repo, deploy: ship.deploy });
     }
     case "scaffold-request":
     case "deploy-request": {

--- a/app/api/forja/loop/route.ts
+++ b/app/api/forja/loop/route.ts
@@ -1,0 +1,35 @@
+/**
+ * POST /api/forja/loop — una iteración del bucle ver→arreglar→verificar.
+ * Body: { url, project_id }. Owner-only (mismo criterio que el resto de la Forja).
+ *
+ * Navega con Vulcano a `url`, lee lo que renderiza, y si detecta una falla
+ * conocida, encola un fix en el Ojo con el texto observado como contexto.
+ * No espera el fix: el caller debe volver a llamar este endpoint después
+ * de que el job termine y la versión se republique (vía /api/builder
+ * approve), para confirmar que ya quedó sano.
+ */
+import { isOwnerRequest } from "@/lib/forja/ojo";
+import { runVerifyIteration } from "@/lib/forja/verify-loop";
+import { safeHttpUrl } from "@/lib/forja/browser";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  if (!(await isOwnerRequest())) {
+    return Response.json({ error: "forbidden" }, { status: 403 });
+  }
+  let body: { url?: string; project_id?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "json_invalido" }, { status: 400 });
+  }
+  const url = safeHttpUrl(body.url);
+  if (!url) return Response.json({ error: "url_invalida" }, { status: 400 });
+  const projectId = String(body.project_id ?? "").trim();
+  if (!projectId) return Response.json({ error: "project_id_requerido" }, { status: 400 });
+
+  const result = await runVerifyIteration(url, projectId);
+  return Response.json(result, { status: result.ok ? 200 : 502 });
+}

--- a/app/api/navegador/control/route.ts
+++ b/app/api/navegador/control/route.ts
@@ -5,61 +5,13 @@ export const dynamic = "force-dynamic";
 // Control del navegador visible (Chrome 138 vía VNC) en el contenedor
 // docker 'vulcano-browser' de Hetzner. Se maneja con CDP (puerto 9222
 // DENTRO del contenedor) a través del relay Hetzner /brain/exec.
+// Helpers compartidos con el bucle ver→arreglar→verificar en lib/forja/browser.ts.
 import { currentUser } from "@clerk/nextjs/server";
 import { isOwnerUser } from "@/lib/auth/owner";
 import { NextResponse } from "next/server";
-
-const RELAY = "http://178.105.135.26";
-const SECRET = process.env.BRAIN_SECRET ?? "";
-const CONTAINER = "vulcano-browser";
-const CDP = "http://localhost:9222";
+import { CONTAINER, CDP, relayExec, safeHttpUrl, cdpControl } from "@/lib/forja/browser";
 
 type Action = "navigate" | "tabs" | "close" | "eval" | "click" | "type" | "read";
-
-/** Ejecuta un cmd en Hetzner vía el relay y devuelve el stdout (texto). */
-async function relayExec(cmd: string): Promise<string> {
-  const res = await fetch(`${RELAY}/brain/exec`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ secret: SECRET, cmd }),
-    cache: "no-store",
-  });
-  if (!res.ok) {
-    throw new Error(`relay HTTP ${res.status}`);
-  }
-  const data = await res.json().catch(() => ({}));
-  // El relay devuelve el stdout en alguno de estos campos según versión.
-  const out =
-    (data?.stdout ?? data?.output ?? data?.result ?? data?.data ?? "") as unknown;
-  return typeof out === "string" ? out : JSON.stringify(out);
-}
-
-/** Acepta solo URLs http/https — evita inyección de comandos por la url. */
-function safeHttpUrl(raw: unknown): string | null {
-  if (typeof raw !== "string") return null;
-  const url = raw.trim();
-  if (!/^https?:\/\//i.test(url)) return null;
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
-    return parsed.toString();
-  } catch {
-    return null;
-  }
-}
-
-
-/** Llama al controlador CDP (cdp_control.py) dentro del contenedor con un comando JSON. */
-async function cdpControl(payload: Record<string, unknown>): Promise<unknown> {
-  const json = JSON.stringify(payload).replace(/'/g, "'\\''");
-  const cmd = `docker exec ${CONTAINER} python3 /home/kasm-user/cdp_control.py '${json}'`;
-  const stdout = await relayExec(cmd);
-  try {
-    return JSON.parse(stdout.trim());
-  } catch {
-    return { ok: false, raw: stdout };
-  }
-}
 
 export async function POST(req: Request) {
   // Auth: solo owners.

--- a/components/workspace/chat/VersionCard.tsx
+++ b/components/workspace/chat/VersionCard.tsx
@@ -17,6 +17,12 @@ type VersionMeta = {
   liked?: boolean | null;
 };
 
+const SHIP_ERRORS: Record<string, string> = {
+  connect_github: "Conecta tu GitHub en Integraciones para publicar.",
+  connect_vercel: "Conecta tu Vercel en Integraciones para publicar.",
+  no_files: "Esta versión no tiene archivos para publicar.",
+};
+
 export default function VersionCard({
   buildId,
   versionId,
@@ -37,7 +43,9 @@ export default function VersionCard({
   const [active, setActive] = useState<VersionMeta>({ id: versionId, n, summary });
   const [liked, setLiked] = useState(false);
   const [confirmShip, setConfirmShip] = useState(false);
-  const [shipped, setShipped] = useState(false);
+  const [shipping, setShipping] = useState(false);
+  const [shipped, setShipped] = useState<{ repoUrl: string; deployUrl: string | null } | null>(null);
+  const [shipError, setShipError] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
   const [visible, setVisible] = useState(false);
   const frameHostRef = useRef<HTMLDivElement>(null);
@@ -99,15 +107,24 @@ export default function VersionCard({
 
   const ship = useCallback(async () => {
     setConfirmShip(false);
+    setShipping(true);
+    setShipError(null);
     try {
       const res = await fetch("/api/builder", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action: "approve", versionId: active.id }),
       });
-      if (res.ok) setShipped(true);
+      const data = await res.json();
+      if (res.ok && data.ok) {
+        setShipped({ repoUrl: data.repo?.url ?? null, deployUrl: data.deploy?.url ?? null });
+      } else {
+        setShipError(SHIP_ERRORS[data.error] ?? "No se pudo publicar. Intenta de nuevo.");
+      }
     } catch {
-      /* best-effort */
+      setShipError("No se pudo publicar. Intenta de nuevo.");
+    } finally {
+      setShipping(false);
     }
   }, [active.id]);
 
@@ -184,7 +201,29 @@ export default function VersionCard({
 
       {/* Acciones */}
       <div className="flex flex-wrap items-center gap-1.5 px-3 py-2.5">
-        {confirmShip ? (
+        {shipped ? (
+          <div className="flex w-full animate-[fadeIn_0.4s_ease-out] flex-wrap items-center gap-2 rounded-xl border border-emerald-400/25 bg-emerald-500/[0.08] px-3 py-2 text-[13px] shadow-[0_0_24px_-8px_rgba(52,211,153,0.5)]">
+            <span className="text-emerald-300">✦ Publicado</span>
+            {shipped.deployUrl && (
+              <a
+                href={shipped.deployUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="flex h-9 items-center gap-1.5 rounded-lg bg-emerald-500/20 px-3 font-medium text-emerald-200 transition hover:bg-emerald-500/30"
+              >
+                Ver sitio en vivo ↗
+              </a>
+            )}
+            <a
+              href={shipped.repoUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex h-9 items-center gap-1.5 rounded-lg px-3 text-on-surface-variant transition hover:bg-[var(--surface-2)] hover:text-[var(--fg-primary)]"
+            >
+              Ver repo ↗
+            </a>
+          </div>
+        ) : confirmShip ? (
           <div className="flex items-center gap-2 rounded-xl bg-[var(--surface-1)] px-3 py-1.5 text-[13px] text-on-surface">
             ¿Publico la versión {active.n}?
             <button
@@ -201,6 +240,14 @@ export default function VersionCard({
             >
               No
             </button>
+          </div>
+        ) : shipping ? (
+          <div className="flex items-center gap-2 rounded-xl bg-[var(--surface-1)] px-3 py-2 text-[13px] text-on-surface-variant">
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-violet-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-violet-400" />
+            </span>
+            Empujando a tu GitHub y desplegando en tu Vercel…
           </div>
         ) : (
           <>
@@ -219,11 +266,13 @@ export default function VersionCard({
             />
             <CardAction
               icon={<IconRocket size={14} />}
-              label={shipped ? "Lista para publicar" : "Publicar"}
-              active={shipped}
-              onClick={() => !shipped && setConfirmShip(true)}
+              label="Publicar"
+              onClick={() => setConfirmShip(true)}
             />
           </>
+        )}
+        {shipError && (
+          <p className="w-full text-[12px] text-red-300">{shipError}</p>
         )}
       </div>
 

--- a/lib/builder/db.ts
+++ b/lib/builder/db.ts
@@ -184,3 +184,18 @@ export async function approveVersion(
   );
   return rows[0] ?? null;
 }
+
+/** Marca el build como publicado de verdad: repo + deploy ya existen. */
+export async function markBuildShipped(
+  buildId: string,
+  info: { repo_full_name: string; vercel_project_id: string },
+): Promise<Build | null> {
+  await ensureTables();
+  const rows = await queryAll<Build>(
+    `UPDATE vforge_builds
+        SET repo_full_name = $2, vercel_project_id = $3, status = 'shipped', updated_at = now()
+      WHERE id = $1 RETURNING *`,
+    [buildId, info.repo_full_name, info.vercel_project_id],
+  );
+  return rows[0] ?? null;
+}

--- a/lib/builder/ship.ts
+++ b/lib/builder/ship.ts
@@ -1,0 +1,201 @@
+/**
+ * Ship real de un build del ensamblador: toma los archivos generados por V
+ * (vforge_build_versions.files) y los publica en la cuenta DEL USUARIO —
+ * su GitHub, su Vercel. Nada se queda en VForge (a diferencia de Replit).
+ *
+ * - Repo nuevo: crea el repo, sube todos los archivos en un solo commit
+ *   (Git Data API: blobs → tree → commit → ref), evitando el límite de
+ *   PUT /contents por archivo y las condiciones de carrera de conflictos.
+ * - Repo existente: agrega un commit encima del HEAD actual con el mismo
+ *   snapshot completo de archivos (los builds representan el estado final,
+ *   no un diff).
+ * - Deploy: sube los mismos archivos directo a Vercel (sin vincular git),
+ *   igual que /api/forja/ship — deploy inmediato sin esperar un webhook.
+ */
+import { getUserSecret } from "@/lib/connect/user-vault";
+import { saveUserApp } from "@/lib/connect/user-apps";
+import type { Build, BuildFile } from "@/lib/builder/db";
+import { markBuildShipped } from "@/lib/builder/db";
+
+export type ShipResult =
+  | { ok: true; repo: { url: string; full: string }; deploy: { url: string | null; id?: string } }
+  | { ok: false; error: string; detail?: unknown };
+
+function slugify(s: string): string {
+  return (
+    (s || "mi-app")
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 50) || "mi-app"
+  );
+}
+
+function gh(path: string, token: string, init: RequestInit = {}) {
+  return fetch("https://api.github.com" + path, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "vforge",
+      "Content-Type": "application/json",
+      ...(init.headers || {}),
+    },
+  });
+}
+
+/** Sube `files` como UN commit al branch por defecto de owner/repo. */
+async function pushFilesAsCommit(
+  owner: string,
+  repo: string,
+  token: string,
+  files: BuildFile[],
+  message: string,
+): Promise<{ ok: true } | { ok: false; error: string; detail?: unknown }> {
+  const repoRes = await gh(`/repos/${owner}/${repo}`, token);
+  if (!repoRes.ok) return { ok: false, error: "repo_not_found", detail: await repoRes.text() };
+  const repoInfo = await repoRes.json();
+  const branch = repoInfo.default_branch || "main";
+
+  const refRes = await gh(`/repos/${owner}/${repo}/git/ref/heads/${branch}`, token);
+  if (!refRes.ok) return { ok: false, error: "ref_not_found", detail: await refRes.text() };
+  const baseCommitSha = (await refRes.json()).object.sha as string;
+
+  const commitRes = await gh(`/repos/${owner}/${repo}/git/commits/${baseCommitSha}`, token);
+  if (!commitRes.ok) return { ok: false, error: "commit_not_found", detail: await commitRes.text() };
+  const baseTreeSha = (await commitRes.json()).tree.sha as string;
+
+  // Blobs en paralelo — cada archivo se sube como blob independiente del tree.
+  const blobs = await Promise.all(
+    files.map(async (f) => {
+      const b64 = Buffer.from(f.content ?? "", "utf8").toString("base64");
+      const r = await gh(`/repos/${owner}/${repo}/git/blobs`, token, {
+        method: "POST",
+        body: JSON.stringify({ content: b64, encoding: "base64" }),
+      });
+      if (!r.ok) throw new Error(`blob_failed:${f.path}`);
+      const j = await r.json();
+      return { path: f.path.replace(/^\/+/, ""), mode: "100644", type: "blob", sha: j.sha as string };
+    }),
+  );
+
+  const treeRes = await gh(`/repos/${owner}/${repo}/git/trees`, token, {
+    method: "POST",
+    body: JSON.stringify({ base_tree: baseTreeSha, tree: blobs }),
+  });
+  if (!treeRes.ok) return { ok: false, error: "tree_failed", detail: await treeRes.text() };
+  const newTreeSha = (await treeRes.json()).sha as string;
+
+  const newCommitRes = await gh(`/repos/${owner}/${repo}/git/commits`, token, {
+    method: "POST",
+    body: JSON.stringify({ message, tree: newTreeSha, parents: [baseCommitSha] }),
+  });
+  if (!newCommitRes.ok) return { ok: false, error: "commit_create_failed", detail: await newCommitRes.text() };
+  const newCommitSha = (await newCommitRes.json()).sha as string;
+
+  const updateRefRes = await gh(`/repos/${owner}/${repo}/git/refs/heads/${branch}`, token, {
+    method: "PATCH",
+    body: JSON.stringify({ sha: newCommitSha }),
+  });
+  if (!updateRefRes.ok) return { ok: false, error: "ref_update_failed", detail: await updateRefRes.text() };
+
+  return { ok: true };
+}
+
+async function deployToVercel(
+  slug: string,
+  files: BuildFile[],
+  vcToken: string,
+  vcTeam: string | null,
+): Promise<{ ok: true; url: string | null; id: string } | { ok: false; error: string; detail?: unknown }> {
+  const q = vcTeam ? `?teamId=${encodeURIComponent(vcTeam)}&forceNew=1` : `?forceNew=1`;
+  const res = await fetch("https://api.vercel.com/v13/deployments" + q, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${vcToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: slug,
+      target: "production",
+      projectSettings: { framework: null },
+      files: files.map((f) => ({ file: f.path.replace(/^\/+/, ""), data: f.content ?? "" })),
+    }),
+  });
+  const data = await res.json();
+  if (!res.ok) return { ok: false, error: "deploy_failed", detail: data };
+  return { ok: true, url: data.url ? `https://${data.url}` : null, id: data.id };
+}
+
+export async function shipBuildVersion(
+  userId: string,
+  build: Build,
+  files: BuildFile[],
+): Promise<ShipResult> {
+  if (!files.length) return { ok: false, error: "no_files" };
+
+  const ghToken = await getUserSecret(userId, "GITHUB_USER_TOKEN");
+  if (!ghToken) return { ok: false, error: "connect_github" };
+  const vcToken = await getUserSecret(userId, "VERCEL_USER_TOKEN");
+  if (!vcToken) return { ok: false, error: "connect_vercel" };
+  const vcTeam = await getUserSecret(userId, "VERCEL_TEAM_ID");
+
+  try {
+    let owner: string;
+    let repoName: string;
+    let repoUrl: string;
+
+    if (build.repo_full_name) {
+      [owner, repoName] = build.repo_full_name.split("/");
+      const push = await pushFilesAsCommit(owner, repoName, ghToken, files, `VForge: publicar versión aprobada`);
+      if (!push.ok) return { ok: false, error: push.error, detail: push.detail };
+      repoUrl = `https://github.com/${build.repo_full_name}`;
+    } else {
+      const meRes = await gh("/user", ghToken);
+      if (!meRes.ok) return { ok: false, error: "github_auth", detail: await meRes.text() };
+      owner = (await meRes.json()).login as string;
+      repoName = slugify(build.project_name) + "-" + Math.random().toString(36).slice(2, 6);
+
+      const createRes = await gh("/user/repos", ghToken, {
+        method: "POST",
+        body: JSON.stringify({
+          name: repoName,
+          description: `${build.project_name} — creada con VForge`,
+          private: false,
+          auto_init: true,
+        }),
+      });
+      if (!createRes.ok) return { ok: false, error: "repo_create", detail: await createRes.text() };
+      const created = await createRes.json();
+      repoUrl = created.html_url;
+
+      const push = await pushFilesAsCommit(owner, repoName, ghToken, files, "VForge: primera versión publicada");
+      if (!push.ok) return { ok: false, error: push.error, detail: push.detail };
+    }
+
+    const deploy = await deployToVercel(repoName, files, vcToken, vcTeam);
+    if (!deploy.ok) return { ok: false, error: deploy.error, detail: deploy.detail };
+
+    await markBuildShipped(build.id, {
+      repo_full_name: `${owner}/${repoName}`,
+      vercel_project_id: repoName,
+    });
+    try {
+      await saveUserApp(userId, {
+        name: build.project_name,
+        repo_url: repoUrl,
+        deploy_url: deploy.url,
+        template: "ensamblador",
+      });
+    } catch {
+      /* best-effort */
+    }
+
+    return {
+      ok: true,
+      repo: { url: repoUrl, full: `${owner}/${repoName}` },
+      deploy: { url: deploy.url, id: deploy.id },
+    };
+  } catch (e) {
+    return { ok: false, error: "exception", detail: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/lib/forja/browser.ts
+++ b/lib/forja/browser.ts
@@ -1,0 +1,77 @@
+/**
+ * Puente al navegador Vulcano (Chrome real vía CDP, dentro del contenedor
+ * docker 'vulcano-browser' en Hetzner, expuesto vía relay /brain/exec).
+ * Compartido entre /api/navegador/control (control manual) y el bucle
+ * ver→arreglar→verificar (lib/forja/verify-loop.ts).
+ */
+const RELAY = "http://178.105.135.26";
+const SECRET = process.env.BRAIN_SECRET ?? "";
+const CONTAINER = "vulcano-browser";
+const CDP = "http://localhost:9222";
+
+/** Ejecuta un cmd en Hetzner vía el relay y devuelve el stdout (texto). */
+export async function relayExec(cmd: string): Promise<string> {
+  const res = await fetch(`${RELAY}/brain/exec`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret: SECRET, cmd }),
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`relay HTTP ${res.status}`);
+  const data = await res.json().catch(() => ({}));
+  const out = (data?.stdout ?? data?.output ?? data?.result ?? data?.data ?? "") as unknown;
+  return typeof out === "string" ? out : JSON.stringify(out);
+}
+
+/** Acepta solo URLs http/https — evita inyección de comandos por la url. */
+export function safeHttpUrl(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const url = raw.trim();
+  if (!/^https?:\/\//i.test(url)) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** Llama al controlador CDP (cdp_control.py) dentro del contenedor con un comando JSON. */
+export async function cdpControl(payload: Record<string, unknown>): Promise<unknown> {
+  const json = JSON.stringify(payload).replace(/'/g, "'\\''");
+  const cmd = `docker exec ${CONTAINER} python3 /home/kasm-user/cdp_control.py '${json}'`;
+  const stdout = await relayExec(cmd);
+  try {
+    return JSON.parse(stdout.trim());
+  } catch {
+    return { ok: false, raw: stdout };
+  }
+}
+
+export async function browserNavigate(url: string): Promise<unknown> {
+  const safe = safeHttpUrl(url);
+  if (!safe) throw new Error("url inválida (solo http/https)");
+  const cmd = `docker exec ${CONTAINER} curl -s -X PUT "${CDP}/json/new?${encodeURIComponent(safe)}"`;
+  const stdout = await relayExec(cmd);
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return stdout;
+  }
+}
+
+export async function browserReadBody(): Promise<string> {
+  const result = await cdpControl({
+    action: "eval",
+    expr: "document.body ? document.body.innerText.slice(0, 4000) : ''",
+  });
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object" && "result" in result) {
+    const r = (result as { result?: unknown }).result;
+    return typeof r === "string" ? r : JSON.stringify(r);
+  }
+  return JSON.stringify(result);
+}
+
+export { CONTAINER, CDP };

--- a/lib/forja/verify-loop.ts
+++ b/lib/forja/verify-loop.ts
@@ -1,0 +1,102 @@
+/**
+ * El puente "ver → pegar → arreglar": une el navegador Vulcano (ojos —
+ * carga la URL real y lee lo que renderiza) con el Ojo (manos — agente
+ * que escribe el fix). Una iteración = navega, lee, decide si hay falla,
+ * y si la hay, encola una tarea de arreglo con el texto observado como
+ * contexto. El caller (frontend, o un loop automático) vuelve a llamar
+ * después de que el fix se publique, para reverificar.
+ *
+ * Límite conocido: `browserReadBody` lee el DOM ya renderizado, no la
+ * consola. Errores no visuales (excepciones atrapadas, fallos de red que
+ * no rompen el render) no se detectan todavía — eso requiere que
+ * cdp_control.py en Hetzner exponga Log/Runtime de CDP, fuera de este repo.
+ */
+import { browserNavigate, browserReadBody } from "@/lib/forja/browser";
+import { ojoPost } from "@/lib/forja/ojo";
+
+export interface VerifyResult {
+  ok: boolean;
+  healthy: boolean;
+  observedText: string;
+  issue: string | null;
+  dispatchedJobId?: number;
+  error?: string;
+}
+
+const FAILURE_SIGNATURES: Array<{ match: RegExp; label: string }> = [
+  { match: /application error.*client-side exception/i, label: "excepción de cliente (Next.js error boundary)" },
+  { match: /this page could not be found/i, label: "404 — página no encontrada" },
+  { match: /internal server error/i, label: "500 — error interno" },
+  { match: /unhandled runtime error/i, label: "runtime error sin capturar" },
+  { match: /cannot read propert(y|ies) of undefined/i, label: "excepción JS: propiedad de undefined" },
+  { match: /hydration failed/i, label: "fallo de hidratación React" },
+];
+
+function detectIssue(text: string): string | null {
+  const trimmed = text.trim();
+  if (trimmed.length < 8) return "página vacía o en blanco";
+  for (const { match, label } of FAILURE_SIGNATURES) {
+    if (match.test(trimmed)) return label;
+  }
+  return null;
+}
+
+/** Corre UNA iteración del bucle contra `url`. No espera al fix — solo lo encola. */
+export async function runVerifyIteration(
+  url: string,
+  projectId: string,
+): Promise<VerifyResult> {
+  try {
+    await browserNavigate(url);
+    // Deja que la página termine de montar antes de leer.
+    await new Promise((r) => setTimeout(r, 1500));
+    const observedText = await browserReadBody();
+    const issue = detectIssue(observedText);
+
+    if (!issue) {
+      return { ok: true, healthy: true, observedText, issue: null };
+    }
+
+    const prompt = [
+      `Verificación automática de ${url} encontró un problema: ${issue}.`,
+      `Esto es lo que el navegador ve renderizado en la página (recórtalo si es ruido):`,
+      "---",
+      observedText.slice(0, 1500),
+      "---",
+      `Corrige el problema en el proyecto ${projectId} y deja el código listo para republicar.`,
+    ].join("\n");
+
+    const dispatchRes = await ojoPost("nueva", {
+      agent: "claude",
+      project_id: projectId,
+      prompt,
+      priority: 3,
+    });
+    const dispatchJson = await dispatchRes.json().catch(() => ({}));
+    if (!dispatchRes.ok || !dispatchJson?.id) {
+      return {
+        ok: false,
+        healthy: false,
+        observedText,
+        issue,
+        error: dispatchJson?.error ?? "no se pudo encolar el fix en el Ojo",
+      };
+    }
+
+    return {
+      ok: true,
+      healthy: false,
+      observedText,
+      issue,
+      dispatchedJobId: dispatchJson.id,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      healthy: false,
+      observedText: "",
+      issue: null,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}


### PR DESCRIPTION
Módulo Ensamblador — trabajo de la rama claude/mindcontextia-vforge-chat-68jxcy hacia main.

Incluye:
- lib/builder/ship.ts (motor de publicación GitHub+Vercel)
- lib/forja/verify-loop.ts + browser.ts
- /api/forja/loop
- Retoques a VersionCard y builder

CANDADO antes de mergear (revisar):
- Duplicación: lib/builder/ship.ts vs app/api/forja/ship/route.ts — debe quedar UN solo motor de publicación. Si ambos publican, consolidar en uno y que el otro lo importe.

Referencia visual del módulo: turbillon50/VFORGE-ENSAMBLADOR (misma rama). Los tokens vf-* (violeta #7c3aed → cyan #22d3ee, fondo #0a0a0f) se respetan, sin paleta nueva.

Merge lo confirma Luis.