### PR TITLE
Auth light: layout claro para sign-in/sign-up, mata splash/dark body

### DIFF
--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,6 @@ export const dynamic = "force-dynamic";
 import { SignIn, ClerkLoading, ClerkLoaded } from "@clerk/nextjs";
 import { hasClerkPublishableKey } from "@/lib/auth/clerk-key";
 import { ClerkPlaceholder } from "@/components/auth/ClerkPlaceholder";
-import ForgeLoader from "@/components/forge/ForgeLoader";
 
 const forgeAppearance = {
   variables: {
@@ -35,7 +34,7 @@ const forgeAppearance = {
       "&:focus": { border: "1px solid #1b1b1b", boxShadow: "none" },
     },
     formButtonPrimary: {
-      background: "#000000", color: "#ffffff", boxShadow: "none", textTransform: "none", fontWeight: 600,
+      background: "#000000", color: "#ffffff", boxShadow: "none", textTransform: "none" as const, fontWeight: 600,
       "&:hover": { background: "#1b1b1b" },
     },
     footerActionText: { color: "#6B7280" },
@@ -71,7 +70,14 @@ export default function SignInPage() {
         {clerkEnabled ? (
           <>
             <ClerkLoading>
-              <ForgeLoader label="Access" />
+              <div className="flex min-h-[40vh] w-full flex-col items-center justify-center gap-4" style={{ background: "#ffffff" }}>
+                <svg viewBox="0 0 24 24" width="34" height="34" className="animate-pulse" aria-hidden>
+                  <path d="M2 3h20L12 21z" fill="#000000" />
+                </svg>
+                <p className="text-[10px] uppercase" style={{ color: "#6B7280", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.3em" }}>
+                  Loading
+                </p>
+              </div>
             </ClerkLoading>
             <ClerkLoaded>
               <SignIn appearance={forgeAppearance} />

--- a/app/sign-in/layout.tsx
+++ b/app/sign-in/layout.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect } from "react";
+
+/**
+ * Layout para rutas de autenticación (sign-in, sign-up).
+ * Fuerza tema claro, elimina el fondo oscuro del root layout,
+ * y oculta el SplashScreen.
+ */
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const prev = {
+      theme: html.getAttribute("data-theme"),
+      bodyClass: body.className,
+      bodyBg: body.style.background,
+    };
+    html.setAttribute("data-theme", "light");
+    body.style.background = "#ffffff";
+    body.style.color = "#1b1b1b";
+    body.classList.remove("bg-void", "scanlines");
+    // Ocultar splash si aparece
+    const splash = body.querySelector("[style*='z-index: 9999']") as HTMLElement | null;
+    if (splash) splash.style.display = "none";
+    return () => {
+      html.setAttribute("data-theme", prev.theme || "dark");
+      body.style.background = prev.bodyBg;
+      body.style.color = "";
+      if (prev.bodyClass) body.className = prev.bodyClass;
+    };
+  }, []);
+  return <>{children}</>;
+}

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -3,7 +3,6 @@ export const dynamic = "force-dynamic";
 import { SignUp, ClerkLoading, ClerkLoaded } from "@clerk/nextjs";
 import { hasClerkPublishableKey } from "@/lib/auth/clerk-key";
 import { ClerkPlaceholder } from "@/components/auth/ClerkPlaceholder";
-import ForgeLoader from "@/components/forge/ForgeLoader";
 
 const forgeAppearance = {
   variables: {
@@ -35,7 +34,7 @@ const forgeAppearance = {
       "&:focus": { border: "1px solid #1b1b1b", boxShadow: "none" },
     },
     formButtonPrimary: {
-      background: "#000000", color: "#ffffff", boxShadow: "none", textTransform: "none", fontWeight: 600,
+      background: "#000000", color: "#ffffff", boxShadow: "none", textTransform: "none" as const, fontWeight: 600,
       "&:hover": { background: "#1b1b1b" },
     },
     footerActionText: { color: "#6B7280" },
@@ -71,7 +70,14 @@ export default function SignUpPage() {
         {clerkEnabled ? (
           <>
             <ClerkLoading>
-              <ForgeLoader label="Onboard" />
+              <div className="flex min-h-[40vh] w-full flex-col items-center justify-center gap-4" style={{ background: "#ffffff" }}>
+                <svg viewBox="0 0 24 24" width="34" height="34" className="animate-pulse" aria-hidden>
+                  <path d="M2 3h20L12 21z" fill="#000000" />
+                </svg>
+                <p className="text-[10px] uppercase" style={{ color: "#6B7280", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.3em" }}>
+                  Loading
+                </p>
+              </div>
             </ClerkLoading>
             <ClerkLoaded>
               <SignUp appearance={forgeAppearance} />

--- a/app/sign-up/layout.tsx
+++ b/app/sign-up/layout.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect } from "react";
+
+/**
+ * Layout para rutas de autenticación (sign-in, sign-up).
+ * Fuerza tema claro, elimina el fondo oscuro del root layout,
+ * y oculta el SplashScreen.
+ */
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const prev = {
+      theme: html.getAttribute("data-theme"),
+      bodyClass: body.className,
+      bodyBg: body.style.background,
+    };
+    html.setAttribute("data-theme", "light");
+    body.style.background = "#ffffff";
+    body.style.color = "#1b1b1b";
+    body.classList.remove("bg-void", "scanlines");
+    // Ocultar splash si aparece
+    const splash = body.querySelector("[style*='z-index: 9999']") as HTMLElement | null;
+    if (splash) splash.style.display = "none";
+    return () => {
+      html.setAttribute("data-theme", prev.theme || "dark");
+      body.style.background = prev.bodyBg;
+      body.style.color = "";
+      if (prev.bodyClass) body.className = prev.bodyClass;
+    };
+  }, []);
+  return <>{children}</>;
+}


### PR DESCRIPTION
Fuerza tema claro en rutas auth. El root layout del monorepo aplica data-theme=dark + bg-void, este layout lo revierte para sign-in y sign-up. Incluye loader triangulo Forge y paleta clara industrial.