### PR TITLE
fix: inherit previews for delivered projects

### DIFF
--- a/lib/projects/live-portal.ts
+++ b/lib/projects/live-portal.ts
@@ -16,6 +16,7 @@ import {
   generateInviteToken,
   hashInviteToken,
 } from "@/lib/projects/invite-token";
+import { resolveProjectViewportUrls } from "@/lib/projects/viewport-url";
 
 const INVITE_DEFAULT_TTL_HOURS = 168; // 7 días
 const INVITE_MAX_TTL_HOURS = 24 * 30; // 30 días
@@ -36,11 +37,17 @@ export interface ProjectViewports {
 export async function getProjectViewports(
   projectId: string,
 ): Promise<ProjectViewports | null> {
-  return queryOne<ProjectViewports>(
+  const project = await queryOne<ProjectViewports>(
     `SELECT id, name, status, desktop_url, mobile_url, admin_url, vercel_url, domain
        FROM projects WHERE id = $1 LIMIT 1`,
     [projectId],
   );
+  if (!project) return null;
+
+  return {
+    ...project,
+    ...resolveProjectViewportUrls(project),
+  };
 }
 
 export interface InvitationSummary {

--- a/lib/projects/viewport-url.ts
+++ b/lib/projects/viewport-url.ts
@@ -1,0 +1,58 @@
+export interface ProjectViewportFields {
+  desktop_url: string | null;
+  mobile_url: string | null;
+  admin_url: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+}
+
+export interface ResolvedProjectViewports {
+  desktop_url: string | null;
+  mobile_url: string | null;
+  admin_url: string | null;
+}
+
+/**
+ * Normaliza una URL publicable sin permitir protocolos ejecutables ni
+ * credenciales embebidas. Los proyectos históricos suelen guardar sólo el
+ * dominio, así que un host sin esquema se interpreta como HTTPS.
+ */
+export function normalizePublishedUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(trimmed);
+  const candidate = hasScheme ? trimmed : `https://${trimmed}`;
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username || url.password || !url.hostname) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resuelve los viewports históricos sin escribir en la base.
+ *
+ * Escritorio y móvil pueden compartir el deploy responsive cuando sus URLs
+ * explícitas aún no existían. Administración nunca se infiere: sólo se expone
+ * cuando fue registrada de forma intencional.
+ */
+export function resolveProjectViewportUrls(
+  project: ProjectViewportFields,
+): ResolvedProjectViewports {
+  const publishedFallback =
+    normalizePublishedUrl(project.vercel_url) ??
+    normalizePublishedUrl(project.domain);
+
+  return {
+    desktop_url:
+      normalizePublishedUrl(project.desktop_url) ?? publishedFallback,
+    mobile_url:
+      normalizePublishedUrl(project.mobile_url) ?? publishedFallback,
+    admin_url: normalizePublishedUrl(project.admin_url),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/viewport-url.test.ts
+++ b/tests/viewport-url.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizePublishedUrl,
+  resolveProjectViewportUrls,
+  type ProjectViewportFields,
+} from "../lib/projects/viewport-url";
+
+function project(
+  overrides: Partial<ProjectViewportFields> = {},
+): ProjectViewportFields {
+  return {
+    desktop_url: null,
+    mobile_url: null,
+    admin_url: null,
+    vercel_url: null,
+    domain: null,
+    ...overrides,
+  };
+}
+
+test("normaliza un dominio histórico como HTTPS", () => {
+  assert.equal(normalizePublishedUrl("carnesn.ink"), "https://carnesn.ink/");
+});
+
+test("conserva URLs HTTP y HTTPS publicables", () => {
+  assert.equal(
+    normalizePublishedUrl("https://example.com/catalogo?area=1"),
+    "https://example.com/catalogo?area=1",
+  );
+  assert.equal(normalizePublishedUrl("http://localhost:3000"), "http://localhost:3000/");
+});
+
+test("rechaza protocolos ejecutables y credenciales embebidas", () => {
+  assert.equal(normalizePublishedUrl("javascript:alert(1)"), null);
+  assert.equal(normalizePublishedUrl("https://user:secret@example.com"), null);
+});
+
+test("prefiere las URLs explícitas de cada viewport", () => {
+  assert.deepEqual(
+    resolveProjectViewportUrls(
+      project({
+        desktop_url: "https://desktop.example.com",
+        mobile_url: "https://mobile.example.com",
+        vercel_url: "https://fallback.vercel.app",
+        domain: "example.com",
+      }),
+    ),
+    {
+      desktop_url: "https://desktop.example.com/",
+      mobile_url: "https://mobile.example.com/",
+      admin_url: null,
+    },
+  );
+});
+
+test("usa vercel_url como fallback responsive", () => {
+  assert.deepEqual(
+    resolveProjectViewportUrls(
+      project({ vercel_url: "https://legacy.vercel.app" }),
+    ),
+    {
+      desktop_url: "https://legacy.vercel.app/",
+      mobile_url: "https://legacy.vercel.app/",
+      admin_url: null,
+    },
+  );
+});
+
+test("usa el dominio cuando no hay URL de Vercel", () => {
+  assert.deepEqual(
+    resolveProjectViewportUrls(project({ domain: "carnesn.ink" })),
+    {
+      desktop_url: "https://carnesn.ink/",
+      mobile_url: "https://carnesn.ink/",
+      admin_url: null,
+    },
+  );
+});
+
+test("una URL explícita inválida cae al deploy publicado", () => {
+  assert.equal(
+    resolveProjectViewportUrls(
+      project({
+        desktop_url: "javascript:alert(1)",
+        vercel_url: "legacy.vercel.app",
+      }),
+    ).desktop_url,
+    "https://legacy.vercel.app/",
+  );
+});
+
+test("administración nunca se infiere desde el dominio", () => {
+  const withoutAdmin = resolveProjectViewportUrls(
+    project({ domain: "carnesn.ink" }),
+  );
+  const withAdmin = resolveProjectViewportUrls(
+    project({ domain: "carnesn.ink", admin_url: "admin.carnesn.ink" }),
+  );
+
+  assert.equal(withoutAdmin.admin_url, null);
+  assert.equal(withAdmin.admin_url, "https://admin.carnesn.ink/");
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -17,6 +17,7 @@
     "tests/**/*.ts",
     "lib/auth/owner.ts",
     "lib/projects/roles.ts",
-    "lib/projects/invite-token.ts"
+    "lib/projects/invite-token.ts",
+    "lib/projects/viewport-url.ts"
   ]
 }


### PR DESCRIPTION
## Qué corrige

- los proyectos históricos ya no requieren que `desktop_url` y `mobile_url` hayan sido migrados manualmente
- respeta primero las URLs explícitas
- usa `vercel_url` y después `domain` como fallback responsive
- nunca infiere `admin_url`
- rechaza protocolos no HTTP(S) y URLs con credenciales embebidas

## Incidente confirmado

`csn-carnes` estaba `live` con `domain=carnesn.ink`, pero los tres campos de viewport estaban en null. La ficha se corrigió de forma reversible y el código evita que vuelva a pasar en proyectos históricos.

## Evidencia

- 28/28 tests
- TypeScript: 0 errores
- ESLint tocado: 0 errores
- Next.js production build: OK