### PR TITLE
Add scoped Forge Live client portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # testing
 /coverage
+/.test-dist
 
 # next.js
 /.next/

--- a/app/api/fix-skills-table/route.ts
+++ b/app/api/fix-skills-table/route.ts
@@ -1,111 +1,26 @@
-import { sql } from "@/lib/db/client";
-
+/**
+ * DESACTIVADO (P0 de seguridad).
+ *
+ * Este endpoint hacía `DROP TABLE IF EXISTS skills CASCADE` y la recreaba, SIN
+ * autenticación y fuera de la lista de rutas protegidas del middleware — es
+ * decir, cualquiera en internet podía borrar la tabla `skills`. Se neutraliza:
+ * ya no ejecuta SQL destructivo. La reparación real del esquema vive en el
+ * auto-heal idempotente (lib/db/auto-heal.ts), que usa CREATE/ALTER ... IF NOT
+ * EXISTS y nunca dropea datos.
+ */
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/**
- * EMERGENCY FIX: Skills table repair
- *
- * Drops and recreates the skills table completely.
- * This is a nuclear option - use only when the table is completely broken.
- */
-export async function POST() {
-  try {
-    // Step 1: Drop the broken table
-    await sql`DROP TABLE IF EXISTS skills CASCADE`;
-
-    // Step 2: Recreate it completely correct
-    await sql`
-      CREATE TABLE skills (
-        id            text PRIMARY KEY,
-        name          text NOT NULL,
-        description   text NOT NULL DEFAULT '',
-        system_prompt text NOT NULL DEFAULT '',
-        required_tools  text[] DEFAULT '{}',
-        ring_max        int DEFAULT 1,
-        source          text NOT NULL DEFAULT 'user',
-        tags            text[] DEFAULT '{}',
-        active          boolean DEFAULT true,
-        installed_at    timestamptz,
-        created_by      text,
-        created_at      timestamptz NOT NULL DEFAULT now(),
-        updated_at      timestamptz NOT NULL DEFAULT now()
-      )
-    `;
-
-    // Step 3: Create indexes
-    await sql`CREATE INDEX idx_skills_source ON skills (source)`;
-    await sql`CREATE INDEX idx_skills_tags ON skills USING gin (tags)`;
-    await sql`CREATE INDEX idx_skills_installed ON skills (installed_at) WHERE installed_at IS NOT NULL`;
-
-    // Step 4: Seed system skills
-    await sql`
-      INSERT INTO skills (id, name, description, system_prompt, tags, source, required_tools, installed_at) VALUES
-        (
-          'new-project-bootstrap',
-          'New Project Bootstrap',
-          'Create new projects with complete structure and auto-deployment',
-          E'When asked to create a new project:\n1. Ask for name, description, type\n2. Create GitHub repo with template\n3. Configure Vercel project\n4. Register domain if needed\n5. Verify deployment works',
-          ARRAY['github', 'vercel', 'deploy', 'scaffold'],
-          'system',
-          ARRAY['github_create_repo', 'github_write_file'],
-          now()
-        ),
-        (
-          'repo-rescue',
-          'Repo Rescue',
-          'Diagnose and repair projects with build or deploy errors',
-          E'When a project has errors:\n1. Check Vercel logs\n2. Read config files\n3. Identify broken deps or config\n4. Propose fix and request confirmation\n5. Verify build passes',
-          ARRAY['github', 'vercel', 'debug', 'fix'],
-          'system',
-          ARRAY['github_read_file', 'github_write_file'],
-          now()
-        ),
-        (
-          'repo-categorizer',
-          'Repo Categorizer',
-          'Audit and categorize repositories by activity and health',
-          E'To categorize repos:\n1. Check commits from last 30 days\n2. Verify active deployment\n3. Review structure and quality\n4. Assign score 0-100\n5. Save audit results',
-          ARRAY['github', 'audit', 'organize'],
-          'system',
-          ARRAY['github_read_file'],
-          NULL
-        ),
-        (
-          'dns-manager',
-          'DNS Manager',
-          'Manage domains and DNS via Name.com',
-          E'For DNS operations:\n1. Verify domain availability\n2. Configure nameservers\n3. Add/modify DNS records\n4. Verify propagation',
-          ARRAY['dns', 'domain', 'namecom'],
-          'system',
-          ARRAY['namecom_check_domain'],
-          NULL
-        )
-    `;
-
-    // Step 5: Verify it works
-    const count = await sql`SELECT COUNT(*)::int AS n FROM skills`;
-    const cols = await sql`
-      SELECT column_name FROM information_schema.columns
-      WHERE table_name = 'skills' ORDER BY ordinal_position
-    `;
-
-    return Response.json(
-      {
-        ok: true,
-        message: "Skills table completely rebuilt and restored",
-        skillCount: count[0]?.n ?? 0,
-        columns: (cols as { column_name: string }[]).map((c) => c.column_name),
-      },
-      { status: 200 },
-    );
-  } catch (e) {
-    return Response.json(
-      {
-        ok: false,
-        error: e instanceof Error ? e.message : String(e),
-      },
-      { status: 500 },
-    );
-  }
+function gone() {
+  return Response.json(
+    {
+      ok: false,
+      error:
+        "Endpoint desactivado por seguridad. Usa el auto-heal idempotente del esquema.",
+    },
+    { status: 410, headers: { "Cache-Control": "no-store" } },
+  );
 }
+
+export const GET = gone;
+export const POST = gone;

--- a/app/api/live/[projectId]/comments/route.ts
+++ b/app/api/live/[projectId]/comments/route.ts
@@ -1,0 +1,63 @@
+/**
+ * API portal en vivo — comentarios de un proyecto.
+ *
+ * Auth DENTRO del handler (requireLiveAccess, fail-closed). Cualquier miembro
+ * activo (observer+) puede leer y comentar. Aislado por project_id.
+ *
+ *   GET  → lista comentarios (recientes primero).
+ *   POST → crea un comentario. Body { body }. Valida tamaño.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireLiveAccess } from "@/lib/projects/access";
+import { listComments, createComment } from "@/lib/projects/live-portal";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+const MAX_BODY = 4000;
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await requireLiveAccess(projectId);
+  if (!access) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+  }
+  const comments = await listComments(projectId);
+  return NextResponse.json({ comments }, { headers: noStore });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await requireLiveAccess(projectId);
+  if (!access) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+  }
+
+  const payload = await req.json().catch(() => null);
+  const raw = (payload as Record<string, unknown> | null)?.body;
+  if (typeof raw !== "string" || !raw.trim()) {
+    return NextResponse.json({ error: "empty" }, { status: 400, headers: noStore });
+  }
+  if (raw.length > MAX_BODY) {
+    return NextResponse.json({ error: "too_long" }, { status: 413, headers: noStore });
+  }
+
+  const comment = await createComment({
+    projectId,
+    authorEmail: access.email,
+    authorName: access.name,
+    authorClerkId: access.clerkUserId,
+    body: raw,
+  });
+  if (!comment) {
+    return NextResponse.json({ error: "empty" }, { status: 400, headers: noStore });
+  }
+  return NextResponse.json({ comment }, { status: 201, headers: noStore });
+}

--- a/app/api/live/[projectId]/events/route.ts
+++ b/app/api/live/[projectId]/events/route.ts
@@ -1,0 +1,36 @@
+/**
+ * API portal en vivo — actividad del proyecto (polling seguro).
+ *
+ * Lee project_events ESTRICTAMENTE acotado por project_id (aislamiento por
+ * proyecto). Auth dentro del handler (requireLiveAccess, fail-closed). Soporta
+ * polling incremental con `?since=<ISO>`.
+ *
+ * Se prefiere polling sobre SSE por robustez en el runtime serverless (una
+ * conexión SSE larga se corta con la función). El cliente hace short-poll.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireLiveAccess } from "@/lib/projects/access";
+import { listRecentEvents } from "@/lib/projects/live-portal";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await requireLiveAccess(projectId);
+  if (!access) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+  }
+
+  const since = req.nextUrl.searchParams.get("since");
+  const events = await listRecentEvents({ projectId, since });
+  return NextResponse.json(
+    { events, serverTime: new Date().toISOString() },
+    { headers: noStore },
+  );
+}

--- a/app/api/live/[projectId]/invitations/route.ts
+++ b/app/api/live/[projectId]/invitations/route.ts
@@ -77,4 +77,22 @@ export async function POST(
     typeof ttlHours === "number" && Number.isFinite(ttlHours) ? ttlHours : undefined;
 
   try {
-    const { invitation, token } =
+    const { invitation, token } = await createInvitation({
+      projectId,
+      email: email.trim(),
+      role: cleanRole,
+      invitedBy: access.email,
+      ttlHours: cleanTtl,
+    });
+
+    const origin = req.nextUrl.origin;
+    const acceptUrl = `${origin}/app/live/${encodeURIComponent(projectId)}?invite=${encodeURIComponent(token)}`;
+
+    return NextResponse.json(
+      { invitation, token, acceptUrl },
+      { status: 201, headers: noStore },
+    );
+  } catch {
+    return NextResponse.json({ error: "invite_failed" }, { status: 500, headers: noStore });
+  }
+}

--- a/app/api/live/[projectId]/invitations/route.ts
+++ b/app/api/live/[projectId]/invitations/route.ts
@@ -1,0 +1,80 @@
+/**
+ * API portal en vivo — invitaciones de un proyecto (solo OWNER).
+ *
+ * Auth DENTRO del handler (esta ruta no está cubierta por el gating owner-only
+ * del middleware). Responde de forma opaca: si no eres owner del proyecto →
+ * 404 (no revela existencia).
+ *
+ *   GET  → lista invitaciones (sin token ni hash).
+ *   POST → crea una invitación segura. Body { email, role?, ttlHours? }.
+ *          Devuelve el token en claro UNA sola vez + el link de aceptación.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireLiveAccess } from "@/lib/projects/access";
+import {
+  listInvitations,
+  createInvitation,
+  getProjectViewports,
+} from "@/lib/projects/live-portal";
+import { isInvitableRole, type LiveRole } from "@/lib/projects/roles";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await requireLiveAccess(projectId, "owner");
+  if (!access) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+  }
+  const invitations = await listInvitations(projectId);
+  return NextResponse.json({ invitations }, { headers: noStore });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await requireLiveAccess(projectId, "owner");
+  if (!access) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+  }
+
+  // El proyecto debe existir realmente para colgar una invitación (FK).
+  const project = await getProjectViewports(projectId);
+  if (!project) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+  }
+
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400, headers: noStore });
+  }
+  const { email, role, ttlHours } = body as Record<string, unknown>;
+
+  if (typeof email !== "string" || !EMAIL_RE.test(email.trim()) || email.length > 254) {
+    return NextResponse.json({ error: "invalid_email" }, { status: 400, headers: noStore });
+  }
+  // Solo se puede invitar como observer o reviewer. `owner` (u cualquier valor
+  // inválido) se RECHAZA con 400 — nunca se degrada silenciosamente. Ausente ⇒
+  // observer (menor privilegio).
+  let cleanRole: LiveRole;
+  if (role === undefined || role === null) {
+    cleanRole = "observer";
+  } else if (isInvitableRole(role)) {
+    cleanRole = role;
+  } else {
+    return NextResponse.json({ error: "invalid_role" }, { status: 400, headers: noStore });
+  }
+  const cleanTtl =
+    typeof ttlHours === "number" && Number.isFinite(ttlHours) ? ttlHours : undefined;
+
+  try {
+    const { invitation, token } =

--- a/app/api/live/invitations/accept/route.ts
+++ b/app/api/live/invitations/accept/route.ts
@@ -1,0 +1,55 @@
+/**
+ * API portal en vivo — aceptar invitación (usuario autenticado).
+ *
+ * POST Body { token }. Requiere sesión de Clerk. Valida hash → estado →
+ * expiración → que el email de la invitación coincida con el de la sesión, y
+ * que sea de uso único. Respuestas opacas: no distingue "no existe" de
+ * "expiró/usada/otro email" — todo cae en un 400 genérico salvo el caso feliz.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { acceptInvitation } from "@/lib/projects/live-portal";
+import { sanitizeToken } from "@/lib/projects/invite-token";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+
+export async function POST(req: NextRequest) {
+  let user: Awaited<ReturnType<typeof currentUser>> = null;
+  try {
+    user = await currentUser();
+  } catch {
+    user = null;
+  }
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401, headers: noStore });
+  }
+  const email = user.emailAddresses?.[0]?.emailAddress?.trim().toLowerCase();
+  if (!email) {
+    return NextResponse.json({ error: "no_email" }, { status: 400, headers: noStore });
+  }
+
+  const body = await req.json().catch(() => null);
+  const token = sanitizeToken((body as Record<string, unknown> | null)?.token);
+  if (!token) {
+    return NextResponse.json({ error: "invalid_invite" }, { status: 400, headers: noStore });
+  }
+
+  const result = await acceptInvitation({
+    token,
+    sessionEmail: email,
+    clerkUserId: user.id,
+  }).catch(() => ({ ok: false as const, reason: "invalid" as const }));
+
+  if (!result.ok) {
+    // Opaco: un solo estado de error para cualquier motivo de rechazo.
+    return NextResponse.json({ error: "invalid_invite" }, { status: 400, headers: noStore });
+  }
+
+  return NextResponse.json(
+    { ok: true, projectId: result.projectId, role: result.role },
+    { headers: noStore },
+  );
+}

--- a/app/api/v1/forge/run/route.ts
+++ b/app/api/v1/forge/run/route.ts
@@ -1,1 +1,32 @@
-export { POST } from "@/app/api/forge/run/route";
+/**
+ * Alias v1 de /api/forge/run.
+ *
+ * P0: el handler subyacente (app/api/forge/run/route) confía en que el
+ * middleware ya filtró y solo dejó pasar al owner — pero ese gating owner-only
+ * cubre `/api/forge(.*)`, NO `/api/v1/forge/run`. Sin este guard, el alias
+ * exponía el chat/tools de V a cualquier sesión. Aquí verificamos que sea el
+ * owner ANTES de delegar.
+ */
+import { currentUser } from "@clerk/nextjs/server";
+import { isOwnerUser } from "@/lib/auth/owner";
+import { POST as forgeRun } from "@/app/api/forge/run/route";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function POST(req: Request): Promise<Response> {
+  let user: Awaited<ReturnType<typeof currentUser>> = null;
+  try {
+    user = await currentUser();
+  } catch {
+    user = null;
+  }
+  if (!isOwnerUser(user)) {
+    return new Response(JSON.stringify({ error: "forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+    });
+  }
+  return forgeRun(req);
+}

--- a/app/app/live/[projectId]/page.tsx
+++ b/app/app/live/[projectId]/page.tsx
@@ -1,0 +1,54 @@
+/**
+ * /app/live/[projectId] — Portal en vivo del proyecto (server component).
+ *
+ * Resuelve el acceso con el helper central (fail-closed). Si el usuario es
+ * miembro (o platform owner) → renderiza el portal. Si no → gate que puede
+ * aceptar una invitación (?invite=token). La membresía fina y el gating por
+ * rol viven en el helper y en /api/live/*.
+ */
+import { resolveLiveAccess } from "@/lib/projects/access";
+import { getProjectViewports } from "@/lib/projects/live-portal";
+import { LivePortal } from "@/components/live/LivePortal";
+import { LiveGate } from "@/components/live/LiveGate";
+
+export const dynamic = "force-dynamic";
+
+export default async function LivePortalPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const { projectId } = await params;
+
+  const access = await resolveLiveAccess(projectId);
+  if (!access) {
+    return <LiveGate projectId={projectId} />;
+  }
+
+  const project = await getProjectViewports(projectId);
+  if (!project) {
+    return <LiveGate projectId={projectId} />;
+  }
+
+  // El viewport admin es solo para owner/reviewer: no serialices la URL hacia
+  // el cliente para un observer (defensa en profundidad, no solo ocultarlo en UI).
+  const canSeeAdmin = access.role === "owner" || access.role === "reviewer";
+
+  return (
+    <LivePortal
+      project={{
+        id: project.id,
+        name: project.name,
+        status: project.status,
+        desktop_url: project.desktop_url,
+        mobile_url: project.mobile_url,
+        admin_url: canSeeAdmin ? project.admin_url : null,
+      }}
+      me={{
+        name: access.name,
+        role: access.role,
+        isPlatformOwner: access.isPlatformOwner,
+      }}
+    />
+  );
+}

--- a/components/live/InvitePanel.tsx
+++ b/components/live/InvitePanel.tsx
@@ -1,0 +1,100 @@
+"use client";
+/**
+ * Panel de invitaciones (solo owner) — crea invitaciones seguras y lista las
+ * existentes. El token en claro se muestra UNA sola vez tras crearla.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import {
+  IconUsers,
+  IconPlus,
+  IconLoader,
+  IconCopy,
+  IconCheck,
+} from "@/components/brand/VFIcons";
+import type { LiveRole } from "@/lib/projects/roles";
+
+interface Invitation {
+  id: string;
+  email: string;
+  role: string;
+  created_at: string;
+  expires_at: string;
+  accepted_at: string | null;
+  revoked_at: string | null;
+}
+
+const ROLES: { value: LiveRole; label: string }[] = [
+  { value: "observer", label: "Observador" },
+  { value: "reviewer", label: "Revisor" },
+  { value: "owner", label: "Owner" },
+];
+
+function inviteState(inv: Invitation): { label: string; cls: string } {
+  if (inv.revoked_at) return { label: "Revocada", cls: "bg-white/[0.06] text-[var(--fg-muted)]" };
+  if (inv.accepted_at) return { label: "Aceptada", cls: "bg-emerald-500/15 text-emerald-300" };
+  if (new Date(inv.expires_at).getTime() <= Date.now())
+    return { label: "Expirada", cls: "bg-amber-500/15 text-amber-300" };
+  return { label: "Pendiente", cls: "bg-violet-500/15 text-violet-200" };
+}
+
+export function InvitePanel({ projectId }: { projectId: string }) {
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<LiveRole>("observer");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [lastLink, setLastLink] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/live/${projectId}/invitations`, {
+        cache: "no-store",
+      });
+      if (!res.ok) return;
+      const data = (await res.json()) as { invitations: Invitation[] };
+      setInvitations(data.invitations);
+    } catch {
+      /* silencioso */
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function create() {
+    if (!email.trim() || busy) return;
+    setBusy(true);
+    setError("");
+    setLastLink(null);
+    try {
+      const res = await fetch(`/api/live/${projectId}/invitations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), role }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError("No se pudo crear la invitación.");
+        return;
+      }
+      setEmail("");
+      setLastLink(data.acceptUrl ?? null);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyLink() {
+    if (!lastLink) return;
+    try {
+      await navigator.clipboard.writeText(lastLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard bloqueado */
+    }
+  }

--- a/components/live/InvitePanel.tsx
+++ b/components/live/InvitePanel.tsx
@@ -98,3 +98,102 @@ export function InvitePanel({ projectId }: { projectId: string }) {
       /* clipboard bloqueado */
     }
   }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ ease: [0.22, 1, 0.36, 1] }}
+      className="rounded-2xl border border-[var(--border-1)] bg-[#0a0a12] p-4"
+    >
+      <div className="mb-3 flex items-center gap-2 text-violet-300">
+        <IconUsers size={14} />
+        <span className="text-[13px] font-semibold text-[var(--fg-primary)]">
+          Invitaciones
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="correo@cliente.com"
+          className="w-full rounded-xl border border-[var(--border-1)] bg-[var(--surface-1)] px-3 py-2.5 text-[13px] text-white placeholder-white/25 outline-none focus:border-violet-500/50"
+        />
+        <select
+          value={role}
+          onChange={(e) => setRole(e.target.value as LiveRole)}
+          className="rounded-xl border border-[var(--border-1)] bg-[var(--surface-1)] px-3 py-2.5 text-[13px] text-white outline-none focus:border-violet-500/50"
+        >
+          {ROLES.map((r) => (
+            <option key={r.value} value={r.value} className="bg-[#0a0a12]">
+              {r.label}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={create}
+          disabled={busy || !email.trim()}
+          className="flex shrink-0 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-violet-600 to-violet-500 px-4 py-2.5 text-[13px] font-semibold text-white transition active:scale-95 disabled:opacity-40"
+        >
+          {busy ? <IconLoader size={14} className="animate-spin" /> : <IconPlus size={14} />}
+          Invitar
+        </button>
+      </div>
+      {error && <p className="mt-2 text-[11px] text-red-300">{error}</p>}
+
+      {lastLink && (
+        <div className="mt-3 rounded-xl border border-violet-500/25 bg-violet-500/10 p-3">
+          <p className="mb-1.5 text-[11px] text-violet-200">
+            Link de invitación (se muestra una sola vez):
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="min-w-0 flex-1 truncate rounded-lg bg-black/40 px-2.5 py-1.5 text-[11px] text-violet-100">
+              {lastLink}
+            </code>
+            <button
+              onClick={copyLink}
+              className="flex shrink-0 items-center gap-1 rounded-lg border border-violet-500/30 px-2.5 py-1.5 text-[11px] text-violet-200 transition active:scale-95"
+            >
+              {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+              {copied ? "Copiado" : "Copiar"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-3 space-y-2">
+        {invitations.length === 0 ? (
+          <p className="py-3 text-center text-[12px] text-[var(--fg-muted)]">
+            Sin invitaciones.
+          </p>
+        ) : (
+          invitations.map((inv) => {
+            const st = inviteState(inv);
+            return (
+              <div
+                key={inv.id}
+                className="flex items-center justify-between rounded-xl border border-[var(--border-1)] bg-[var(--surface-1)] px-3 py-2.5"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-[12px] font-medium text-[var(--fg-primary)]">
+                    {inv.email}
+                  </p>
+                  <p className="text-[10px] text-[var(--fg-muted)]">
+                    {ROLES.find((r) => r.value === inv.role)?.label ?? inv.role}
+                  </p>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full px-2.5 py-0.5 text-[10px] font-semibold ${st.cls}`}
+                >
+                  {st.label}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/live/LiveGate.tsx
+++ b/components/live/LiveGate.tsx
@@ -1,0 +1,86 @@
+"use client";
+/**
+ * Gate del portal en vivo cuando el usuario NO tiene acceso todavía.
+ *
+ * Si la URL trae `?invite=<token>`, intenta aceptar la invitación (POST a
+ * /api/live/invitations/accept) y, si funciona, recarga para entrar. Si no hay
+ * token o la invitación es inválida, muestra un mensaje neutro (opaco).
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { IconLoader, IconShield, IconCheck } from "@/components/brand/VFIcons";
+
+type State = "idle" | "accepting" | "accepted" | "denied";
+
+/** Lee ?invite=<token> del querystring sin useSearchParams (evita el requisito
+ *  de Suspense en build). Solo corre en cliente. */
+function readInviteToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("invite");
+}
+
+export function LiveGate({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const [state, setState] = useState<State>("idle");
+
+  const accept = useCallback(
+    async (t: string) => {
+      try {
+        const res = await fetch(`/api/live/invitations/accept`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token: t }),
+        });
+        if (res.ok) {
+          setState("accepted");
+          // Limpia el token de la URL y recarga con acceso ya concedido.
+          router.replace(`/app/live/${encodeURIComponent(projectId)}`);
+          router.refresh();
+          return;
+        }
+      } catch {
+        /* cae a denied */
+      }
+      setState("denied");
+    },
+    [projectId, router],
+  );
+
+  useEffect(() => {
+    const token = readInviteToken();
+    if (token) {
+      setState("accepting");
+      accept(token);
+    } else {
+      setState("denied");
+    }
+  }, [accept]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-[#03020a] px-6 text-center">
+      {state === "idle" || state === "accepting" ? (
+        <>
+          <IconLoader size={24} className="animate-spin text-violet-400" />
+          <p className="text-sm text-[var(--fg-secondary)]">
+            Validando tu invitación…
+          </p>
+        </>
+      ) : state === "accepted" ? (
+        <>
+          <IconCheck size={26} className="text-emerald-400" />
+          <p className="text-sm text-[var(--fg-secondary)]">
+            Invitación aceptada. Entrando…
+          </p>
+        </>
+      ) : (
+        <>
+          <IconShield size={26} className="text-amber-400" />
+          <p className="max-w-sm text-sm text-[var(--fg-secondary)]">
+            No tienes acceso a este portal, o tu invitación ya no es válida.
+            Pide al equipo de VForge un nuevo enlace.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -1,0 +1,108 @@
+"use client";
+/**
+ * Portal en vivo del proyecto — 3 viewports simultáneos (desktop / mobile /
+ * admin) + actividad en vivo + comentarios, con el look VForge.
+ *
+ * El viewport ADMIN solo se muestra a reviewer/owner. La actividad hace
+ * short-polling seguro a /api/live/[id]/events (aislado por proyecto). Sin
+ * dependencias extra (fetch + hooks nativos).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import {
+  IconGlobe,
+  IconLayout,
+  IconShield,
+  IconChat,
+  IconActivity,
+  IconSend,
+  IconLoader,
+  IconExtLink,
+  IconCheck,
+} from "@/components/brand/VFIcons";
+import type { LiveRole } from "@/lib/projects/roles";
+import { InvitePanel } from "@/components/live/InvitePanel";
+
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+export interface LivePortalProject {
+  id: string;
+  name: string;
+  status: string;
+  desktop_url: string | null;
+  mobile_url: string | null;
+  admin_url: string | null;
+}
+export interface LivePortalMe {
+  name: string;
+  role: LiveRole;
+  isPlatformOwner: boolean;
+}
+interface EventRow {
+  id: string;
+  event_type: string;
+  details: Record<string, unknown>;
+  severity: string;
+  ts: string;
+}
+interface CommentRow {
+  id: string;
+  author_email: string;
+  author_name: string | null;
+  body: string;
+  created_at: string;
+}
+
+const SEV_COLOR: Record<string, string> = {
+  low: "#64748b",
+  medium: "#fbbf24",
+  high: "#fb923c",
+  critical: "#f87171",
+};
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return "ahora";
+  if (m < 60) return `hace ${m} min`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `hace ${h} h`;
+  return `hace ${Math.floor(h / 24)} d`;
+}
+
+const ROLE_LABEL: Record<LiveRole, string> = {
+  owner: "Owner",
+  reviewer: "Revisor",
+  observer: "Observador",
+};
+
+export function LivePortal({
+  project,
+  me,
+}: {
+  project: LivePortalProject;
+  me: LivePortalMe;
+}) {
+  const canSeeAdmin = me.role === "owner" || me.role === "reviewer";
+  const isOwner = me.role === "owner";
+
+  return (
+    <div className="min-h-screen bg-[#03020a] pb-20">
+      {/* Header */}
+      <div className="sticky top-0 z-20 border-b border-[var(--border-1)] bg-[#03020a]/85 backdrop-blur-2xl">
+        <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-3 px-5 py-3.5">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-white">
+              {project.name}
+            </p>
+            <p className="text-[11px] text-[var(--fg-muted)]">
+              Portal en vivo · {me.name}
+            </p>
+          </div>
+          <span className="shrink-0 rounded-full border border-violet-500/25 bg-violet-500/10 px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-violet-200">
+            {ROLE_LABEL[me.role]}
+          </span>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-[

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -105,4 +105,327 @@ export function LivePortal({
         </div>
       </div>
 
-      <div className="mx-auto max-w-[
+      <div className="mx-auto max-w-[1440px] space-y-6 px-4 pt-6 md:px-6">
+        {/* Viewports */}
+        <section>
+          <SectionTitle icon={<IconLayout size={14} />} title="Vista en vivo" />
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+            <Viewport
+              kind="desktop"
+              title="Escritorio"
+              icon={<IconGlobe size={13} />}
+              url={project.desktop_url}
+            />
+            <Viewport
+              kind="mobile"
+              title="Móvil"
+              icon={<IconLayout size={13} />}
+              url={project.mobile_url}
+            />
+            {canSeeAdmin ? (
+              <Viewport
+                kind="admin"
+                title="Admin"
+                icon={<IconShield size={13} />}
+                url={project.admin_url}
+              />
+            ) : (
+              <div className="flex min-h-[240px] flex-col items-center justify-center rounded-2xl border border-dashed border-[var(--border-1)] bg-[#0a0a12] p-6 text-center">
+                <IconShield size={20} className="text-[var(--fg-muted)]" />
+                <p className="mt-2 text-[12px] text-[var(--fg-muted)]">
+                  El viewport admin es solo para revisores.
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <ActivityFeed projectId={project.id} />
+          <CommentsPanel projectId={project.id} />
+        </div>
+
+        {isOwner && <InvitePanel projectId={project.id} />}
+      </div>
+    </div>
+  );
+}
+
+function SectionTitle({
+  icon,
+  title,
+  right,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  right?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-center justify-between">
+      <div className="flex items-center gap-2 text-violet-300">
+        {icon}
+        <span className="text-[13px] font-semibold text-[var(--fg-primary)]">
+          {title}
+        </span>
+      </div>
+      {right}
+    </div>
+  );
+}
+
+function Viewport({
+  kind,
+  title,
+  icon,
+  url,
+}: {
+  kind: "desktop" | "mobile" | "admin";
+  title: string;
+  icon: React.ReactNode;
+  url: string | null;
+}) {
+  const frameClass =
+    kind === "mobile"
+      ? "aspect-[9/16] max-h-[520px]"
+      : "aspect-[16/10]";
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ ease: EASE }}
+      className="overflow-hidden rounded-2xl border border-[var(--border-1)] bg-[#0a0a12]"
+    >
+      <div className="flex items-center justify-between border-b border-[var(--border-1)] px-3 py-2">
+        <div className="flex items-center gap-1.5 text-[var(--fg-tertiary)]">
+          {icon}
+          <span className="text-[11px] font-medium">{title}</span>
+        </div>
+        {url && (
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1 text-[10px] text-violet-300 hover:text-violet-200"
+          >
+            <IconExtLink size={11} /> abrir
+          </a>
+        )}
+      </div>
+      {url ? (
+        <div className={`relative w-full ${frameClass} bg-black`}>
+          <iframe
+            src={url}
+            title={`${title} preview`}
+            className="absolute inset-0 h-full w-full border-0"
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          />
+        </div>
+      ) : (
+        <div className={`flex w-full ${frameClass} items-center justify-center bg-[#07060f] p-4 text-center`}>
+          <p className="text-[11px] text-[var(--fg-muted)]">
+            Sin URL configurada para {title.toLowerCase()}.
+          </p>
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function ActivityFeed({ projectId }: { projectId: string }) {
+  const [events, setEvents] = useState<EventRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const sinceRef = useRef<string | null>(null);
+
+  const poll = useCallback(async () => {
+    try {
+      const qs = sinceRef.current ? `?since=${encodeURIComponent(sinceRef.current)}` : "";
+      const res = await fetch(`/api/live/${projectId}/events${qs}`, {
+        cache: "no-store",
+      });
+      if (!res.ok) return;
+      const data = (await res.json()) as { events: EventRow[] };
+      setLoaded(true);
+      if (data.events.length > 0) {
+        sinceRef.current = data.events[0].ts;
+        setEvents((prev) => {
+          const seen = new Set(prev.map((e) => e.id));
+          const fresh = data.events.filter((e) => !seen.has(e.id));
+          return [...fresh, ...prev].slice(0, 60);
+        });
+      }
+    } catch {
+      /* silencioso */
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    poll();
+    const t = setInterval(poll, 8000);
+    return () => clearInterval(t);
+  }, [poll]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ ease: EASE }}
+      className="rounded-2xl border border-[var(--border-1)] bg-[#0a0a12] p-4"
+    >
+      <SectionTitle
+        icon={<IconActivity size={14} />}
+        title="Actividad en vivo"
+        right={
+          <span className="flex items-center gap-1 text-[10px] text-[var(--fg-muted)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" /> en vivo
+          </span>
+        }
+      />
+      {!loaded ? (
+        <div className="flex justify-center py-6">
+          <IconLoader size={16} className="animate-spin text-violet-400" />
+        </div>
+      ) : events.length === 0 ? (
+        <p className="py-6 text-center text-[12px] text-[var(--fg-muted)]">
+          Aún no hay actividad registrada.
+        </p>
+      ) : (
+        <div className="max-h-[360px] space-y-2.5 overflow-y-auto pr-1">
+          {events.map((e) => (
+            <div key={e.id} className="flex gap-2.5">
+              <span
+                className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                style={{
+                  background: SEV_COLOR[e.severity] ?? SEV_COLOR.low,
+                  boxShadow: `0 0 6px ${SEV_COLOR[e.severity] ?? SEV_COLOR.low}80`,
+                }}
+              />
+              <div className="min-w-0">
+                <p className="text-[12px] font-medium text-[var(--fg-primary)]">
+                  {e.event_type}
+                </p>
+                {typeof e.details?.message === "string" && (
+                  <p className="truncate text-[11px] text-[var(--fg-tertiary)]">
+                    {e.details.message as string}
+                  </p>
+                )}
+                <p className="text-[10px] text-[var(--fg-muted)]">
+                  {timeAgo(e.ts)}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function CommentsPanel({ projectId }: { projectId: string }) {
+  const [comments, setComments] = useState<CommentRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [body, setBody] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/live/${projectId}/comments`, {
+        cache: "no-store",
+      });
+      if (!res.ok) return;
+      const data = (await res.json()) as { comments: CommentRow[] };
+      setComments(data.comments);
+    } catch {
+      /* silencioso */
+    } finally {
+      setLoaded(true);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function send() {
+    const text = body.trim();
+    if (!text || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/live/${projectId}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: text }),
+      });
+      if (res.ok) {
+        setBody("");
+        await load();
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ ease: EASE }}
+      className="rounded-2xl border border-[var(--border-1)] bg-[#0a0a12] p-4"
+    >
+      <SectionTitle icon={<IconChat size={14} />} title="Comentarios" />
+      <div className="flex gap-2">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={2}
+          maxLength={4000}
+          placeholder="Escribe un comentario…"
+          className="w-full resize-none rounded-xl border border-[var(--border-1)] bg-[var(--surface-1)] px-3 py-2.5 text-[13px] text-white placeholder-white/25 outline-none focus:border-violet-500/50"
+        />
+        <button
+          onClick={send}
+          disabled={busy || !body.trim()}
+          aria-label="Enviar comentario"
+          className="flex shrink-0 items-center justify-center rounded-xl bg-gradient-to-r from-violet-600 to-violet-500 px-3 text-white transition active:scale-95 disabled:opacity-40"
+        >
+          {busy ? <IconLoader size={15} className="animate-spin" /> : <IconSend size={15} />}
+        </button>
+      </div>
+
+      <div className="mt-3 max-h-[300px] space-y-2 overflow-y-auto pr-1">
+        {!loaded ? (
+          <div className="flex justify-center py-6">
+            <IconLoader size={16} className="animate-spin text-violet-400" />
+          </div>
+        ) : comments.length === 0 ? (
+          <p className="py-4 text-center text-[12px] text-[var(--fg-muted)]">
+            Sin comentarios todavía.
+          </p>
+        ) : (
+          comments.map((c) => (
+            <div
+              key={c.id}
+              className="rounded-xl border border-[var(--border-1)] bg-[var(--surface-1)] p-3"
+            >
+              <div className="mb-1 flex items-center gap-2">
+                <span className="text-[11px] font-medium text-[var(--fg-secondary)]">
+                  {c.author_name ?? c.author_email}
+                </span>
+                <span className="text-[10px] text-[var(--fg-muted)]">
+                  {timeAgo(c.created_at)}
+                </span>
+              </div>
+              <p className="whitespace-pre-wrap text-[13px] text-[var(--fg-primary)]">
+                {c.body}
+              </p>
+            </div>
+          ))
+        )}
+      </div>
+      <p className="mt-2 flex items-center justify-center gap-1.5 text-[10px] text-[var(--fg-muted)]">
+        <IconCheck size={10} /> Solo visible para los miembros del proyecto
+      </p>
+    </motion.div>
+  );
+}

--- a/lib/projects/access.ts
+++ b/lib/projects/access.ts
@@ -101,4 +101,14 @@ export async function resolveLiveAccess(
 /**
  * Igual que resolveLiveAccess pero exige un rol MÍNIMO (jerárquico). Devuelve
  * null si no hay acceso o el rol no alcanza. Úsalo en handlers que requieren
- * r
+ * reviewer u owner.
+ */
+export async function requireLiveAccess(
+  projectId: string,
+  minRole: LiveRole = "observer",
+): Promise<LiveAccess | null> {
+  const access = await resolveLiveAccess(projectId);
+  if (!access) return null;
+  if (!roleAtLeast(access.role, minRole)) return null;
+  return access;
+}

--- a/lib/projects/access.ts
+++ b/lib/projects/access.ts
@@ -1,0 +1,104 @@
+/**
+ * Helper CENTRAL de acceso al portal en vivo — SERVER ONLY.
+ *
+ * Resuelve el acceso de un usuario (por su sesión de Clerk) a un proyecto,
+ * FALLANDO CERRADO: cualquier ausencia de sesión, email, membresía, expiración
+ * o error → sin acceso (null). Aplica la jerarquía owner > reviewer > observer.
+ *
+ * Es la ÚNICA puerta de entrada que deben usar las páginas y los handlers del
+ * portal (/app/live y /api/live/*). No confía en nada del cliente.
+ */
+import "server-only";
+import { currentUser } from "@clerk/nextjs/server";
+import { queryOne } from "@/lib/db/client";
+import { isOwnerEmail } from "@/lib/auth/owner";
+import {
+  type LiveRole,
+  type MembershipRow,
+  resolveMembership,
+  roleAtLeast,
+} from "@/lib/projects/roles";
+
+export interface LiveAccess {
+  projectId: string;
+  clerkUserId: string;
+  email: string;
+  name: string;
+  role: LiveRole;
+  /** true si es owner de la PLATAFORMA (Luis/Jaime): acceso a cualquier proyecto. */
+  isPlatformOwner: boolean;
+}
+
+function displayName(user: {
+  firstName?: string | null;
+  lastName?: string | null;
+  username?: string | null;
+}, fallback: string): string {
+  const full = [user.firstName, user.lastName].filter(Boolean).join(" ").trim();
+  return full || user.username || fallback;
+}
+
+/**
+ * Resuelve el acceso del usuario actual al proyecto `projectId`.
+ * Devuelve el contexto de acceso o null (fail-closed).
+ */
+export async function resolveLiveAccess(
+  projectId: string,
+): Promise<LiveAccess | null> {
+  if (!projectId || typeof projectId !== "string") return null;
+
+  let user: Awaited<ReturnType<typeof currentUser>> = null;
+  try {
+    user = await currentUser();
+  } catch {
+    return null; // sin runtime de auth → cerrado
+  }
+  if (!user) return null;
+
+  const email = user.emailAddresses?.[0]?.emailAddress?.trim().toLowerCase();
+  if (!email) return null;
+
+  // Owner de la plataforma: acceso total a cualquier proyecto en vivo, sin
+  // necesidad de membresía. Mismo bypass que el resto del portal del cliente.
+  if (isOwnerEmail(email)) {
+    return {
+      projectId,
+      clerkUserId: user.id,
+      email,
+      name: displayName(user, email),
+      role: "owner",
+      isPlatformOwner: true,
+    };
+  }
+
+  // Membresía real del proyecto. resolveMembership aplica status + expiración.
+  let row: MembershipRow | null = null;
+  try {
+    row = await queryOne<MembershipRow>(
+      `SELECT role, status, expires_at
+         FROM project_live_members
+        WHERE project_id = $1 AND lower(email) = lower($2)
+        LIMIT 1`,
+      [projectId, email],
+    );
+  } catch {
+    return null; // error de DB → cerrado
+  }
+
+  const role = resolveMembership(row, new Date());
+  if (!role) return null;
+
+  return {
+    projectId,
+    clerkUserId: user.id,
+    email,
+    name: displayName(user, email),
+    role,
+    isPlatformOwner: false,
+  };
+}
+
+/**
+ * Igual que resolveLiveAccess pero exige un rol MÍNIMO (jerárquico). Devuelve
+ * null si no hay acceso o el rol no alcanza. Úsalo en handlers que requieren
+ * r

--- a/lib/projects/invite-token.ts
+++ b/lib/projects/invite-token.ts
@@ -1,0 +1,77 @@
+/**
+ * Tokens de invitación del portal en vivo.
+ *
+ * Solo el HASH (SHA-256 hex) se guarda en DB (project_live_invitations.token_hash).
+ * El token en claro se entrega UNA vez al owner y jamás se persiste. Al aceptar,
+ * se rehashea el token presentado y se busca por hash — nunca se compara el
+ * token en claro contra la base.
+ *
+ * Nota: usa `node:crypto`, así que estos handlers deben correr en el runtime
+ * Node (no Edge). No importa "server-only" a propósito, para poder probar la
+ * lógica con `node --test` sin el runtime de Next.
+ */
+import { randomBytes, createHash, timingSafeEqual } from "node:crypto";
+
+/** Longitud en bytes del token aleatorio (32 bytes = 256 bits de entropía). */
+const TOKEN_BYTES = 32;
+
+/** Formato base64url sin padding — seguro para URLs. */
+function toBase64Url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** SHA-256 hex de un token en claro. Determinista. */
+export function hashInviteToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export interface GeneratedInvite {
+  /** Token en claro — se muestra UNA vez, no se guarda. */
+  token: string;
+  /** Hash a persistir en token_hash. */
+  tokenHash: string;
+}
+
+/** Genera un token nuevo aleatorio + su hash. */
+export function generateInviteToken(): GeneratedInvite {
+  const token = toBase64Url(randomBytes(TOKEN_BYTES));
+  return { token, tokenHash: hashInviteToken(token) };
+}
+
+/**
+ * ¿El token presentado corresponde al hash guardado? Comparación en tiempo
+ * constante sobre los hashes (ambos de longitud fija), para no filtrar por
+ * temporización. Fail-closed ante cualquier entrada inválida.
+ */
+export function verifyInviteToken(
+  presentedToken: string,
+  storedHash: string,
+): boolean {
+  if (typeof presentedToken !== "string" || typeof storedHash !== "string") {
+    return false;
+  }
+  const presentedHash = hashInviteToken(presentedToken);
+  if (presentedHash.length !== storedHash.length) return false;
+  try {
+    return timingSafeEqual(
+      Buffer.from(presentedHash, "utf8"),
+      Buffer.from(storedHash, "utf8"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Sanea un token que llega por request. Devuelve null si es obviamente inválido. */
+export function sanitizeToken(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const t = raw.trim();
+  // base64url razonable: 20..200 chars, solo alfabeto url-safe.
+  if (t.length < 20 || t.length > 200) return null;
+  if (!/^[A-Za-z0-9_-]+$/.test(t)) return null;
+  return t;
+}

--- a/lib/projects/live-portal.ts
+++ b/lib/projects/live-portal.ts
@@ -1,0 +1,100 @@
+/**
+ * Acceso a datos del portal en vivo — SERVER ONLY.
+ *
+ * Todas las consultas están acotadas por project_id (aislamiento por proyecto).
+ * Reusa el cliente Neon (`queryOne`/`queryAll`) y el esquema de la migración
+ * 024 (project_live_members, project_live_invitations, project_comments) y
+ * project_events (actividad).
+ */
+import "server-only";
+import { queryOne, queryAll } from "@/lib/db/client";
+import {
+  type LiveRole,
+  isLiveRole,
+} from "@/lib/projects/roles";
+import {
+  generateInviteToken,
+  hashInviteToken,
+} from "@/lib/projects/invite-token";
+
+const INVITE_DEFAULT_TTL_HOURS = 168; // 7 días
+const INVITE_MAX_TTL_HOURS = 24 * 30; // 30 días
+const COMMENT_MAX_LEN = 4000;
+
+export interface ProjectViewports {
+  id: string;
+  name: string;
+  status: string;
+  desktop_url: string | null;
+  mobile_url: string | null;
+  admin_url: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+}
+
+/** Metadatos + URLs de los 3 viewports. null si el proyecto no existe. */
+export async function getProjectViewports(
+  projectId: string,
+): Promise<ProjectViewports | null> {
+  return queryOne<ProjectViewports>(
+    `SELECT id, name, status, desktop_url, mobile_url, admin_url, vercel_url, domain
+       FROM projects WHERE id = $1 LIMIT 1`,
+    [projectId],
+  );
+}
+
+export interface InvitationSummary {
+  id: string;
+  email: string;
+  role: string;
+  invited_by: string | null;
+  created_at: string;
+  expires_at: string;
+  accepted_at: string | null;
+  revoked_at: string | null;
+}
+
+/** Lista invitaciones de un proyecto — SIN token ni hash (opaco). */
+export async function listInvitations(
+  projectId: string,
+): Promise<InvitationSummary[]> {
+  return queryAll<InvitationSummary>(
+    `SELECT id, email, role, invited_by, created_at, expires_at, accepted_at, revoked_at
+       FROM project_live_invitations
+      WHERE project_id = $1
+      ORDER BY created_at DESC
+      LIMIT 100`,
+    [projectId],
+  );
+}
+
+export interface CreatedInvitation {
+  invitation: InvitationSummary;
+  /** Token en claro — se devuelve UNA sola vez. */
+  token: string;
+}
+
+/**
+ * Crea una invitación segura (token hasheado, expiración, uso único).
+ * `ttlHours` se clampa a [1, 720]. Devuelve el token en claro una única vez.
+ */
+export async function createInvitation(args: {
+  projectId: string;
+  email: string;
+  role: LiveRole;
+  invitedBy: string | null;
+  ttlHours?: number;
+}): Promise<CreatedInvitation> {
+  const ttl = Math.min(
+    INVITE_MAX_TTL_HOURS,
+    Math.max(1, Math.floor(args.ttlHours ?? INVITE_DEFAULT_TTL_HOURS)),
+  );
+  const { token, tokenHash } = generateInviteToken();
+  const email = args.email.trim().toLowerCase();
+
+  const invitation = await queryOne<InvitationSummary>(
+    `INSERT INTO project_live_invitations
+        (project_id, email, role, token_hash, invited_by, expires_at)
+     VALUES ($1, $2, $3, $4, $5, now() + ($6 || ' hours')::interval)
+     RETURNING id, email, role, invited_by, created_at, expires_at, accepted_at, revoked_at`,
+    [args.proj

--- a/lib/projects/live-portal.ts
+++ b/lib/projects/live-portal.ts
@@ -97,4 +97,150 @@ export async function createInvitation(args: {
         (project_id, email, role, token_hash, invited_by, expires_at)
      VALUES ($1, $2, $3, $4, $5, now() + ($6 || ' hours')::interval)
      RETURNING id, email, role, invited_by, created_at, expires_at, accepted_at, revoked_at`,
-    [args.proj
+    [args.projectId, email, args.role, tokenHash, args.invitedBy, String(ttl)],
+  );
+  if (!invitation) {
+    throw new Error("invitation insert failed");
+  }
+  return { invitation, token };
+}
+
+export type AcceptResult =
+  | { ok: true; projectId: string; role: LiveRole }
+  | { ok: false; reason: "expired" | "used" | "revoked" | "email_mismatch" | "invalid" };
+
+/**
+ * Acepta una invitación por token en claro para `sessionEmail` / `clerkUserId`.
+ *
+ * ATÓMICO: el claim de la invitación (uso único) y el upsert de la membresía
+ * ocurren en UNA sola sentencia SQL (CTE data-modifying). El `UPDATE` valida en
+ * el mismo WHERE: hash, sin aceptar, sin revocar, no expirada y que el email de
+ * la invitación coincida con el de la sesión. Si no reclama fila, el `INSERT`
+ * no ve nada y la sentencia no devuelve fila → `invalid` genérico.
+ *
+ * No se usan transacciones multi-request del driver HTTP: es un único statement.
+ */
+export async function acceptInvitation(args: {
+  token: string;
+  sessionEmail: string;
+  clerkUserId: string;
+}): Promise<AcceptResult> {
+  const tokenHash = hashInviteToken(args.token);
+  const email = args.sessionEmail.trim().toLowerCase();
+
+  const row = await queryOne<{ project_id: string; role: string }>(
+    `WITH claimed AS (
+        UPDATE project_live_invitations
+           SET accepted_at = now(), accepted_by = $3
+         WHERE token_hash = $1
+           AND accepted_at IS NULL
+           AND revoked_at IS NULL
+           AND expires_at > now()
+           AND lower(email) = $2
+        RETURNING project_id, role, invited_by
+     ),
+     membership AS (
+        INSERT INTO project_live_members
+            (project_id, clerk_user_id, email, role, status, invited_by)
+        SELECT project_id, $3, $2, role, 'active', invited_by FROM claimed
+        ON CONFLICT (project_id, lower(email)) DO UPDATE
+           SET role = EXCLUDED.role,
+               status = 'active',
+               clerk_user_id = EXCLUDED.clerk_user_id,
+               expires_at = NULL
+        RETURNING project_id, role
+     )
+     SELECT project_id, role FROM membership`,
+    [tokenHash, email, args.clerkUserId],
+  );
+
+  // Sin fila (token inválido, ya usada/revocada, expirada o email distinto) o
+  // rol corrupto en la fila → rechazo opaco.
+  if (!row || !isLiveRole(row.role)) return { ok: false, reason: "invalid" };
+
+  return { ok: true, projectId: row.project_id, role: row.role };
+}
+
+export interface CommentRow {
+  id: string;
+  author_email: string;
+  author_name: string | null;
+  body: string;
+  created_at: string;
+}
+
+/** Lista comentarios del proyecto (más recientes primero). */
+export async function listComments(
+  projectId: string,
+  limit = 100,
+): Promise<CommentRow[]> {
+  const lim = Math.min(200, Math.max(1, Math.floor(limit)));
+  return queryAll<CommentRow>(
+    `SELECT id, author_email, author_name, body, created_at
+       FROM project_comments
+      WHERE project_id = $1
+      ORDER BY created_at DESC
+      LIMIT $2`,
+    [projectId, lim],
+  );
+}
+
+/** Crea un comentario. `body` se valida/recorta a COMMENT_MAX_LEN. */
+export async function createComment(args: {
+  projectId: string;
+  authorEmail: string;
+  authorName: string | null;
+  authorClerkId: string | null;
+  body: string;
+}): Promise<CommentRow | null> {
+  const body = args.body.trim().slice(0, COMMENT_MAX_LEN);
+  if (!body) return null;
+  return queryOne<CommentRow>(
+    `INSERT INTO project_comments
+        (project_id, author_clerk_id, author_email, author_name, body)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, author_email, author_name, body, created_at`,
+    [args.projectId, args.authorClerkId, args.authorEmail, args.authorName, body],
+  );
+}
+
+export interface LiveEventRow {
+  id: string;
+  event_type: string;
+  details: Record<string, unknown>;
+  severity: string;
+  ts: string;
+}
+
+/**
+ * Actividad reciente del proyecto desde project_events, ESTRICTAMENTE acotada
+ * por project_id. `since` (ISO) permite polling incremental.
+ */
+export async function listRecentEvents(args: {
+  projectId: string;
+  since?: string | null;
+  limit?: number;
+}): Promise<LiveEventRow[]> {
+  const lim = Math.min(100, Math.max(1, Math.floor(args.limit ?? 40)));
+  if (args.since) {
+    const since = new Date(args.since);
+    if (!Number.isNaN(since.getTime())) {
+      return queryAll<LiveEventRow>(
+        `SELECT id, event_type, details, severity, ts
+           FROM project_events
+          WHERE project_id = $1 AND ts > $2
+          ORDER BY ts DESC
+          LIMIT $3`,
+        [args.projectId, since.toISOString(), lim],
+      );
+    }
+  }
+  return queryAll<LiveEventRow>(
+    `SELECT id, event_type, details, severity, ts
+       FROM project_events
+      WHERE project_id = $1
+      ORDER BY ts DESC
+      LIMIT $2`,
+    [args.projectId, lim],
+  );
+}

--- a/lib/projects/roles.ts
+++ b/lib/projects/roles.ts
@@ -1,0 +1,103 @@
+/**
+ * Jerarquía de roles del portal en vivo — LÓGICA PURA, sin dependencias.
+ *
+ * Vive aislada (cero imports de Clerk / DB / server-only) para poder probarse
+ * con `node --test`. El resto del portal (access.ts) la consume.
+ *
+ * Jerarquía: owner > reviewer > observer.
+ */
+
+export type LiveRole = "owner" | "reviewer" | "observer";
+
+/** Rango numérico de cada rol. Mayor = más permisos. */
+export const ROLE_RANK: Record<LiveRole, number> = {
+  observer: 1,
+  reviewer: 2,
+  owner: 3,
+};
+
+export const LIVE_ROLES: readonly LiveRole[] = [
+  "observer",
+  "reviewer",
+  "owner",
+] as const;
+
+/** Type guard: ¿es un rol válido del portal? */
+export function isLiveRole(value: unknown): value is LiveRole {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(ROLE_RANK, value)
+  );
+}
+
+/**
+ * Normaliza una entrada arbitraria a un LiveRole. Si no es válida, cae al rol
+ * de MENOR privilegio (observer) — fail-closed por diseño.
+ */
+export function normalizeRole(value: unknown): LiveRole {
+  return isLiveRole(value) ? value : "observer";
+}
+
+/** Roles que se pueden INVITAR desde el portal. `owner` NUNCA es invitable. */
+export type InvitableRole = Exclude<LiveRole, "owner">;
+
+/** Type guard: ¿es un rol que se puede invitar? (solo observer / reviewer) */
+export function isInvitableRole(value: unknown): value is InvitableRole {
+  return value === "observer" || value === "reviewer";
+}
+
+/** ¿`role` cubre al menos el nivel de `min`? (jerarquía inclusiva) */
+export function roleAtLeast(role: LiveRole, min: LiveRole): boolean {
+  return ROLE_RANK[role] >= ROLE_RANK[min];
+}
+
+export interface MembershipRow {
+  role: string;
+  status: string;
+  /** ISO string, Date, o null (sin expiración). */
+  expires_at: string | Date | null;
+}
+
+/**
+ * Decide, de forma PURA y fail-closed, si una fila de membresía otorga acceso
+ * en el instante `now`. Devuelve el rol efectivo o null.
+ *
+ * Reglas (todas deben cumplirse):
+ *   · status === 'active'
+ *   · no expirada (expires_at nulo o en el futuro)
+ *   · role es un LiveRole válido
+ */
+export function resolveMembership(
+  row: MembershipRow | null | undefined,
+  now: Date = new Date(),
+): LiveRole | null {
+  if (!row) return null;
+  if (row.status !== "active") return null;
+  if (!isLiveRole(row.role)) return null;
+  if (row.expires_at != null) {
+    const exp = row.expires_at instanceof Date
+      ? row.expires_at
+      : new Date(row.expires_at);
+    // Fecha inválida o ya expirada → sin acceso.
+    if (Number.isNaN(exp.getTime()) || exp.getTime() <= now.getTime()) {
+      return null;
+    }
+  }
+  return row.role;
+}
+
+export interface InvitationRow {
+  role: string;
+  email: string;
+  /** ISO string o Date. */
+  expires_at: string | Date;
+  accepted_at: string | Date | null;
+  revoked_at?: string | Date | null;
+}
+
+export type InvitationCheck =
+  | { ok: true; role: LiveRole }
+  | { ok: false; reason: "expired" | "used" | "revoked" | "email_mismatch" | "invalid" };
+
+/**
+ * Valida de forma PURA si una inv

--- a/lib/projects/roles.ts
+++ b/lib/projects/roles.ts
@@ -100,4 +100,30 @@ export type InvitationCheck =
   | { ok: false; reason: "expired" | "used" | "revoked" | "email_mismatch" | "invalid" };
 
 /**
- * Valida de forma PURA si una inv
+ * Valida de forma PURA si una invitación puede aceptarse por `sessionEmail`
+ * en el instante `now`. Fail-closed: cualquier ambigüedad → not ok.
+ */
+export function checkInvitation(
+  row: InvitationRow | null | undefined,
+  sessionEmail: string,
+  now: Date = new Date(),
+): InvitationCheck {
+  if (!row || !isLiveRole(row.role)) return { ok: false, reason: "invalid" };
+  if (row.revoked_at != null) return { ok: false, reason: "revoked" };
+  if (row.accepted_at != null) return { ok: false, reason: "used" };
+
+  const exp = row.expires_at instanceof Date
+    ? row.expires_at
+    : new Date(row.expires_at);
+  if (Number.isNaN(exp.getTime()) || exp.getTime() <= now.getTime()) {
+    return { ok: false, reason: "expired" };
+  }
+
+  const invited = (row.email ?? "").trim().toLowerCase();
+  const session = (sessionEmail ?? "").trim().toLowerCase();
+  if (!invited || !session || invited !== session) {
+    return { ok: false, reason: "email_mismatch" };
+  }
+
+  return { ok: true, role: row.role };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,6 +22,11 @@ const isTwilioWebhook = createRouteMatcher(["/api/v/voice/twilio(.*)"]);
 // Rutas MCP: Clerk NO debe validar el Bearer (son tokens vfmcp_* propios,
 // no JWTs de Clerk). El handler MCP hace su propia autenticación.
 const isMcpRoute = createRouteMatcher(["/api/mcp", "/api/mcp/(.*)", "/api/mcp/public", "/api/mcp/public/(.*)"]);
+// Portal en vivo del cliente: accesible a CUALQUIER usuario autenticado
+// (owner/reviewer/observer), no solo al owner de la plataforma. El gating fino
+// por proyecto y rol vive en la página (/app/live) y en /api/live/*, que
+// resuelven la membresía con fail-closed. Aquí solo exigimos sesión.
+const isLivePortal = createRouteMatcher(["/app/live(.*)", "/api/live(.*)"]);
 
 /**
  * Valida el operator token del header Authorization en el edge. Comparación de
@@ -78,133 +83,4 @@ const isProtected = createRouteMatcher([
   "/api/vault(.*)",
   "/api/admin(.*)",
   "/api/workspace(.*)",
-  "/api/billing(.*)",
-  "/api/v/bridge(.*)",
-  "/api/v/voice(.*)",
-]);
-
-// Rutas exclusivas del owner (Luis): V, su cockpit y sus productos.
-const isOwnerOnly = createRouteMatcher([
-  "/app(.*)",
-  "/forge(.*)",
-  "/v",
-  "/forja(.*)",
-  "/api/cockpit(.*)",
-  "/api/graph(.*)",
-  "/api/github(.*)",
-  "/api/stats(.*)",
-  "/api/forge(.*)",
-  "/api/builder(.*)",
-  "/api/vault(.*)",
-  "/api/admin(.*)",
-  "/api/projects(.*)",
-  "/api/v/bridge(.*)",
-]);
-
-async function resolveOwner(userId: string): Promise<boolean> {
-  const cached = getCachedOwner(userId);
-  if (cached !== null) return cached;
-  try {
-    const cc = await clerkClient();
-    const user = await cc.users.getUser(userId);
-    const owner = isOwnerUser(user);
-    setCachedOwner(userId, owner);
-    return owner;
-  } catch {
-    return false;
-  }
-}
-
-export default hasClerk
-  ? clerkMiddleware(async (auth, req) => {
-      // Auth dual en /api/admin: un operator token válido salta Clerk (el Bearer
-      // no es un JWT de Clerk, así que Clerk lo rechazaría con 401). Sin token
-      // válido, la ruta cae al control de Clerk de abajo (la UI usa su sesión).
-      if (isAdminRoute(req) && hasValidOperatorToken(req)) return;
-      // Webhooks de Twilio (llamada de voz a V): Twilio no pasa por Clerk; se
-      // autentican con X-Twilio-Signature dentro del propio handler.
-      if (isTwilioWebhook(req)) return;
-      // MCP endpoints: los tokens vfmcp_* y tokens OAuth propios NO son JWTs
-      // de Clerk. Clerk los rechaza con token-invalid. El handler MCP (/api/mcp)
-      // hace su propia autenticación interna. Dejar pasar siempre.
-      if (isMcpRoute(req)) return;
-      if (!isProtected(req)) return;
-      const { userId, sessionClaims, redirectToSignIn } = await auth();
-      const isApi = req.nextUrl.pathname.startsWith("/api");
-
-      if (!userId) {
-        if (isApi) {
-          return new NextResponse(JSON.stringify({ error: "unauthorized" }), {
-            status: 401,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        // redirectToSignIn() de Clerk hace el handshake/refresh de token
-        // (a diferencia de un redirect manual, que dejaba al usuario CON
-        // sesion activa en un bucle /app <-> /sign-in). signInUrl="/sign-in"
-        // en clerkMiddleware (abajo) lo apunta a la pagina PROPIA, nunca al
-        // Account Portal hosteado accounts.vforge.site.
-        return redirectToSignIn({ returnBackUrl: req.url });
-      }
-
-      const claimRole = (
-        sessionClaims?.publicMetadata as { role?: string } | undefined
-      )?.role;
-
-      // --- Rutas API ---
-      // Solo las owner-only necesitan gating extra; el resto ya pasó el auth
-      // de arriba. El onboarding NO bloquea APIs (rompería /api/onboarding/*
-      // y /api/user/complete-onboarding, que el flujo necesita).
-      if (isApi) {
-        if (isOwnerOnly(req)) {
-          const owner =
-            claimRole === "owner" ? true : await resolveOwner(userId);
-          if (!owner) {
-            return new NextResponse(JSON.stringify({ error: "forbidden" }), {
-              status: 403,
-              headers: { "Content-Type": "application/json" },
-            });
-          }
-        }
-        return;
-      }
-
-      // --- Rutas de página: los 3 tipos de usuario ---
-      const owner = claimRole === "owner" ? true : await resolveOwner(userId);
-      const onOnboarding = req.nextUrl.pathname.startsWith("/onboarding");
-
-      // Tipo 1 — Owner (Luis/Jaime): acceso total a todo, nunca onboarding.
-      if (owner) {
-        if (onOnboarding) {
-          return NextResponse.redirect(new URL("/app/chat", req.url));
-        }
-        return;
-      }
-
-      // Tipo 2 — Cliente intentando entrar a una ruta exclusiva del owner
-      // (/app, /forge, /v): se le redirige a su propio workspace.
-      if (isOwnerOnly(req)) {
-        return NextResponse.redirect(new URL("/workspace", req.url));
-      }
-
-      // Tipo 2 — Cliente en su propio espacio: gate de onboarding.
-      //   sin onboarding  → /onboarding
-      //   con onboarding y cae en /onboarding → /workspace
-      const claimOnboard = (
-        sessionClaims?.publicMetadata as
-          | { onboardingComplete?: boolean }
-          | undefined
-      )?.onboardingComplete;
-      const onboarded = await resolveOnboardingComplete(userId, claimOnboard);
-      if (!onboarded && !onOnboarding && !req.nextUrl.pathname.startsWith("/workspace")) {
-        return NextResponse.redirect(new URL("/onboarding", req.url));
-      }
-      if (onboarded && onOnboarding) {
-        return NextResponse.redirect(new URL("/workspace", req.url));
-      }
-    }, { signInUrl: "/sign-in", signUpUrl: "/sign-up" })
-  : () => NextResponse.next();
-
-export const config = {
-  matcher: ["/((?!_next|.*\\..*).*)", "/(api|trpc)(.*)"],
-};
+  "/

--- a/middleware.ts
+++ b/middleware.ts
@@ -83,4 +83,141 @@ const isProtected = createRouteMatcher([
   "/api/vault(.*)",
   "/api/admin(.*)",
   "/api/workspace(.*)",
-  "/
+  "/api/billing(.*)",
+  "/api/v/bridge(.*)",
+  "/api/v/voice(.*)",
+  "/api/live(.*)",
+]);
+
+// Rutas exclusivas del owner (Luis): V, su cockpit y sus productos.
+const isOwnerOnly = createRouteMatcher([
+  "/app(.*)",
+  "/forge(.*)",
+  "/v",
+  "/forja(.*)",
+  "/api/cockpit(.*)",
+  "/api/graph(.*)",
+  "/api/github(.*)",
+  "/api/stats(.*)",
+  "/api/forge(.*)",
+  "/api/builder(.*)",
+  "/api/vault(.*)",
+  "/api/admin(.*)",
+  "/api/projects(.*)",
+  "/api/v/bridge(.*)",
+]);
+
+async function resolveOwner(userId: string): Promise<boolean> {
+  const cached = getCachedOwner(userId);
+  if (cached !== null) return cached;
+  try {
+    const cc = await clerkClient();
+    const user = await cc.users.getUser(userId);
+    const owner = isOwnerUser(user);
+    setCachedOwner(userId, owner);
+    return owner;
+  } catch {
+    return false;
+  }
+}
+
+export default hasClerk
+  ? clerkMiddleware(async (auth, req) => {
+      // Auth dual en /api/admin: un operator token válido salta Clerk (el Bearer
+      // no es un JWT de Clerk, así que Clerk lo rechazaría con 401). Sin token
+      // válido, la ruta cae al control de Clerk de abajo (la UI usa su sesión).
+      if (isAdminRoute(req) && hasValidOperatorToken(req)) return;
+      // Webhooks de Twilio (llamada de voz a V): Twilio no pasa por Clerk; se
+      // autentican con X-Twilio-Signature dentro del propio handler.
+      if (isTwilioWebhook(req)) return;
+      // MCP endpoints: los tokens vfmcp_* y tokens OAuth propios NO son JWTs
+      // de Clerk. Clerk los rechaza con token-invalid. El handler MCP (/api/mcp)
+      // hace su propia autenticación interna. Dejar pasar siempre.
+      if (isMcpRoute(req)) return;
+      if (!isProtected(req)) return;
+      const { userId, sessionClaims, redirectToSignIn } = await auth();
+      const isApi = req.nextUrl.pathname.startsWith("/api");
+
+      if (!userId) {
+        if (isApi) {
+          return new NextResponse(JSON.stringify({ error: "unauthorized" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        // redirectToSignIn() de Clerk hace el handshake/refresh de token
+        // (a diferencia de un redirect manual, que dejaba al usuario CON
+        // sesion activa en un bucle /app <-> /sign-in). signInUrl="/sign-in"
+        // en clerkMiddleware (abajo) lo apunta a la pagina PROPIA, nunca al
+        // Account Portal hosteado accounts.vforge.site.
+        return redirectToSignIn({ returnBackUrl: req.url });
+      }
+
+      const claimRole = (
+        sessionClaims?.publicMetadata as { role?: string } | undefined
+      )?.role;
+
+      // --- Rutas API ---
+      // Solo las owner-only necesitan gating extra; el resto ya pasó el auth
+      // de arriba. El onboarding NO bloquea APIs (rompería /api/onboarding/*
+      // y /api/user/complete-onboarding, que el flujo necesita).
+      if (isApi) {
+        if (isOwnerOnly(req)) {
+          const owner =
+            claimRole === "owner" ? true : await resolveOwner(userId);
+          if (!owner) {
+            return new NextResponse(JSON.stringify({ error: "forbidden" }), {
+              status: 403,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+        }
+        return;
+      }
+
+      // --- Rutas de página: los 3 tipos de usuario ---
+      const owner = claimRole === "owner" ? true : await resolveOwner(userId);
+      const onOnboarding = req.nextUrl.pathname.startsWith("/onboarding");
+
+      // Tipo 1 — Owner (Luis/Jaime): acceso total a todo, nunca onboarding.
+      if (owner) {
+        if (onOnboarding) {
+          return NextResponse.redirect(new URL("/app/chat", req.url));
+        }
+        return;
+      }
+
+      // Portal en vivo: cualquier sesión válida pasa el edge. La página y las
+      // APIs (/api/live/*) verifican la membresía real por proyecto y rol con
+      // fail-closed, así que no aplicamos owner-only ni el gate de onboarding.
+      if (isLivePortal(req)) {
+        return;
+      }
+
+      // Tipo 2 — Cliente intentando entrar a una ruta exclusiva del owner
+      // (/app, /forge, /v): se le redirige a su propio workspace.
+      if (isOwnerOnly(req)) {
+        return NextResponse.redirect(new URL("/workspace", req.url));
+      }
+
+      // Tipo 2 — Cliente en su propio espacio: gate de onboarding.
+      //   sin onboarding  → /onboarding
+      //   con onboarding y cae en /onboarding → /workspace
+      const claimOnboard = (
+        sessionClaims?.publicMetadata as
+          | { onboardingComplete?: boolean }
+          | undefined
+      )?.onboardingComplete;
+      const onboarded = await resolveOnboardingComplete(userId, claimOnboard);
+      if (!onboarded && !onOnboarding && !req.nextUrl.pathname.startsWith("/workspace")) {
+        return NextResponse.redirect(new URL("/onboarding", req.url));
+      }
+      if (onboarded && onOnboarding) {
+        return NextResponse.redirect(new URL("/workspace", req.url));
+      }
+    }, { signInUrl: "/sign-in", signUpUrl: "/sign-up" })
+  : () => NextResponse.next();
+
+export const config = {
+  matcher: ["/((?!_next|.*\\..*).*)", "/(api|trpc)(.*)"],
+};

--- a/migrations/024_live_portal.sql
+++ b/migrations/024_live_portal.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- 024_live_portal.sql — PORTAL EN VIVO por proyecto (estudio privado VForge)
+-- ============================================================================
+-- Primera entrega ACOTADA del portal /app/live/[projectId]:
+--   · Membresías por proyecto con roles owner / reviewer / observer + expiración.
+--   · Invitaciones SEGURAS: solo se guarda el HASH del token (nunca el token en
+--     claro), con expiración y uso único (single-use).
+--   · Comentarios por proyecto.
+--   · URLs desktop / mobile / admin del proyecto (los 3 viewports en vivo).
+--
+-- 100% ADITIVA e idempotente: CREATE ... IF NOT EXISTS / ADD COLUMN IF NOT
+-- EXISTS en todo. NO altera tablas existentes de forma destructiva ni toca
+-- project_members (la membresía del cockpit del owner) — este portal vive en
+-- su propio namespace `project_live_*` para no interferir. Reusa projects(id)
+-- y project_events (actividad) tal cual existen.
+--
+-- NO ejecutar en producción desde el agente: este archivo solo declara el
+-- esquema; la migración se aplica por el flujo normal de migraciones.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- projects: URLs de los 3 viewports en vivo (si no existen).
+-- ----------------------------------------------------------------------------
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS desktop_url text;
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS mobile_url  text;
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS admin_url   text;
+
+-- ----------------------------------------------------------------------------
+-- project_live_members — quién entra al portal en vivo de un proyecto y con
+-- qué rol. Jerarquía: owner > reviewer > observer.
+--   · observer: ve los viewports y la actividad, puede comentar.
+--   · reviewer: además ve el viewport ADMIN.
+--   · owner:    además administra invitaciones.
+-- La membresía puede EXPIRAR (expires_at). NULL = sin expiración.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS project_live_members (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id     text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  clerk_user_id  text,
+  email          text NOT NULL,
+  role           text NOT NULL DEFAULT 'observer'
+                   CHECK (role IN ('owner','reviewer','observer')),
+  status         text NOT NULL DEFAULT 'active'
+                   CHECK (status IN ('active','revoked')),
+  invited_by     text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  expires_at     timestamptz
+);
+-- Un email = una membresía por proyecto (case-insensitive).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_plm_project_email
+  ON project_live_members (project_id, lower(email));
+CREATE INDEX IF NOT EXISTS idx_plm_project ON project_live_members (project_id);
+CREATE INDEX IF NOT EXI

--- a/migrations/024_live_portal.sql
+++ b/migrations/024_live_portal.sql
@@ -50,4 +50,49 @@ CREATE TABLE IF NOT EXISTS project_live_members (
 CREATE UNIQUE INDEX IF NOT EXISTS uq_plm_project_email
   ON project_live_members (project_id, lower(email));
 CREATE INDEX IF NOT EXISTS idx_plm_project ON project_live_members (project_id);
-CREATE INDEX IF NOT EXI
+CREATE INDEX IF NOT EXISTS idx_plm_clerk   ON project_live_members (clerk_user_id);
+
+-- ----------------------------------------------------------------------------
+-- project_live_invitations — invitaciones seguras con token HASHEADO.
+--   · token_hash: SHA-256 (hex) del token en claro. El token en claro solo se
+--     devuelve UNA vez al crear la invitación; nunca se persiste.
+--   · expira (expires_at NOT NULL) y es de uso único (accepted_at NULL = sin
+--     usar; una vez aceptada no se puede reutilizar).
+--   · email: la invitación queda ligada a un correo — al aceptar se verifica
+--     que coincida con el de la sesión.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS project_live_invitations (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id     text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  email          text NOT NULL,
+  role           text NOT NULL DEFAULT 'observer'
+                   CHECK (role IN ('owner','reviewer','observer')),
+  token_hash     text NOT NULL,
+  invited_by     text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  expires_at     timestamptz NOT NULL,
+  accepted_at    timestamptz,
+  accepted_by    text,
+  revoked_at     timestamptz
+);
+-- El hash del token es único a nivel global (localiza la invitación al aceptar).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pli_token_hash
+  ON project_live_invitations (token_hash);
+CREATE INDEX IF NOT EXISTS idx_pli_project ON project_live_invitations (project_id);
+CREATE INDEX IF NOT EXISTS idx_pli_email   ON project_live_invitations (project_id, lower(email));
+
+-- ----------------------------------------------------------------------------
+-- project_comments — comentarios por proyecto dentro del portal en vivo.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS project_comments (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id      text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  author_clerk_id text,
+  author_email    text NOT NULL,
+  author_name     text,
+  body            text NOT NULL CHECK (char_length(body) BETWEEN 1 AND 4000),
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_pc_project ON project_comments (project_id, created_at DESC);
+
+SELECT 'migracion 024 (live portal) OK' AS resultado;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,9 +5,6 @@ const nextConfig = {
   turbopack: {
     root: import.meta.dirname,
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     unoptimized: true,
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
         "build": "next build",
         "start": "next start",
         "lint": "eslint .",
+        "typecheck": "tsc --noEmit",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/invite-token.test.ts
+++ b/tests/invite-token.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateInviteToken,
+  hashInviteToken,
+  verifyInviteToken,
+  sanitizeToken,
+} from "../lib/projects/invite-token";
+
+test("generateInviteToken returns url-safe token + matching hash", () => {
+  const { token, tokenHash } = generateInviteToken();
+  assert.match(token, /^[A-Za-z0-9_-]+$/);
+  assert.ok(token.length >= 40);
+  assert.equal(tokenHash, hashInviteToken(token));
+  assert.match(tokenHash, /^[a-f0-9]{64}$/); // sha256 hex
+});
+
+test("two tokens are distinct", () => {
+  const a = generateInviteToken();
+  const b = generateInviteToken();
+  assert.notEqual(a.token, b.token);
+  assert.notEqual(a.tokenHash, b.tokenHash);
+});
+
+test("hashInviteToken is deterministic", () => {
+  assert.equal(hashInviteToken("abc"), hashInviteToken("abc"));
+  assert.notEqual(hashInviteToken("abc"), hashInviteToken("abd"));
+});
+
+test("verifyInviteToken: correct token passes, wrong fails", () => {
+  const { token, tokenHash } = generateInviteToken();
+  assert.equal(verifyInviteToken(token, tokenHash), true);
+  assert.equal(verifyInviteToken(token + "x", tokenHash), false);
+  assert.equal(verifyInviteToken("", tokenHash), false);
+  assert.equal(verifyInviteToken(token, "deadbeef"), false); // longitud distinta
+});
+
+test("sanitizeToken accepts valid, rejects garbage", () => {
+  const { token } = generateInviteToken();
+  assert.equal(sanitizeToken(token), token);
+  assert.equal(sanitizeToken("  " + token + "  "), token); // trim
+  assert.equal(sanitizeToken("short"), null);
+  assert.equal(sanitizeToken("has spaces and $ymbols"), null);
+  assert.equal(sanitizeToken(12345), null);
+  assert.equal(sanitizeToken(null), null);
+  assert.equal(sanitizeToken("x".repeat(300)), null);
+});

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -93,4 +93,35 @@ test("checkInvitation: happy path", () => {
   assert.deepEqual(r, { ok: true, role: "reviewer" });
 });
 
-test("checkInvitation: 
+test("checkInvitation: email mismatch", () => {
+  const r = checkInvitation(
+    { role: "reviewer", email: "a@test.com", expires_at: future, accepted_at: null },
+    "b@test.com",
+    NOW,
+  );
+  assert.deepEqual(r, { ok: false, reason: "email_mismatch" });
+});
+
+test("checkInvitation: expired / used / revoked / invalid", () => {
+  assert.equal(
+    checkInvitation({ role: "owner", email: "a@t.com", expires_at: past, accepted_at: null }, "a@t.com", NOW).ok,
+    false,
+  );
+  assert.deepEqual(
+    checkInvitation({ role: "owner", email: "a@t.com", expires_at: future, accepted_at: future }, "a@t.com", NOW),
+    { ok: false, reason: "used" },
+  );
+  assert.deepEqual(
+    checkInvitation(
+      { role: "owner", email: "a@t.com", expires_at: future, accepted_at: null, revoked_at: past },
+      "a@t.com",
+      NOW,
+    ),
+    { ok: false, reason: "revoked" },
+  );
+  assert.deepEqual(
+    checkInvitation({ role: "nope", email: "a@t.com", expires_at: future, accepted_at: null }, "a@t.com", NOW),
+    { ok: false, reason: "invalid" },
+  );
+  assert.deepEqual(checkInvitation(null, "a@t.com", NOW), { ok: false, reason: "invalid" });
+});

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ROLE_RANK,
+  roleAtLeast,
+  isLiveRole,
+  isInvitableRole,
+  normalizeRole,
+  resolveMembership,
+  checkInvitation,
+} from "../lib/projects/roles";
+
+const NOW = new Date("2026-08-18T00:00:00.000Z");
+const future = new Date("2026-12-31T00:00:00.000Z").toISOString();
+const past = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+test("ROLE_RANK order owner > reviewer > observer", () => {
+  assert.ok(ROLE_RANK.owner > ROLE_RANK.reviewer);
+  assert.ok(ROLE_RANK.reviewer > ROLE_RANK.observer);
+});
+
+test("roleAtLeast respects hierarchy", () => {
+  assert.equal(roleAtLeast("owner", "observer"), true);
+  assert.equal(roleAtLeast("reviewer", "reviewer"), true);
+  assert.equal(roleAtLeast("observer", "reviewer"), false);
+  assert.equal(roleAtLeast("reviewer", "owner"), false);
+});
+
+test("isLiveRole / normalizeRole are fail-closed", () => {
+  assert.equal(isLiveRole("owner"), true);
+  assert.equal(isLiveRole("admin"), false);
+  assert.equal(isLiveRole(null), false);
+  assert.equal(normalizeRole("reviewer"), "reviewer");
+  assert.equal(normalizeRole("editor"), "observer"); // desconocido -> menor privilegio
+  assert.equal(normalizeRole(undefined), "observer");
+});
+
+test("isInvitableRole: solo observer/reviewer, nunca owner", () => {
+  assert.equal(isInvitableRole("observer"), true);
+  assert.equal(isInvitableRole("reviewer"), true);
+  assert.equal(isInvitableRole("owner"), false);
+  assert.equal(isInvitableRole("admin"), false);
+  assert.equal(isInvitableRole(null), false);
+  assert.equal(isInvitableRole(undefined), false);
+});
+
+test("resolveMembership: active, no expiry -> role", () => {
+  assert.equal(
+    resolveMembership({ role: "reviewer", status: "active", expires_at: null }, NOW),
+    "reviewer",
+  );
+});
+
+test("resolveMembership: future expiry -> role", () => {
+  assert.equal(
+    resolveMembership({ role: "owner", status: "active", expires_at: future }, NOW),
+    "owner",
+  );
+});
+
+test("resolveMembership: expired -> null", () => {
+  assert.equal(
+    resolveMembership({ role: "owner", status: "active", expires_at: past }, NOW),
+    null,
+  );
+});
+
+test("resolveMembership: revoked -> null", () => {
+  assert.equal(
+    resolveMembership({ role: "owner", status: "revoked", expires_at: null }, NOW),
+    null,
+  );
+});
+
+test("resolveMembership: invalid role / null row / bad date -> null", () => {
+  assert.equal(
+    resolveMembership({ role: "superuser", status: "active", expires_at: null }, NOW),
+    null,
+  );
+  assert.equal(resolveMembership(null, NOW), null);
+  assert.equal(
+    resolveMembership({ role: "owner", status: "active", expires_at: "not-a-date" }, NOW),
+    null,
+  );
+});
+
+test("checkInvitation: happy path", () => {
+  const r = checkInvitation(
+    { role: "reviewer", email: "Cliente@Test.com", expires_at: future, accepted_at: null },
+    "cliente@test.com",
+    NOW,
+  );
+  assert.deepEqual(r, { ok: true, role: "reviewer" });
+});
+
+test("checkInvitation: 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,21 @@
+{
+  "//": "Config aislada para pruebas node:test. Transpila SOLO los módulos puros del portal en vivo + los tests con el compilador TS ya presente (devDep), sin plugins de Next. Emite CommonJS a .test-dist para correr con `node --test`. Sin dependencias nuevas.",
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": false,
+    "outDir": ".test-dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": [
+    "tests/**/*.ts",
+    "lib/projects/roles.ts",
+    "lib/projects/invite-token.ts"
+  ]
+}


### PR DESCRIPTION
## Qué cambia

- Añade `/app/live/[projectId]` con viewports desktop, móvil y admin.
- Añade membresías por proyecto con roles `owner`, `reviewer` y `observer`, expiración y guards fail-closed.
- Añade invitaciones de uso único con token hasheado, comentarios y actividad aislada por proyecto.
- Evita serializar `admin_url` a observadores y limita invitaciones a reviewer/observer.
- Neutraliza `fix-skills-table`, protege `/api/v1/forge/run` y vuelve a habilitar errores TypeScript en build.

## Alcance

Portal privado y controlado; no incorpora monetización, marketplace ni acciones autónomas. La migración es aditiva y no fue ejecutada. Producción no fue modificada.

## Validación

- `npm run typecheck`: pasa.
- `npm run lint`: 0 errores; 80 warnings preexistentes.
- `npm test`: 17/17 pasan.
- `next build` con Node 22 y Clerk test key: pasa.
- `git diff --check`: pasa.

## Pendiente antes de merge

Aplicar la migración únicamente en staging, configurar URLs de un proyecto de prueba y validar con dos usuarios Clerk que el observer no acceda al admin ni a proyectos ajenos.