### PR TITLE
fix: stabilize mobile workspace and isolate projects

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,7 +1,7 @@
 # VForge — Manual / README completo
 
 **Dominio:** https://vforge.site · **Stack:** Next.js 16.2.4 (App Router, React 19) · Clerk (auth) · Neon Postgres · Vercel (deploy) · Tailwind 3 · framer-motion · MCP (mcp-handler).
-**Tema visual:** obsidian dark, dos esferas (la forja VForge + el copiloto Vulcano/V).
+**Tema visual:** sistema propio blanco y negro, mobile-first, con estudio del owner y salas privadas por proyecto.
 **Última verificación:** 2026-06-10 — deploy READY, alias vforge.site, consola y red **limpias** en todas las rutas (0 errores).
 
 ---
@@ -19,14 +19,16 @@ VForge es "la fábrica de apps con IA": dos piezas en un sistema —
 La autorización vive en `middleware.ts` + `lib/auth/owner.ts`. Hay tres formas de identidad:
 
 ### a) Owner (Luis) — acceso total
-Un usuario es **owner** si:
-- su `publicMetadata.role === "owner"` en Clerk, **o**
-- alguno de sus emails está en `VFORGE_OWNER_EMAILS` (CSV en env). Default: `turbillon50@gmail.com, dluisdelatorre@gmail.com, luisdelator@vmomentums.info`.
+Un usuario es **owner** únicamente si alguno de sus emails está en
+`VFORGE_OWNER_EMAILS` (CSV en env). Default:
+`turbillon50@gmail.com, jaime@vmomentums.info`. La metadata de Clerk nunca
+eleva permisos; las cuentas secundarias sólo ven proyectos donde tienen una
+membresía activa.
 
 El owner ve todo el cockpit `/app/*`, la V (`/forge`, `/v`) y todos los endpoints owner-only.
 
 ### b) Usuario registrado NO-owner — su propio workspace
-Cualquier persona que se registra con Clerk y **no** es owner. Al intentar entrar a una ruta owner-only es redirigida automáticamente a **`/workspace`** (su espacio propio). No ve los datos privados de la V ni el cockpit de Luis.
+Cualquier persona que se registra con Clerk y **no** es owner. Al intentar entrar a una ruta owner-only es redirigida automáticamente a **`/workspace`** (su espacio propio). El catálogo sólo incluye proyectos ligados a su correo por una membresía activa; no ve los datos privados de la V ni el cockpit de Luis.
 
 ### c) Operator token — para CLI / curl del owner
 Endpoints `/api/admin/*` aceptan además un **Bearer token** (`VFORGE_OPERATOR_TOKEN`) con comparación de tiempo constante en el edge. Sirve para automatización (migraciones, seed, health) sin sesión de navegador.

