### PR TITLE
fix: align standalone preview resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/services/vforge-api/server.mjs
+++ b/services/vforge-api/server.mjs
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import { timingSafeEqual } from "node:crypto";
 import { neon } from "@neondatabase/serverless";
+import { resolveProjectViewportUrls } from "./viewport-url.mjs";
 
 const databaseUrl = process.env.DATABASE_URL?.trim();
 const internalToken = process.env.VFORGE_API_INTERNAL_TOKEN?.trim();
@@ -209,7 +210,8 @@ async function liveProject(req, res, projectId) {
   if (!access) return;
 
   const rows = await sql.query(
-    `SELECT id, name, status, desktop_url, mobile_url, admin_url
+    `SELECT id, name, status,
+            desktop_url, mobile_url, admin_url, vercel_url, domain
        FROM projects
       WHERE id = $1
       LIMIT 1`,
@@ -222,14 +224,15 @@ async function liveProject(req, res, projectId) {
   }
 
   const canSeeAdmin = access.role === "owner" || access.role === "reviewer";
+  const viewports = resolveProjectViewportUrls(project);
   json(res, 200, {
     project: {
       id: project.id,
       name: project.name,
       status: project.status,
-      desktop_url: project.desktop_url,
-      mobile_url: project.mobile_url,
-      admin_url: canSeeAdmin ? project.admin_url : null,
+      desktop_url: viewports.desktop_url,
+      mobile_url: viewports.mobile_url,
+      admin_url: canSeeAdmin ? viewports.admin_url : null,
     },
     me: {
       name: access.name,

--- a/services/vforge-api/viewport-url.mjs
+++ b/services/vforge-api/viewport-url.mjs
@@ -1,0 +1,30 @@
+export function normalizePublishedUrl(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) return null;
+
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(trimmed);
+  const candidate = hasScheme ? trimmed : `https://${trimmed}`;
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username || url.password || !url.hostname) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveProjectViewportUrls(project) {
+  const publishedFallback =
+    normalizePublishedUrl(project.vercel_url) ??
+    normalizePublishedUrl(project.domain);
+
+  return {
+    desktop_url:
+      normalizePublishedUrl(project.desktop_url) ?? publishedFallback,
+    mobile_url:
+      normalizePublishedUrl(project.mobile_url) ?? publishedFallback,
+    admin_url: normalizePublishedUrl(project.admin_url),
+  };
+}

--- a/tests/vforge-api-viewport.test.mjs
+++ b/tests/vforge-api-viewport.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizePublishedUrl,
+  resolveProjectViewportUrls,
+} from "../services/vforge-api/viewport-url.mjs";
+
+const emptyProject = {
+  desktop_url: null,
+  mobile_url: null,
+  admin_url: null,
+  vercel_url: null,
+  domain: null,
+};
+
+test("standalone API inherits a historical domain for both responsive previews", () => {
+  assert.deepEqual(
+    resolveProjectViewportUrls({ ...emptyProject, domain: "carnesn.ink" }),
+    {
+      desktop_url: "https://carnesn.ink/",
+      mobile_url: "https://carnesn.ink/",
+      admin_url: null,
+    },
+  );
+});
+
+test("standalone API prefers explicit viewports and never infers admin", () => {
+  assert.deepEqual(
+    resolveProjectViewportUrls({
+      ...emptyProject,
+      desktop_url: "desktop.example.com",
+      mobile_url: "mobile.example.com",
+      vercel_url: "fallback.vercel.app",
+    }),
+    {
+      desktop_url: "https://desktop.example.com/",
+      mobile_url: "https://mobile.example.com/",
+      admin_url: null,
+    },
+  );
+});
+
+test("standalone API rejects executable URLs and embedded credentials", () => {
+  assert.equal(normalizePublishedUrl("javascript:alert(1)"), null);
+  assert.equal(normalizePublishedUrl("https://user:secret@example.com"), null);
+});


### PR DESCRIPTION
## Qué corrige

`api.vforge.site` usa el servicio Node independiente en Hetzner, no el route handler de Next.js. Este cambio aplica allí la misma resolución segura de viewports:

- URL explícita → Vercel → dominio
- escritorio y móvil comparten el deploy responsive cuando el proyecto es histórico
- administración nunca se infiere
- protocolos no HTTP(S) y credenciales embebidas se rechazan

## Evidencia

- CSN estaba live con `domain=carnesn.ink` y viewports null
- ficha CSN ya quedó backfilled de forma reversible
- 31/31 tests
- TypeScript: 0 errores
- ESLint tocado: 0 errores