### PR TITLE
Landing + Auth: identidad Architect's Vault en producción

### DIFF
--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -15,9 +15,9 @@ export default function SignInPage() {
 
   return (
     <AuthSurface
-      eyebrow="Acceso a la sala"
-      title="Entra a VForge"
-      body="Abre tus proyectos, revisa las tres vistas y comparte avances con cada invitado autorizado."
+      eyebrow="Acceso"
+      title="Entra a Forge"
+      body="Plan. Integra. Ejecuta. Abre tus proyectos y conecta GitHub, Vercel y el resto cuando estés listo."
     >
       {clerkEnabled ? (
         <>

--- a/components/auth/AuthSurface.tsx
+++ b/components/auth/AuthSurface.tsx
@@ -22,10 +22,10 @@ export function AuthSurface({
 
         <div className="max-w-[620px]">
           <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/55">
-            VForge · sala privada
+            The Architect&apos;s Vault
           </p>
           <h1 className="mt-6 text-[clamp(3.2rem,6vw,6.8rem)] font-semibold leading-[0.88] tracking-[-0.075em] text-white">
-            Todo el proyecto, en una sola mirada.
+            Plan. Integrate. Execute.
           </h1>
           <div className="mt-10 grid grid-cols-3 border-y border-white/20 py-5">
             {[


### PR DESCRIPTION
## Qué entra a producción

- AuthSurface alineado con identidad Forge: **The Architect's Vault** + **Plan. Integrate. Execute.**
- Sign-in copy limpio (Entra a Forge + conectar cuando estés listo)
- Sin tocar OAuth, vault ni MCP

## Verificación

- `/` landing monochrome (sin cambios estructurales)
- `/sign-in` panel negro con nueva voz de marca