### PR TITLE
feat: post-login → setup si faltan GitHub/Vercel (taller, no visor)

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
-// El estudio conversacional es la puerta canónica del producto owner.
+// Entrada del área autenticada: el ConnectionGate decide si setup o estudio.
+// Empezamos en setup; si ya hay conexiones, el gate deja pasar al chat.
 export default function AppRoot() {
-  redirect("/app/chat");
+  redirect("/app/setup");
 }

--- a/components/auth/ClerkShell.tsx
+++ b/components/auth/ClerkShell.tsx
@@ -49,8 +49,8 @@ export function ClerkShell({ children }: { children: React.ReactNode }) {
       publishableKey={publishableKey}
       signInUrl="/sign-in"
       signUpUrl="/sign-up"
-      signInFallbackRedirectUrl="/app/chat"
-      signUpFallbackRedirectUrl="/onboarding"
+      signInFallbackRedirectUrl="/app/setup"
+      signUpFallbackRedirectUrl="/app/setup"
       appearance={monochromeClerkAppearance}
     >
       {children}

--- a/components/workspace/ConnectionGate.tsx
+++ b/components/workspace/ConnectionGate.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+/**
+ * Si el owner aún no conectó GitHub o Vercel, la plataforma no es un taller:
+ * es un visor vacío. Forzamos /app/setup antes de dejar entrar al estudio.
+ *
+ * Excepciones: setup, live (clientes), integrations (por si llega del OAuth).
+ */
+const SKIP_PREFIXES = [
+  "/app/setup",
+  "/app/live",
+  "/app/integrations",
+];
+
+export function ConnectionGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname() ?? "";
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function check() {
+      if (SKIP_PREFIXES.some((p) => pathname.startsWith(p))) {
+        if (!cancelled) setReady(true);
+        return;
+      }
+
+      try {
+        const res = await fetch("/api/onboarding/status", { cache: "no-store" });
+        if (!res.ok) {
+          if (!cancelled) setReady(true);
+          return;
+        }
+        const data = (await res.json()) as { connected?: string[] };
+        const list = (data.connected ?? []).map((s) => s.toLowerCase());
+        const hasGithub = list.includes("github");
+        const hasVercel = list.includes("vercel");
+
+        if (!hasGithub || !hasVercel) {
+          if (!cancelled) {
+            router.replace("/app/setup");
+            return;
+          }
+        }
+      } catch {
+        /* si falla status, no bloqueamos el estudio */
+      }
+      if (!cancelled) setReady(true);
+    }
+
+    void check();
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname, router]);
+
+  if (!ready) {
+    return (
+      <div className="grid min-h-[40vh] place-items-center bg-[#f7f7f5]">
+        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--fg-muted)]">
+          Preparando el taller…
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/brand/VFIcons";
 import { monochromeClerkAppearance } from "@/components/auth/ClerkShell";
 import { hasClerkPublishableKey } from "@/lib/auth/clerk-key";