--- a/app/(dashboard)/forja/page.tsx
+++ b/app/(dashboard)/forja/page.tsx
@@ -7,19 +7,16 @@ export const metadata = { title: "La Forja — VForge" };
 export const dynamic = "force-dynamic";
 
 export default async function ForjaPage() {
-  const { userId, sessionClaims } = await auth();
+  const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  const role = (sessionClaims?.publicMetadata as { role?: string } | undefined)?.role;
-  let owner = role === "owner";
-  if (!owner) {
-    try {
-      const cc = await clerkClient();
-      const u = await cc.users.getUser(userId);
-      owner = isOwnerUser(u);
-    } catch {
-      owner = false;
-    }
+  let owner = false;
+  try {
+    const cc = await clerkClient();
+    const u = await cc.users.getUser(userId);
+    owner = isOwnerUser(u);
+  } catch {
+    owner = false;
   }
   if (!owner) redirect("/workspace");
 

--- a/app/api/my-project/route.ts
+++ b/app/api/my-project/route.ts
@@ -1,26 +1,15 @@
 /**
  * API Portal Cliente — lista de proyectos del usuario actual (read-only).
  *
- * GET — devuelve los proyectos donde el usuario es miembro ACTIVO.
- *   Match por email (project_members.email = email del usuario en Clerk)
- *   y status = 'active'. Join con projects para los datos del proyecto.
+ * GET — devuelve exclusivamente proyectos con membresía ACTIVA para el correo
+ * actual, tanto del portal histórico como de las salas live nuevas.
  */
 import { NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
-import { queryAll } from "@/lib/db/client";
+import { listScopedProjects } from "@/lib/projects/scoped-catalog";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-type MyProjectRow = {
-  project_id: string;
-  member_role: string;
-  name: string;
-  status: string;
-  github_repo: string | null;
-  vercel_url: string | null;
-  domain: string | null;
-};
 
 export async function GET() {
   const user = await currentUser();
@@ -33,21 +22,7 @@ export async function GET() {
     );
   }
 
-  const rows = await queryAll<MyProjectRow>(
-    `SELECT pm.project_id     AS project_id,
-            pm.role           AS member_role,
-            p.name            AS name,
-            p.status          AS status,
-            p.github_repo     AS github_repo,
-            p.vercel_url      AS vercel_url,
-            p.domain          AS domain
-       FROM project_members pm
-       JOIN projects p ON p.id = pm.project_id
-      WHERE lower(pm.email) = lower($1)
-        AND pm.status = 'active'
-      ORDER BY p.name ASC`,
-    [email],
-  );
+  const rows = await listScopedProjects(email);
 
   return NextResponse.json(
     { projects: rows },

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,4 +1,5 @@
 import { sql, queryOne } from "@/lib/db/client";
+import { resolveRequestOwner } from "@/lib/auth/request-owner";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -35,6 +36,9 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
   const { id } = await params;
 
   const project = await queryOne<ProjectDetail>(
@@ -52,13 +56,13 @@ export async function GET(
   if (!project) {
     return new Response(JSON.stringify({ error: "project not found" }), {
       status: 404,
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
     });
   }
 
   return new Response(JSON.stringify({ project }), {
     status: 200,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
   });
 }
 
@@ -72,6 +76,9 @@ export async function DELETE(
   _req: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const denied = await requireOwner();
+  if (denied) return denied;
+
   const { id } = await params;
 
   try {
@@ -81,7 +88,7 @@ export async function DELETE(
     if (rows.length === 0) {
       return new Response(JSON.stringify({ error: "project not found" }), {
         status: 404,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
       });
     }
 
@@ -95,13 +102,30 @@ export async function DELETE(
 
     return new Response(JSON.stringify({ deleted: rows[0] }), {
       status: 200,
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return new Response(JSON.stringify({ error: `db error: ${message}` }), {
       status: 500,
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
     });
   }
+}
+
+async function requireOwner(): Promise<Response | null> {
+  const access = await resolveRequestOwner();
+  if (!access.userId) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+    });
+  }
+  if (!access.isOwner) {
+    return new Response(JSON.stringify({ error: "forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+    });
+  }
+  return null;
 }

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,5 +1,5 @@
 import { queryAll, sql } from "@/lib/db/client";
-import { resolveAccess } from "@/lib/connect/resolve-token";
+import { resolveRequestOwner } from "@/lib/auth/request-owner";
 import { createRepo } from "@/lib/github/client";
 import { neon } from "@neondatabase/serverless";
 
@@ -36,16 +36,14 @@ const OPERATOR_USER_ID = "operator_luis";
  */
 export async function GET() {
   // AISLAMIENTO: el catálogo `projects` es del owner. Un no-owner NO lo ve.
-  const access = await resolveAccess();
+  const access = await resolveRequestOwner();
   if (!access.userId) {
     return new Response(JSON.stringify({ error: "unauthorized" }), {
       status: 401, headers: { "Content-Type": "application/json" },
     });
   }
   if (!access.isOwner) {
-    return new Response(JSON.stringify({ projects: [] }), {
-      status: 200, headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
-    });
+    return jsonError("forbidden", 403);
   }
   const rows = await queryAll<ProjectRow>(
     `SELECT id, name, category, status,
@@ -66,7 +64,7 @@ export async function GET() {
   );
   return new Response(JSON.stringify({ projects: rows }), {
     status: 200,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
   });
 }
 
@@ -77,6 +75,10 @@ export async function GET() {
  * Validates id format and category enum, audit-logs the action.
  */
 export async function POST(req: Request) {
+  const access = await resolveRequestOwner();
+  if (!access.userId) return jsonError("unauthorized", 401);
+  if (!access.isOwner) return jsonError("forbidden", 403);
+
   let body: {
     id?: string;
     name?: string;
@@ -195,7 +197,7 @@ export async function POST(req: Request) {
       }),
       {
         status: 201,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
       },
     );
   } catch (err) {
@@ -211,6 +213,6 @@ export async function POST(req: Request) {
 function jsonError(message: string, status: number): Response {
   return new Response(JSON.stringify({ error: message }), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
   });
 }

--- a/app/api/user/complete-onboarding/route.ts
+++ b/app/api/user/complete-onboarding/route.ts
@@ -7,6 +7,7 @@
  * el saludo de V en el workspace. Idempotente: llamarlo dos veces no rompe nada.
  */
 import { auth, clerkClient } from "@clerk/nextjs/server";
+import { isOwnerUser } from "@/lib/auth/owner";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -17,19 +18,21 @@ export async function POST(req: Request) {
 
   const body = (await req.json().catch(() => ({}))) as {
     name?: string;
-    role?: string;
     services?: number;
   };
 
   try {
     const cc = await clerkClient();
     const user = await cc.users.getUser(userId);
+    const metadata = { ...(user.publicMetadata ?? {}) } as Record<string, unknown>;
+    const owner = isOwnerUser(user);
+    if (!owner && metadata.role === "owner") metadata.role = "user";
     await cc.users.updateUser(userId, {
       publicMetadata: {
-        ...(user.publicMetadata ?? {}),
+        ...metadata,
         onboardingComplete: true,
         onboardingName: body.name?.trim() || undefined,
-        onboardingRole: body.role || undefined,
+        onboardingRole: owner ? "owner" : "client",
         servicesConnected:
           typeof body.services === "number" ? body.services : undefined,
       },

--- a/app/api/vulcano/mission-control/route.ts
+++ b/app/api/vulcano/mission-control/route.ts
@@ -3,6 +3,7 @@
 
 import { NextResponse } from "next/server";
 import { queryAll, queryOne } from "@/lib/db/client";
+import { resolveRequestOwner } from "@/lib/auth/request-owner";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -28,7 +29,8 @@ interface JobRow {
 
 async function fetchBrain(path: string, body?: object) {
   const BRAIN = process.env.RELAY_BASE_URL || "http://178.105.135.26";
-  const SECRET = process.env.HETZNER_SECRET || "superclaude2025";
+  const SECRET = process.env.HETZNER_SECRET;
+  if (!SECRET) return null;
   try {
     const r = await fetch(`${BRAIN}${path}`, {
       method: "POST",
@@ -42,6 +44,20 @@ async function fetchBrain(path: string, body?: object) {
 }
 
 export async function GET() {
+  const access = await resolveRequestOwner();
+  if (!access.userId) {
+    return NextResponse.json(
+      { error: "unauthorized" },
+      { status: 401, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  if (!access.isOwner) {
+    return NextResponse.json(
+      { error: "forbidden" },
+      { status: 403, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
   const [
     projects,
     vState,
@@ -70,31 +86,44 @@ export async function GET() {
     query: "SELECT id, agent, source, status, LEFT(result,150) as result_preview, created_at FROM dispatch_queue ORDER BY created_at DESC LIMIT 20"
   });
 
-  return NextResponse.json({
-    timestamp: new Date().toISOString(),
-    v: {
-      state: vState,
-      memory: vMemory,
-      proactive: vProactive,
-      episodes,
+  return NextResponse.json(
+    {
+      timestamp: new Date().toISOString(),
+      v: {
+        state: vState,
+        memory: vMemory,
+        proactive: vProactive,
+        episodes,
+      },
+      projects: projects.map((p) => ({
+        ...p,
+        health: p.blocked
+          ? "blocked"
+          : p.phase === "produccion"
+            ? "live"
+            : "building",
+      })),
+      brain: {
+        skills: brainData?.skills || 0,
+        projects_count: brainData?.projects?.length || 0,
+        lessons_count: brainData?.lessons?.length || 0,
+        recent_memory: brainData?.recent_memory || [],
+        top_lessons: brainData?.lessons?.slice(0, 5) || [],
+      },
+      enjambre: {
+        jobs: (enjambreData?.rows ?? []) as JobRow[],
+        done: ((enjambreData?.rows ?? []) as JobRow[]).filter(
+          (j) => j.status === "done",
+        ).length,
+        running: ((enjambreData?.rows ?? []) as JobRow[]).filter(
+          (j) => j.status === "running",
+        ).length,
+        pending: ((enjambreData?.rows ?? []) as JobRow[]).filter(
+          (j) => j.status === "pending",
+        ).length,
+      },
+      conversations: recentConvs,
     },
-    projects: projects.map((p) => ({
-      ...p,
-      health: p.blocked ? "blocked" : p.phase === "produccion" ? "live" : "building",
-    })),
-    brain: {
-      skills: brainData?.skills || 0,
-      projects_count: brainData?.projects?.length || 0,
-      lessons_count: brainData?.lessons?.length || 0,
-      recent_memory: brainData?.recent_memory || [],
-      top_lessons: brainData?.lessons?.slice(0, 5) || [],
-    },
-    enjambre: {
-      jobs: (enjambreData?.rows ?? []) as JobRow[],
-      done: ((enjambreData?.rows ?? []) as JobRow[]).filter((j) => j.status === "done").length,
-      running: ((enjambreData?.rows ?? []) as JobRow[]).filter((j) => j.status === "running").length,
-      pending: ((enjambreData?.rows ?? []) as JobRow[]).filter((j) => j.status === "pending").length,
-    },
-    conversations: recentConvs,
-  });
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,6 +83,7 @@ html {
 
 body {
   min-height: 100vh;
+  min-height: 100svh;
   margin: 0;
   overflow-x: hidden;
   background: var(--color-background);
@@ -90,6 +91,23 @@ body {
   font-family: var(--font-geist-sans), Geist, Arial, sans-serif;
   font-size: 0.9375rem;
   line-height: 1.55;
+}
+
+/*
+ * Superficies tipo app en móvil: 100svh no cambia cuando Safari/Chrome
+ * muestran u ocultan su barra. Los campos a 16px evitan el zoom automático
+ * de iOS, otra fuente común de saltos en un chat de pantalla completa.
+ */
+@media (max-width: 767px) {
+  .vf-mobile-stable input:not([type="checkbox"]):not([type="radio"]),
+  .vf-mobile-stable textarea,
+  .vf-mobile-stable select {
+    font-size: 16px;
+  }
+
+  .vf-studio-composer {
+    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+  }
 }
 
 h1,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({
       className={`${GeistSans.variable} ${GeistMono.variable}`}
       suppressHydrationWarning
     >
-      <body className="min-h-dvh bg-background font-sans text-ink">
+      <body className="min-h-svh bg-background font-sans text-ink">
         <SplashScreen />
         <AppProviders>
           <ClerkShell>{children}</ClerkShell>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -74,7 +74,6 @@ function OnboardingWithClerk() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: user?.fullName ?? user?.firstName ?? "",
-          role: "owner",
           services: connected.length,
         }),
       });

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,15 +1,27 @@
 import { currentUser } from "@clerk/nextjs/server";
-import { ClientShell } from "@/components/workspace/ClientShell";
-import { HomeExperience } from "@/components/workspace/home/HomeExperience";
+import { redirect } from "next/navigation";
+import { ScopedWorkspaceHome } from "@/components/workspace/ScopedWorkspaceHome";
+import { isOwnerUser } from "@/lib/auth/owner";
+import { listScopedProjects } from "@/lib/projects/scoped-catalog";
 
 export const dynamic = "force-dynamic";
 
 export default async function WorkspacePage() {
   const user = await currentUser().catch(() => null);
-  const name = user?.firstName || user?.username || "";
-  return (
-    <ClientShell>
-      <HomeExperience name={name} />
-    </ClientShell>
-  );
+  const email =
+    user?.emailAddresses.find(
+      (address) => address.id === user.primaryEmailAddressId,
+    )?.emailAddress ?? user?.emailAddresses[0]?.emailAddress;
+  if (!user || !email) redirect("/sign-in");
+  if (isOwnerUser(user)) redirect("/app/chat");
+
+  const name = user.firstName || user.username || "";
+  const projects = await listScopedProjects(email).catch((error: unknown) => {
+    console.error("[workspace] scoped catalog failed", {
+      email,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  });
+  return <ScopedWorkspaceHome name={name} email={email} projects={projects} />;
 }

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -104,8 +104,8 @@ export function LivePortal({
   }, [drawerOpen]);
 
   return (
-    <div className="flex h-dvh overflow-hidden bg-white text-black">
-      <aside className="hidden h-dvh w-[208px] shrink-0 border-r border-[var(--border-1)] bg-white lg:block">
+    <div className="vf-mobile-stable flex h-svh overflow-hidden overscroll-none bg-[var(--color-surface)] text-[var(--color-ink)] lg:h-dvh">
+      <aside className="hidden h-full w-[208px] shrink-0 border-r border-[var(--border-1)] bg-[var(--color-surface)] lg:block">
         <LiveSidebar project={project} me={me} />
       </aside>
 
@@ -166,7 +166,7 @@ export function LivePortal({
         </header>
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          <main className="min-w-0 flex-1 overflow-y-auto bg-[#f7f7f5] p-3 md:p-4">
+          <main className="min-w-0 flex-1 overflow-y-auto overscroll-contain bg-[var(--color-background)] p-3 md:p-4">
             <div className="grid items-start gap-3 xl:grid-cols-[minmax(280px,1.12fr)_minmax(150px,0.48fr)_minmax(260px,0.92fr)] 2xl:grid-cols-[minmax(360px,1.25fr)_minmax(220px,0.58fr)_minmax(320px,0.95fr)]">
               <Viewport
                 kind="desktop"
@@ -245,7 +245,7 @@ function LiveSidebar({
 
       <div className="px-4 py-5">
         <Link
-          href="/app/projects"
+          href={me.isPlatformOwner ? "/app/projects" : "/workspace"}
           className="inline-flex items-center gap-2 text-[11px] text-[var(--fg-muted)] hover:text-black"
         >
           <IconArrowL size={12} /> Proyectos

--- a/components/studio/ForgeStudio.tsx
+++ b/components/studio/ForgeStudio.tsx
@@ -245,7 +245,7 @@ export function ForgeStudio() {
   });
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const endRef = useRef<HTMLDivElement>(null);
+  const conversationViewportRef = useRef<HTMLDivElement>(null);
 
   const loadProjects = useCallback(async (preferredId?: string) => {
     setProjectsLoading(true);
@@ -463,7 +463,12 @@ export function ForgeStudio() {
   }, [activeProjectId]);
 
   useEffect(() => {
-    endRef.current?.scrollIntoView({ block: "end" });
+    const viewport = conversationViewportRef.current;
+    if (!viewport) return;
+    const frame = window.requestAnimationFrame(() => {
+      viewport.scrollTop = viewport.scrollHeight;
+    });
+    return () => window.cancelAnimationFrame(frame);
   }, [messages, sending]);
 
   const fallbackPreviewUrl = useMemo(
@@ -722,7 +727,7 @@ export function ForgeStudio() {
   }
 
   return (
-    <div className="flex h-[calc(100dvh-58px)] min-h-[620px] flex-col overflow-hidden bg-[var(--vf-bg)] text-[var(--vf-fg)]">
+    <div className="vf-mobile-stable flex h-full min-h-0 flex-col overflow-hidden overscroll-none bg-[var(--vf-bg)] text-[var(--vf-fg)]">
       <StudioToolbar
         projects={projects}
         activeProjectId={activeProjectId}
@@ -772,7 +777,10 @@ export function ForgeStudio() {
             </button>
           </header>
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5 md:px-5">
+          <div
+            ref={conversationViewportRef}
+            className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-5 md:px-5"
+          >
             {conversationLoading ? (
               <div className="grid h-full min-h-[260px] place-items-center">
                 <div className="text-center">
@@ -792,12 +800,11 @@ export function ForgeStudio() {
                 {messages.map((message) => (
                   <Message key={message.id} message={message} />
                 ))}
-                <div ref={endRef} />
               </div>
             )}
           </div>
 
-          <div className="shrink-0 border-t border-[var(--vf-border)] bg-[var(--vf-bg-1)] p-3 md:p-4">
+          <div className="vf-studio-composer shrink-0 border-t border-[var(--vf-border)] bg-[var(--vf-bg-1)] p-3 md:p-4">
             {attachment ? (
               <div className="mb-2 flex items-center justify-between gap-3 rounded-md border border-[var(--vf-border)] bg-[var(--vf-bg-2)] px-3 py-2">
                 <div className="min-w-0">
@@ -889,7 +896,7 @@ export function ForgeStudio() {
             }}
           />
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-3 md:p-4">
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3 md:p-4">
             {!activeProjectId ? (
               <NoProject onCreate={() => setShowCreate(true)} />
             ) : projectLoading && !project ? (

--- a/components/workspace/ScopedWorkspaceHome.tsx
+++ b/components/workspace/ScopedWorkspaceHome.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { UserButton } from "@clerk/nextjs";
+import { VWordmark } from "@/components/brand/VMark";
+import {
+  IconArrowR,
+  IconGlobe,
+  IconLayout,
+  IconShield,
+} from "@/components/brand/VFIcons";
+import { monochromeClerkAppearance } from "@/components/auth/ClerkShell";
+import type { ScopedProject } from "@/lib/projects/scoped-catalog";
+
+const ROLE_LABEL: Record<string, string> = {
+  owner: "Owner",
+  editor: "Editor",
+  viewer: "Observador",
+  reviewer: "Revisor",
+  observer: "Observador",
+};
+
+export function ScopedWorkspaceHome({
+  name,
+  email,
+  projects,
+}: {
+  name: string;
+  email: string;
+  projects: ScopedProject[];
+}) {
+  return (
+    <main className="min-h-svh bg-[var(--color-background)] text-[var(--color-ink)]">
+      <header className="border-b border-[var(--border-1)] bg-[var(--color-surface)]">
+        <div className="mx-auto flex min-h-[64px] max-w-[1180px] items-center justify-between gap-4 px-4 sm:px-6">
+          <Link href="/workspace" aria-label="VForge, proyectos compartidos">
+            <VWordmark />
+          </Link>
+          <div className="flex items-center gap-2 rounded-full border border-[var(--border-1)] bg-[var(--color-surface)] py-1 pl-1 pr-3">
+            <UserButton
+              afterSignOutUrl="/"
+              appearance={{
+                ...monochromeClerkAppearance,
+                elements: {
+                  ...monochromeClerkAppearance.elements,
+                  avatarBox: "h-7 w-7",
+                },
+              }}
+            />
+            <span className="hidden max-w-[150px] truncate text-[11px] font-medium sm:block">
+              {name || email}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-[1180px] px-4 py-10 sm:px-6 sm:py-16">
+        <p className="mono-label">Acceso por membresía</p>
+        <h1 className="mt-4 max-w-3xl text-[clamp(2.8rem,8vw,6.8rem)] font-semibold leading-[0.88] tracking-[-0.07em]">
+          Tus proyectos autorizados.
+        </h1>
+        <p className="mt-6 max-w-2xl break-words text-[15px] leading-7 text-[var(--fg-secondary)] sm:text-[17px]">
+          Aquí sólo aparecen las salas compartidas con {email}. Otros proyectos,
+          repositorios, secretos y administración permanecen fuera de alcance.
+        </p>
+
+        {projects.length === 0 ? (
+          <section className="mt-10 border border-[var(--color-ink)] bg-[var(--color-surface)] p-6 sm:mt-14 sm:p-9">
+            <IconShield size={22} />
+            <h2 className="mt-5 text-[26px] font-medium tracking-[-0.045em]">
+              Todavía no tienes una sala compartida.
+            </h2>
+            <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--fg-secondary)]">
+              La invitación debe enviarse y aceptarse con este mismo correo. En
+              cuanto exista una membresía activa, el proyecto aparecerá aquí.
+            </p>
+          </section>
+        ) : (
+          <section className="mt-10 grid gap-3 sm:mt-14 md:grid-cols-2">
+            {projects.map((project) => {
+              const href =
+                project.access_kind === "live"
+                  ? `/app/live/${encodeURIComponent(project.id)}`
+                  : `/workspace/proyecto/${encodeURIComponent(project.id)}`;
+              const destination = project.domain || project.vercel_url;
+              return (
+                <Link
+                  key={project.id}
+                  href={href}
+                  className="group flex min-h-[210px] flex-col border border-[var(--border-1)] bg-[var(--color-surface)] p-5 transition-colors hover:border-[var(--color-ink)] sm:p-6"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <span className="inline-flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.13em] text-[var(--fg-muted)]">
+                      <span className="status-shape" data-active="true" />
+                      {ROLE_LABEL[project.member_role] ?? project.member_role}
+                    </span>
+                    <IconLayout size={15} />
+                  </div>
+                  <h2 className="mt-8 text-[28px] font-medium tracking-[-0.05em]">
+                    {project.name}
+                  </h2>
+                  <p className="mt-2 font-mono text-[9px] uppercase tracking-[0.11em] text-[var(--fg-muted)]">
+                    {project.status}
+                  </p>
+                  <div className="mt-auto flex items-end justify-between gap-4 pt-8">
+                    <span className="flex min-w-0 items-center gap-2 text-[10px] text-[var(--fg-secondary)]">
+                      <IconGlobe size={11} className="shrink-0" />
+                      <span className="truncate">{destination || "Sala privada"}</span>
+                    </span>
+                    <span className="inline-flex shrink-0 items-center gap-2 text-[11px] font-medium">
+                      Abrir <IconArrowR size={12} className="transition-transform group-hover:translate-x-1" />
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -161,6 +161,7 @@ function Sidebar({
 export function WorkspaceShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() ?? "";
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const isStudio = pathname === "/app/chat";
 
   useEffect(() => {
     setDrawerOpen(false);
@@ -184,7 +185,14 @@ export function WorkspaceShell({ children }: { children: React.ReactNode }) {
     "VForge";
 
   return (
-    <div className="min-h-dvh bg-[#f7f7f5] text-black">
+    <div
+      className={cn(
+        "bg-[var(--color-background)] text-[var(--color-ink)]",
+        isStudio
+          ? "h-svh overflow-hidden overscroll-none lg:h-dvh"
+          : "min-h-svh",
+      )}
+    >
       <aside className="fixed inset-y-0 left-0 z-30 hidden w-[220px] border-r border-[var(--border-1)] md:block">
         <Sidebar pathname={pathname} />
       </aside>
@@ -211,8 +219,18 @@ export function WorkspaceShell({ children }: { children: React.ReactNode }) {
         </div>
       ) : null}
 
-      <div className="min-h-dvh md:pl-[220px]">
-        <header className="sticky top-0 z-20 border-b border-[var(--border-1)] bg-white/95 backdrop-blur-md">
+      <div
+        className={cn(
+          "md:pl-[220px]",
+          isStudio ? "h-full overflow-hidden" : "min-h-svh",
+        )}
+      >
+        <header
+          className={cn(
+            "z-20 border-b border-[var(--border-1)] bg-white/95 backdrop-blur-md",
+            isStudio ? "relative shrink-0" : "sticky top-0",
+          )}
+        >
           <div className="flex h-[58px] items-center justify-between gap-4 px-4 md:px-6">
             <div className="flex min-w-0 items-center gap-3">
               <button
@@ -236,7 +254,15 @@ export function WorkspaceShell({ children }: { children: React.ReactNode }) {
           </div>
         </header>
 
-        <main className="min-h-[calc(100dvh-58px)]">{children}</main>
+        <main
+          className={cn(
+            isStudio
+              ? "h-[calc(100svh-58px)] overflow-hidden lg:h-[calc(100dvh-58px)]"
+              : "min-h-[calc(100svh-58px)]",
+          )}
+        >
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/docs/acceso-dueno-v.md
+++ b/docs/acceso-dueno-v.md
@@ -31,8 +31,8 @@ oculta para `client`).
 - Token de Luis (`vfmcp_7dce…`) → `scope=admin`, `org_id=null`. Es el que conecta
   V desde cualquier cuenta/cliente. El token completo está en el CLAUDE.md de Luis.
 - Clerk owner: `turbillon50@gmail.com` (`user_3Ds7ij…`, `role=owner`).
-- Owners se detectan por `lib/auth/owner.ts` (`VFORGE_OWNER_EMAILS` o
-  `publicMetadata.role === "owner"`); los tokens nuevos de un owner se emiten
+- Owners se detectan exclusivamente por `lib/auth/owner.ts`
+  (`VFORGE_OWNER_EMAILS`); la metadata de Clerk no eleva permisos. Los tokens nuevos de un owner se emiten
   como `admin` automáticamente (`scopeForUser` en `lib/mcp/tokens.ts`).
 
 ## Conectar V desde otra cuenta / cliente MCP

--- a/lib/auth/owner.ts
+++ b/lib/auth/owner.ts
@@ -1,20 +1,30 @@
 /**
  * Owner gating — V (y todo su cockpit) es para los owners (Luis + Jaime).
  *
- * Un usuario es owner si:
- *  1. publicMetadata.role === "owner" en Clerk, o
- *  2. alguno de sus emails está en VFORGE_OWNER_EMAILS (env, CSV).
+ * Un usuario es owner únicamente si alguno de sus emails está en
+ * VFORGE_OWNER_EMAILS (env, CSV). El metadata de Clerk nunca eleva permisos:
+ * puede quedar obsoleto, copiarse entre instancias o haber sido escrito por
+ * un onboarding antiguo.
  *
- * Default de emails: las cuentas de Luis + Jaime (owners de V·Forge).
+ * Default de emails: las cuentas canónicas de Luis + Jaime. Las cuentas
+ * secundarias se comportan como clientes y sólo ven proyectos por membresía.
  */
-export const OWNER_EMAILS: string[] = (
-  process.env.VFORGE_OWNER_EMAILS ??
-  "turbillon50@gmail.com,dluisdelatorre@gmail.com,luisdelator@vmomentums.info,jaime@vmomentums.info"
-)
+export const DEFAULT_OWNER_EMAILS = [
+  "turbillon50@gmail.com",
+  "jaime@vmomentums.info",
+] as const;
+
+export function parseOwnerEmails(value?: string): string[] {
+  return (value ?? DEFAULT_OWNER_EMAILS.join(","))
   .toLowerCase()
   .split(",")
   .map((s) => s.trim())
   .filter(Boolean);
+}
+
+export const OWNER_EMAILS: string[] = parseOwnerEmails(
+  process.env.VFORGE_OWNER_EMAILS,
+);
 
 export function isOwnerEmail(email: string | null | undefined): boolean {
   if (!email) return false;
@@ -22,15 +32,11 @@ export function isOwnerEmail(email: string | null | undefined): boolean {
 }
 
 type MinimalUser = {
-  publicMetadata?: Record<string, unknown> | null;
   emailAddresses?: Array<{ emailAddress: string }>;
 };
 
 export function isOwnerUser(user: MinimalUser | null | undefined): boolean {
   if (!user) return false;
-  if ((user.publicMetadata as { role?: string } | null)?.role === "owner") {
-    return true;
-  }
   return (user.emailAddresses ?? []).some((e) => isOwnerEmail(e.emailAddress));
 }
 

--- a/lib/auth/request-owner.ts
+++ b/lib/auth/request-owner.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { currentUser } from "@clerk/nextjs/server";
+import { isOwnerUser } from "@/lib/auth/owner";
+
+export interface RequestOwner {
+  userId: string | null;
+  isOwner: boolean;
+}
+
+/**
+ * Resuelve únicamente identidad y propiedad para rutas owner-only. A diferencia
+ * de resolveAccess(), no consulta ni sincroniza tokens GitHub/Vercel: intentar
+ * abrir un endpoint prohibido nunca debe producir efectos laterales en vaults.
+ */
+export async function resolveRequestOwner(): Promise<RequestOwner> {
+  const user = await currentUser().catch(() => null);
+  return {
+    userId: user?.id ?? null,
+    isOwner: isOwnerUser(user),
+  };
+}

--- a/lib/connect/resolve-token.ts
+++ b/lib/connect/resolve-token.ts
@@ -80,13 +80,9 @@ export async function resolveAccess(): Promise<ResolvedAccess> {
     const a = await auth();
     userId = a.userId ?? null;
     if (userId) {
-      const claimRole = (a.sessionClaims?.publicMetadata as { role?: string } | undefined)?.role;
-      if (claimRole === "owner") owner = true;
-      else {
-        const cc = await clerkClient();
-        const u = await cc.users.getUser(userId).catch(() => null);
-        owner = isOwnerUser(u);
-      }
+      const cc = await clerkClient();
+      const u = await cc.users.getUser(userId).catch(() => null);
+      owner = isOwnerUser(u);
     }
   } catch {
     /* sin sesión */

--- a/lib/forja/ojo.ts
+++ b/lib/forja/ojo.ts
@@ -56,10 +56,8 @@ export const OJO_BASE = resolveOjoBase();
 
 /** Solo el owner (Luis/Jaime) puede tocar la Forja. */
 export async function isOwnerRequest(): Promise<boolean> {
-  const { userId, sessionClaims } = await auth();
+  const { userId } = await auth();
   if (!userId) return false;
-  const role = (sessionClaims?.publicMetadata as { role?: string } | undefined)?.role;
-  if (role === "owner") return true;
   try {
     const cc = await clerkClient();
     const u = await cc.users.getUser(userId);

--- a/lib/projects/scoped-catalog.ts
+++ b/lib/projects/scoped-catalog.ts
@@ -1,0 +1,86 @@
+import "server-only";
+
+import { queryAll, queryOne } from "@/lib/db/client";
+
+export interface ScopedProject {
+  id: string;
+  project_id: string;
+  name: string;
+  status: string;
+  github_repo: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+  member_role: string;
+  access_kind: "live" | "workspace";
+}
+
+/**
+ * Catálogo fail-closed para clientes. Sólo reúne membresías activas ligadas al
+ * correo actual; nunca consulta ni devuelve el catálogo global del owner.
+ * Si existen las dos membresías históricas para el mismo proyecto, preferimos
+ * la sala live nueva porque aplica los roles observer/reviewer por endpoint.
+ */
+export async function listScopedProjects(email: string): Promise<ScopedProject[]> {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized || normalized.length > 320) return [];
+
+  const tables = await queryOne<{
+    has_workspace_members: boolean;
+    has_live_members: boolean;
+  }>(
+    `SELECT to_regclass('public.project_members') IS NOT NULL
+              AS has_workspace_members,
+            to_regclass('public.project_live_members') IS NOT NULL
+              AS has_live_members`,
+  );
+
+  const sources: string[] = [];
+  if (tables?.has_workspace_members) {
+    sources.push(
+      `SELECT pm.project_id,
+              pm.role::text AS member_role,
+              'workspace'::text AS access_kind,
+              1 AS priority
+         FROM project_members pm
+        WHERE lower(pm.email) = $1
+          AND pm.status = 'active'`,
+    );
+  }
+  if (tables?.has_live_members) {
+    sources.push(
+      `SELECT plm.project_id,
+              plm.role::text AS member_role,
+              'live'::text AS access_kind,
+              2 AS priority
+         FROM project_live_members plm
+        WHERE lower(plm.email) = $1
+          AND plm.status = 'active'
+          AND (plm.expires_at IS NULL OR plm.expires_at > now())`,
+    );
+  }
+  if (sources.length === 0) return [];
+
+  return queryAll<ScopedProject>(
+    `WITH memberships AS (
+       ${sources.join("\nUNION ALL\n")}
+     ), scoped AS (
+       SELECT DISTINCT ON (project_id)
+              project_id, member_role, access_kind
+         FROM memberships
+        ORDER BY project_id, priority DESC
+     )
+     SELECT p.id,
+            p.id AS project_id,
+            p.name,
+            p.status,
+            p.github_repo,
+            p.vercel_url,
+            p.domain,
+            scoped.member_role,
+            scoped.access_kind
+       FROM scoped
+       JOIN projects p ON p.id = scoped.project_id
+      ORDER BY p.name ASC`,
+    [normalized],
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -86,6 +86,7 @@ const isProtected = createRouteMatcher([
   "/api/billing(.*)",
   "/api/v/bridge(.*)",
   "/api/v/voice(.*)",
+  "/api/vulcano(.*)",
   "/api/live(.*)",
 ]);
 
@@ -102,6 +103,7 @@ const isOwnerOnly = createRouteMatcher([
   "/api/forge(.*)",
   "/api/builder(.*)",
   "/api/vault(.*)",
+  "/api/vulcano(.*)",
   "/api/admin(.*)",
   "/api/projects(.*)",
   "/api/v/bridge(.*)",
@@ -153,18 +155,13 @@ export default hasClerk
         return redirectToSignIn({ returnBackUrl: req.url });
       }
 
-      const claimRole = (
-        sessionClaims?.publicMetadata as { role?: string } | undefined
-      )?.role;
-
       // --- Rutas API ---
       // Solo las owner-only necesitan gating extra; el resto ya pasó el auth
       // de arriba. El onboarding NO bloquea APIs (rompería /api/onboarding/*
       // y /api/user/complete-onboarding, que el flujo necesita).
       if (isApi) {
         if (isOwnerOnly(req)) {
-          const owner =
-            claimRole === "owner" ? true : await resolveOwner(userId);
+          const owner = await resolveOwner(userId);
           if (!owner) {
             return new NextResponse(JSON.stringify({ error: "forbidden" }), {
               status: 403,
@@ -176,7 +173,7 @@ export default hasClerk
       }
 
       // --- Rutas de página: los 3 tipos de usuario ---
-      const owner = claimRole === "owner" ? true : await resolveOwner(userId);
+      const owner = await resolveOwner(userId);
       const onOnboarding = req.nextUrl.pathname.startsWith("/onboarding");
 
       // Tipo 1 — Owner (Luis/Jaime): acceso total a todo, nunca onboarding.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // VForge minimal service worker — offline shell + network-first for documents
 // Bump VERSION on every deploy where you want forced cache invalidation
-const VERSION = "vforge-monochrome-studio-2026-08-23";
+const VERSION = "vforge-monochrome-stability-2026-08-23";
 const SHELL = ["/", "/app/chat", "/offline"];
 
 self.addEventListener("install", (event) => {

--- a/tests/owner-auth.test.ts
+++ b/tests/owner-auth.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_OWNER_EMAILS,
+  isOwnerEmail,
+  isOwnerUser,
+  parseOwnerEmails,
+} from "../lib/auth/owner";
+
+test("the default owner allowlist contains only the canonical accounts", () => {
+  assert.deepEqual(parseOwnerEmails(), [...DEFAULT_OWNER_EMAILS]);
+  assert.equal(parseOwnerEmails().includes("dluisdelatorre@gmail.com"), false);
+  assert.equal(parseOwnerEmails().includes("luisdelator@vmomentums.info"), false);
+});
+
+test("owner email matching is normalized", () => {
+  assert.equal(isOwnerEmail("  TURBILLON50@GMAIL.COM "), true);
+  assert.equal(isOwnerEmail("cliente@example.com"), false);
+});
+
+test("stale Clerk owner metadata cannot elevate a secondary account", () => {
+  const staleUser = {
+    emailAddresses: [{ emailAddress: "dluisdelatorre@gmail.com" }],
+    publicMetadata: { role: "owner" },
+  };
+
+  assert.equal(isOwnerUser(staleUser), false);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "tests/**/*.ts",
+    "lib/auth/owner.ts",
     "lib/projects/roles.ts",
     "lib/projects/invite-token.ts"
   ]


### PR DESCRIPTION
## Qué corrige

- estabiliza el estudio y el portal live en móvil con viewport fijo, scroll interno y safe-area
- elimina el salto global causado por `scrollIntoView`
- limita owner a `VFORGE_OWNER_EMAILS`; Clerk metadata ya no eleva privilegios
- elimina las cuentas secundarias del allowlist por defecto
- reemplaza el inicio azul de clientes por un catálogo blanco y negro por membresía
- soporta tanto `project_live_members` como el esquema histórico cuando exista
- cierra `/api/projects`, detalle/POST y Mission Control con defensa interna owner-only
- elimina el fallback hardcodeado del secreto de Hetzner

## Evidencia

- TypeScript: 0 errores
- ESLint de archivos tocados: 0 errores / 0 warnings
- Tests: 20/20
- Next.js production build: OK
- Neon read-only: `projects` + `project_live_members` existen; la tabla legacy no existe, por eso la consulta detecta el esquema antes de usarlo
- cuenta secundaria: 0 membresías activas; debe ver estado vacío
- árbol GitHub remoto coincide con el árbol local: `6d1f091b04b47500ee70f3637d8799d620227344`

## Limitación de entorno

El supervisor exigido por AGENTS.md no está instalado en este contenedor:
`MODULE_NOT_FOUND /root/agents/supervisor/review.js`.

No se promueve hasta verificar el preview y los checks de Vercel.