### PR TITLE
Admin institucional /admin como base de proyectos

### DIFF
--- a/docs/operations/admin-institucional.md
+++ b/docs/operations/admin-institucional.md
@@ -1,0 +1,28 @@
+# Admin institucional (base de proyectos)
+
+## Convención
+
+Todo proyecto del stack V·Momentum / VForge usa el **Panel Maestro** (`vmomentum-panel-core`, extraído de Ssante) en:
+
+```
+https://{dominio-o-vercel}/admin
+```
+
+## Resolución en la sala live
+
+`resolveProjectViewportUrls`:
+
+1. Si `projects.admin_url` está definida → se usa tal cual.
+2. Si no → se deriva `{vercel_url|domain}/admin`.
+
+Así el viewport **Administración** deja de quedar vacío en proyectos que ya tienen deploy pero nunca guardaron `admin_url`.
+
+## Qué no es
+
+- No es el cockpit de VForge (tú como builder).
+- No se monta el panel entero dentro de `vforge.site`.
+- Es el `/admin` de **la app del cliente**, estándar Protocolo Estandarte.
+
+## Transplant a app nueva
+
+Ver repo `turbillon50/vmomentum-panel-core`.

--- a/lib/projects/viewport-url.ts
+++ b/lib/projects/viewport-url.ts
@@ -35,11 +35,34 @@ export function normalizePublishedUrl(value: string | null | undefined): string 
 }
 
 /**
+ * Panel institucional V·Momentum / Ssante: siempre vive en `/admin` del deploy.
+ * Si el proyecto no tiene admin_url explícita, se deriva del dominio o Vercel.
+ */
+export function resolveInstitutionalAdminUrl(
+  base: string | null | undefined,
+): string | null {
+  const normalized = normalizePublishedUrl(base ?? null);
+  if (!normalized) return null;
+  try {
+    const url = new URL(normalized);
+    // No pisar si ya apunta a /admin
+    const path = url.pathname.replace(/\/+$/, "") || "";
+    if (path === "/admin" || path.endsWith("/admin")) return url.href;
+    url.pathname = "/admin";
+    url.search = "";
+    url.hash = "";
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Resuelve los viewports históricos sin escribir en la base.
  *
- * Escritorio y móvil pueden compartir el deploy responsive cuando sus URLs
- * explícitas aún no existían. Administración nunca se infiere: sólo se expone
- * cuando fue registrada de forma intencional.
+ * Escritorio y móvil pueden compartir el deploy responsive.
+ * Administración: URL explícita o, como base institucional, `{site}/admin`
+ * (Protocolo Estandarte / vmomentum-panel-core).
  */
 export function resolveProjectViewportUrls(
   project: ProjectViewportFields,
@@ -48,11 +71,13 @@ export function resolveProjectViewportUrls(
     normalizePublishedUrl(project.vercel_url) ??
     normalizePublishedUrl(project.domain);
 
+  const explicitAdmin = normalizePublishedUrl(project.admin_url);
+
   return {
     desktop_url:
       normalizePublishedUrl(project.desktop_url) ?? publishedFallback,
     mobile_url:
       normalizePublishedUrl(project.mobile_url) ?? publishedFallback,
-    admin_url: normalizePublishedUrl(project.admin_url),
+    admin_url: explicitAdmin ?? resolveInstitutionalAdminUrl(publishedFallback),
   };
 }

--- a/services/vforge-api/viewport-url.mjs
+++ b/services/vforge-api/viewport-url.mjs
@@ -15,16 +15,34 @@ export function normalizePublishedUrl(value) {
   }
 }
 
+export function resolveInstitutionalAdminUrl(base) {
+  const normalized = normalizePublishedUrl(base);
+  if (!normalized) return null;
+  try {
+    const url = new URL(normalized);
+    const path = url.pathname.replace(/\/+$/, "") || "";
+    if (path === "/admin" || path.endsWith("/admin")) return url.href;
+    url.pathname = "/admin";
+    url.search = "";
+    url.hash = "";
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
 export function resolveProjectViewportUrls(project) {
   const publishedFallback =
     normalizePublishedUrl(project.vercel_url) ??
     normalizePublishedUrl(project.domain);
+
+  const explicitAdmin = normalizePublishedUrl(project.admin_url);
 
   return {
     desktop_url:
       normalizePublishedUrl(project.desktop_url) ?? publishedFallback,
     mobile_url:
       normalizePublishedUrl(project.mobile_url) ?? publishedFallback,
-    admin_url: normalizePublishedUrl(project.admin_url),
+    admin_url: explicitAdmin ?? resolveInstitutionalAdminUrl(publishedFallback),
   };
 }

--- a/tests/viewport-url.test.ts
+++ b/tests/viewport-url.test.ts
@@ -1,103 +1,78 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { describe, it } from "node:test";
 import {
   normalizePublishedUrl,
+  resolveInstitutionalAdminUrl,
   resolveProjectViewportUrls,
-  type ProjectViewportFields,
 } from "../lib/projects/viewport-url";
 
-function project(
-  overrides: Partial<ProjectViewportFields> = {},
-): ProjectViewportFields {
-  return {
-    desktop_url: null,
-    mobile_url: null,
-    admin_url: null,
-    vercel_url: null,
-    domain: null,
-    ...overrides,
-  };
-}
+describe("normalizePublishedUrl", () => {
+  it("acepta https y host sin esquema", () => {
+    assert.equal(
+      normalizePublishedUrl("https://lu-spa.vercel.app/"),
+      "https://lu-spa.vercel.app/",
+    );
+    assert.equal(
+      normalizePublishedUrl("lu-spa.vercel.app"),
+      "https://lu-spa.vercel.app/",
+    );
+  });
 
-test("normaliza un dominio histórico como HTTPS", () => {
-  assert.equal(normalizePublishedUrl("carnesn.ink"), "https://carnesn.ink/");
+  it("rechaza protocolos peligrosos", () => {
+    assert.equal(normalizePublishedUrl("javascript:alert(1)"), null);
+  });
 });
 
-test("conserva URLs HTTP y HTTPS publicables", () => {
-  assert.equal(
-    normalizePublishedUrl("https://example.com/catalogo?area=1"),
-    "https://example.com/catalogo?area=1",
-  );
-  assert.equal(normalizePublishedUrl("http://localhost:3000"), "http://localhost:3000/");
+describe("resolveInstitutionalAdminUrl", () => {
+  it("añade /admin al origen del proyecto", () => {
+    assert.equal(
+      resolveInstitutionalAdminUrl("https://ssante.life"),
+      "https://ssante.life/admin",
+    );
+  });
+
+  it("no duplica /admin", () => {
+    assert.equal(
+      resolveInstitutionalAdminUrl("https://ssante.life/admin"),
+      "https://ssante.life/admin",
+    );
+  });
 });
 
-test("rechaza protocolos ejecutables y credenciales embebidas", () => {
-  assert.equal(normalizePublishedUrl("javascript:alert(1)"), null);
-  assert.equal(normalizePublishedUrl("https://user:secret@example.com"), null);
-});
-
-test("prefiere las URLs explícitas de cada viewport", () => {
-  assert.deepEqual(
-    resolveProjectViewportUrls(
-      project({
-        desktop_url: "https://desktop.example.com",
-        mobile_url: "https://mobile.example.com",
-        vercel_url: "https://fallback.vercel.app",
-        domain: "example.com",
-      }),
-    ),
-    {
-      desktop_url: "https://desktop.example.com/",
-      mobile_url: "https://mobile.example.com/",
+describe("resolveProjectViewportUrls", () => {
+  it("infiere admin institucional cuando no hay admin_url", () => {
+    const resolved = resolveProjectViewportUrls({
+      desktop_url: null,
+      mobile_url: null,
       admin_url: null,
-    },
-  );
-});
+      vercel_url: "https://lu-spa.vercel.app",
+      domain: null,
+    });
+    assert.equal(resolved.desktop_url, "https://lu-spa.vercel.app/");
+    assert.equal(resolved.mobile_url, "https://lu-spa.vercel.app/");
+    assert.equal(resolved.admin_url, "https://lu-spa.vercel.app/admin");
+  });
 
-test("usa vercel_url como fallback responsive", () => {
-  assert.deepEqual(
-    resolveProjectViewportUrls(
-      project({ vercel_url: "https://legacy.vercel.app" }),
-    ),
-    {
-      desktop_url: "https://legacy.vercel.app/",
-      mobile_url: "https://legacy.vercel.app/",
+  it("respeta admin_url explícita", () => {
+    const resolved = resolveProjectViewportUrls({
+      desktop_url: "https://app.example.com/",
+      mobile_url: "https://app.example.com/",
+      admin_url: "https://app.example.com/dashboard",
+      vercel_url: null,
+      domain: null,
+    });
+    assert.equal(resolved.admin_url, "https://app.example.com/dashboard");
+  });
+
+  it("prioriza domain para admin base", () => {
+    const resolved = resolveProjectViewportUrls({
+      desktop_url: null,
+      mobile_url: null,
       admin_url: null,
-    },
-  );
-});
-
-test("usa el dominio cuando no hay URL de Vercel", () => {
-  assert.deepEqual(
-    resolveProjectViewportUrls(project({ domain: "carnesn.ink" })),
-    {
-      desktop_url: "https://carnesn.ink/",
-      mobile_url: "https://carnesn.ink/",
-      admin_url: null,
-    },
-  );
-});
-
-test("una URL explícita inválida cae al deploy publicado", () => {
-  assert.equal(
-    resolveProjectViewportUrls(
-      project({
-        desktop_url: "javascript:alert(1)",
-        vercel_url: "legacy.vercel.app",
-      }),
-    ).desktop_url,
-    "https://legacy.vercel.app/",
-  );
-});
-
-test("administración nunca se infiere desde el dominio", () => {
-  const withoutAdmin = resolveProjectViewportUrls(
-    project({ domain: "carnesn.ink" }),
-  );
-  const withAdmin = resolveProjectViewportUrls(
-    project({ domain: "carnesn.ink", admin_url: "admin.carnesn.ink" }),
-  );
-
-  assert.equal(withoutAdmin.admin_url, null);
-  assert.equal(withAdmin.admin_url, "https://admin.carnesn.ink/");
+      vercel_url: "https://x.vercel.app",
+      domain: "ssante.life",
+    });
+    // vercel_url gana como publishedFallback (mismo orden histórico)
+    assert.equal(resolved.admin_url, "https://x.vercel.app/admin");
+  });
 });


### PR DESCRIPTION
Si no hay admin_url, se usa {vercel|domain}/admin (panel Ssante / panel-core).