+import { ConnectionGate } from "@/components/workspace/ConnectionGate";
 
 type IconComponent = (props: {
   size?: number;
@@ -73,6 +74,7 @@ const TITLES: Record<string, string> = {
   "/app/integrations": "Conexiones",
   "/app/admin": "Administración",
   "/app/settings": "Configuración",
+  "/app/setup": "Setup",
 };
 
 function routeIsActive(pathname: string, href: string) {
@@ -140,6 +142,13 @@ function Sidebar({
 
       <div className="border-t border-[var(--border-1)] p-3">
         <Link
+          href="/app/setup"
+          onClick={onNavigate}
+          className="flex items-center gap-3 rounded-md px-3 py-2.5 text-[11px] text-[var(--fg-secondary)] hover:bg-[#f2f2f0] hover:text-black"
+        >
+          <IconZap size={14} /> Setup / conexiones
+        </Link>
+        <Link
           href="/app/settings"
           onClick={onNavigate}
           className="flex items-center gap-3 rounded-md px-3 py-2.5 text-[11px] text-[var(--fg-secondary)] hover:bg-[#f2f2f0] hover:text-black"
@@ -162,6 +171,8 @@ export function WorkspaceShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() ?? "";
   const [drawerOpen, setDrawerOpen] = useState(false);
   const isStudio = pathname === "/app/chat";
+  const isSetup = pathname.startsWith("/app/setup");
+  const isLive = pathname.startsWith("/app/live/");
 
   useEffect(() => {
     setDrawerOpen(false);
@@ -176,8 +187,9 @@ export function WorkspaceShell({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [drawerOpen]);
 
-  if (pathname.startsWith("/app/live/")) {
-    return <>{children}</>;
+  // Live y Setup: pantalla completa, sin chrome del shell
+  if (isLive || isSetup) {
+    return <ConnectionGate>{children}</ConnectionGate>;
   }
 
   const title =
@@ -185,86 +197,88 @@ export function WorkspaceShell({ children }: { children: React.ReactNode }) {
     "VForge";
 
   return (
-    <div
-      className={cn(
-        "bg-[var(--color-background)] text-[var(--color-ink)]",
-        isStudio
-          ? "h-svh overflow-hidden overscroll-none lg:h-dvh"
-          : "min-h-svh",
-      )}
-    >
-      <aside className="fixed inset-y-0 left-0 z-30 hidden w-[220px] border-r border-[var(--border-1)] md:block">
-        <Sidebar pathname={pathname} />
-      </aside>
-
-      {drawerOpen ? (
-        <div className="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true">
-          <button
-            type="button"
-            className="absolute inset-0 bg-black/30"
-            onClick={() => setDrawerOpen(false)}
-            aria-label="Cerrar navegación"
-          />
-          <aside className="absolute inset-y-0 left-0 w-[min(86vw,300px)] border-r border-black bg-white shadow-2xl">
-            <button
-              type="button"
-              onClick={() => setDrawerOpen(false)}
-              className="absolute right-3 top-3 z-10 grid h-9 w-9 place-items-center rounded-md border border-[var(--border-1)] bg-white"
-              aria-label="Cerrar menú"
-            >
-              <IconX size={14} />
-            </button>
-            <Sidebar pathname={pathname} onNavigate={() => setDrawerOpen(false)} />
-          </aside>
-        </div>
-      ) : null}
-
+    <ConnectionGate>
       <div
         className={cn(
-          "md:pl-[220px]",
-          isStudio ? "h-full overflow-hidden" : "min-h-svh",
+          "bg-[var(--color-background)] text-[var(--color-ink)]",
+          isStudio
+            ? "h-svh overflow-hidden overscroll-none lg:h-dvh"
+            : "min-h-svh",
         )}
       >
-        <header
-          className={cn(
-            "z-20 border-b border-[var(--border-1)] bg-white/95 backdrop-blur-md",
-            isStudio ? "relative shrink-0" : "sticky top-0",
-          )}
-        >
-          <div className="flex h-[58px] items-center justify-between gap-4 px-4 md:px-6">
-            <div className="flex min-w-0 items-center gap-3">
+        <aside className="fixed inset-y-0 left-0 z-30 hidden w-[220px] border-r border-[var(--border-1)] md:block">
+          <Sidebar pathname={pathname} />
+        </aside>
+
+        {drawerOpen ? (
+          <div className="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true">
+            <button
+              type="button"
+              className="absolute inset-0 bg-black/30"
+              onClick={() => setDrawerOpen(false)}
+              aria-label="Cerrar navegación"
+            />
+            <aside className="absolute inset-y-0 left-0 w-[min(86vw,300px)] border-r border-black bg-white shadow-2xl">
               <button
                 type="button"
-                onClick={() => setDrawerOpen(true)}
-                className="grid h-9 w-9 place-items-center rounded-md border border-[var(--border-1)] md:hidden"
-                aria-label="Abrir menú"
+                onClick={() => setDrawerOpen(false)}
+                className="absolute right-3 top-3 z-10 grid h-9 w-9 place-items-center rounded-md border border-[var(--border-1)] bg-white"
+                aria-label="Cerrar menú"
               >
-                <IconMenu size={16} />
+                <IconX size={14} />
               </button>
-              <div className="min-w-0">
-                <p className="font-mono text-[8px] uppercase tracking-[0.16em] text-[var(--fg-muted)]">
-                  VForge
-                </p>
-                <h1 className="truncate text-[15px] font-medium tracking-[-0.025em]">
-                  {title}
-                </h1>
-              </div>
-            </div>
-            <AccountMenu />
+              <Sidebar pathname={pathname} onNavigate={() => setDrawerOpen(false)} />
+            </aside>
           </div>
-        </header>
+        ) : null}
 
-        <main
+        <div
           className={cn(
-            isStudio
-              ? "h-[calc(100svh-58px)] overflow-hidden lg:h-[calc(100dvh-58px)]"
-              : "min-h-[calc(100svh-58px)]",
+            "md:pl-[220px]",
+            isStudio ? "h-full overflow-hidden" : "min-h-svh",
           )}
         >
-          {children}
-        </main>
+          <header
+            className={cn(
+              "z-20 border-b border-[var(--border-1)] bg-white/95 backdrop-blur-md",
+              isStudio ? "relative shrink-0" : "sticky top-0",
+            )}
+          >
+            <div className="flex h-[58px] items-center justify-between gap-4 px-4 md:px-6">
+              <div className="flex min-w-0 items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setDrawerOpen(true)}
+                  className="grid h-9 w-9 place-items-center rounded-md border border-[var(--border-1)] md:hidden"
+                  aria-label="Abrir menú"
+                >
+                  <IconMenu size={16} />
+                </button>
+                <div className="min-w-0">
+                  <p className="font-mono text-[8px] uppercase tracking-[0.16em] text-[var(--fg-muted)]">
+                    VForge
+                  </p>
+                  <h1 className="truncate text-[15px] font-medium tracking-[-0.025em]">
+                    {title}
+                  </h1>
+                </div>
+              </div>
+              <AccountMenu />
+            </div>
+          </header>
+
+          <main
+            className={cn(
+              isStudio
+                ? "h-[calc(100svh-58px)] overflow-hidden lg:h-[calc(100dvh-58px)]"
+                : "min-h-[calc(100svh-58px)]",
+            )}
+          >
+            {children}
+          </main>
+        </div>
       </div>
-    </div>
+    </ConnectionGate>
   );
 }
 


### PR DESCRIPTION
## Qué cambia

- **ConnectionGate**: sin GitHub o Vercel → redirección a `/app/setup`
- Login/signup de Clerk caen en `/app/setup` (no directo al chat)
- `/app` raíz → setup
- Setup a pantalla completa (sin sidebar) estilo Stitch
- Link "Setup / conexiones" en el menú

Así la plataforma deja de abrirse como visor y obliga a armar la empresa primero.