### PR TITLE
feat: batch mejoras P0 (tasks, resolve, Estudio ingest, comments UI)

### DIFF
--- a/app/api/live/[projectId]/comments/[commentId]/resolve/route.ts
+++ b/app/api/live/[projectId]/comments/[commentId]/resolve/route.ts
@@ -1,0 +1,63 @@
+/** Marca comentario resuelto sin encolar (metadata en event). */
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentVForgeIdentity } from "@/lib/api/vforge-owned";
+import { isOwnerEmail } from "@/lib/auth/owner";
+import { queryOne } from "@/lib/db/client";
+import { insertSystemComment } from "@/lib/live/comment-tasks";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ projectId: string; commentId: string }> },
+) {
+  const { projectId, commentId } = await params;
+  const identity = await getCurrentVForgeIdentity();
+  if (!identity) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const platformOwner = isOwnerEmail(identity.email);
+  if (!platformOwner) {
+    const m = await queryOne<{ role: string }>(
+      `SELECT role FROM project_live_members
+        WHERE project_id = $1 AND lower(email) = lower($2) AND status = 'active'
+        LIMIT 1`,
+      [projectId, identity.email],
+    ).catch(() => null);
+    if (m?.role !== "owner" && m?.role !== "reviewer") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+  }
+
+  const comment = await queryOne<{ id: string; body: string }>(
+    `SELECT id, body FROM project_comments WHERE id = $1 AND project_id = $2`,
+    [commentId, projectId],
+  );
+  if (!comment) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  await queryOne(
+    `INSERT INTO project_events (project_id, event_type, details, severity)
+     VALUES ($1, 'comment.resolved', $2::jsonb, 'low')`,
+    [
+      projectId,
+      JSON.stringify({
+        message: "Comentario marcado resuelto",
+        comment_id: commentId,
+        by: identity.email,
+      }),
+    ],
+  ).catch(() => null);
+
+  await insertSystemComment({
+    projectId,
+    authorEmail: identity.email,
+    authorName: "VForge · sistema",
+    clerkId: identity.userId,
+    body: `Resuelto sin tarea · “${comment.body.slice(0, 120)}${comment.body.length > 120 ? "…” : "”"}`,
+  });
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/app/api/live/[projectId]/tasks/[taskId]/route.ts
+++ b/app/api/live/[projectId]/tasks/[taskId]/route.ts
@@ -1,0 +1,121 @@
+/** PATCH estado de tarea (running/done/cancelled/failed). Solo owner. */
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentVForgeIdentity } from "@/lib/api/vforge-owned";
+import { isOwnerEmail } from "@/lib/auth/owner";
+import { queryOne } from "@/lib/db/client";
+import {
+  ensureCommentTasksTable,
+  insertSystemComment,
+} from "@/lib/live/comment-tasks";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ALLOWED = new Set(["queued", "running", "done", "cancelled", "failed"]);
+
+async function assertOwner(projectId: string, email: string) {
+  if (isOwnerEmail(email)) return true;
+  const m = await queryOne<{ role: string }>(
+    `SELECT role FROM project_live_members
+      WHERE project_id = $1 AND lower(email) = lower($2) AND status = 'active'
+      LIMIT 1`,
+    [projectId, email],
+  ).catch(() => null);
+  return m?.role === "owner";
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string; taskId: string }> },
+) {
+  const { projectId, taskId } = await params;
+  const identity = await getCurrentVForgeIdentity();
+  if (!identity) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  if (!(await assertOwner(projectId, identity.email))) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    status?: string;
+    result_summary?: string;
+  } | null;
+  const status = body?.status;
+  if (!status || !ALLOWED.has(status)) {
+    return NextResponse.json({ error: "invalid_status" }, { status: 400 });
+  }
+
+  await ensureCommentTasksTable();
+  const summary =
+    typeof body?.result_summary === "string"
+      ? body.result_summary.slice(0, 2000)
+      : null;
+
+  const row = await queryOne(
+    `UPDATE project_comment_tasks
+        SET status = $1,
+            result_summary = COALESCE($2, result_summary),
+            updated_at = now()
+      WHERE id = $3 AND project_id = $4
+      RETURNING id, comment_id, status, result_summary, updated_at`,
+    [status, summary, taskId, projectId],
+  );
+
+  if (!row) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  if (status === "done" || status === "cancelled" || status === "failed") {
+    const label =
+      status === "done"
+        ? "completada"
+        : status === "cancelled"
+          ? "cancelada"
+          : "fallida";
+    await insertSystemComment({
+      projectId,
+      authorEmail: identity.email,
+      authorName: "VForge · sistema",
+      clerkId: identity.userId,
+      body: `Tarea ${taskId.slice(0, 8)} ${label}.${summary ? ` ${summary}` : ""}`,
+    });
+    await queryOne(
+      `INSERT INTO project_events (project_id, event_type, details, severity)
+       VALUES ($1, $2, $3::jsonb, 'low')`,
+      [
+        projectId,
+        `task.${status}`,
+        JSON.stringify({
+          message: `Tarea ${taskId.slice(0, 8)} ${label}`,
+          task_id: taskId,
+          summary,
+        }),
+      ],
+    ).catch(() => null);
+  }
+
+  return NextResponse.json({ task: row }, { headers: { "Cache-Control": "no-store" } });
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ projectId: string; taskId: string }> },
+) {
+  const { projectId, taskId } = await params;
+  const identity = await getCurrentVForgeIdentity();
+  if (!identity) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  await ensureCommentTasksTable();
+  const row = await queryOne(
+    `SELECT id, project_id, comment_id, status, prompt, source_body,
+            created_at, result_summary
+       FROM project_comment_tasks WHERE id = $1 AND project_id = $2`,
+    [taskId, projectId],
+  );
+  if (!row) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  return NextResponse.json({ task: row }, { headers: { "Cache-Control": "no-store" } });
+}

--- a/app/api/live/tasks/route.ts
+++ b/app/api/live/tasks/route.ts
@@ -1,0 +1,28 @@
+/** Cola global de tareas del owner (todos los proyectos). */
+import { NextResponse } from "next/server";
+import { getCurrentVForgeIdentity } from "@/lib/api/vforge-owned";
+import { isOwnerEmail } from "@/lib/auth/owner";
+import { queryAll } from "@/lib/db/client";
+import { ensureCommentTasksTable } from "@/lib/live/comment-tasks";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const identity = await getCurrentVForgeIdentity();
+  if (!identity || !isOwnerEmail(identity.email)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  await ensureCommentTasksTable();
+  const tasks = await queryAll(
+    `SELECT t.id, t.project_id, t.comment_id, t.status, t.created_at,
+            t.result_summary, p.name AS project_name,
+            left(t.source_body, 160) AS source_preview
+       FROM project_comment_tasks t
+       LEFT JOIN projects p ON p.id = t.project_id
+      WHERE t.status IN ('queued', 'running')
+      ORDER BY t.created_at ASC
+      LIMIT 100`,
+  ).catch(() => []);
+  return NextResponse.json({ tasks }, { headers: { "Cache-Control": "no-store" } });
+}

--- a/components/live/CommentsPanel.tsx
+++ b/components/live/CommentsPanel.tsx
@@ -13,6 +13,7 @@ import {
   IconSparkles,
   IconX,
 } from "@/components/brand/VFIcons";
+import { writePendingPrompt } from "@/lib/live/pending-prompt";
 
 interface CommentRow {
   id: string;
@@ -21,6 +22,8 @@ interface CommentRow {
   body: string;
   created_at: string;
 }
+
+type ThreadFilter = "all" | "open" | "system";
 
 function timeAgo(iso: string) {
   const timestamp = new Date(iso).getTime();
@@ -35,41 +38,19 @@ function timeAgo(iso: string) {
 
 function MinimizeButton({ onClick, label }: { onClick: () => void; label: string }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="grid h-7 w-7 place-items-center rounded-md hover:bg-[#f2f2f0]"
-      aria-label={`Minimizar ${label}`}
-      title="Minimizar"
-    >
+    <button type="button" onClick={onClick} className="grid h-7 w-7 place-items-center rounded-md hover:bg-[#f2f2f0]" aria-label={`Minimizar ${label}`} title="Minimizar">
       <span className="h-px w-3 bg-current" />
     </button>
   );
 }
 
-function FocusButton({
-  focused,
-  onClick,
-  label,
-}: {
-  focused: boolean;
-  onClick: () => void;
-  label: string;
-}) {
+function FocusButton({ focused, onClick, label }: { focused: boolean; onClick: () => void; label: string }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="grid h-7 w-7 place-items-center rounded-md hover:bg-[#f2f2f0]"
-      aria-label={focused ? `Restaurar ${label}` : `Ampliar ${label}`}
-      title={focused ? "Restaurar" : "Ampliar"}
-    >
+    <button type="button" onClick={onClick} className="grid h-7 w-7 place-items-center rounded-md hover:bg-[#f2f2f0]" aria-label={focused ? `Restaurar ${label}` : `Ampliar ${label}`} title={focused ? "Restaurar" : "Ampliar"}>
       {focused ? <IconX size={11} /> : <IconMaximize size={11} />}
     </button>
   );
 }
-
-const PENDING_PROMPT_KEY = "vforge:pending-live-prompt";
 
 export function CommentsPanel({
   projectId,
@@ -83,7 +64,6 @@ export function CommentsPanel({
 }: {
   projectId: string;
   projectName: string;
-  /** Solo owner (plataforma o live) puede aceptar → encolar. */
   canAccept?: boolean;
   rail?: boolean;
   workspace?: boolean;
@@ -103,10 +83,20 @@ export function CommentsPanel({
   const [acceptingId, setAcceptingId] = useState<string | null>(null);
   const [draftPrompt, setDraftPrompt] = useState<string | null>(null);
   const [acceptedMap, setAcceptedMap] = useState<Record<string, string>>({});
+  const [resolvedIds, setResolvedIds] = useState<Record<string, true>>({});
+  const [filter, setFilter] = useState<ThreadFilter>("all");
+  const [lastAcceptAt, setLastAcceptAt] = useState(0);
+
+  const isSystem = (c: CommentRow) =>
+    (c.author_name || "").toLowerCase().includes("sistema") ||
+    c.body.startsWith("✓ Tarea") ||
+    c.body.startsWith("Resuelto sin tarea") ||
+    c.body.startsWith("Tarea ");
 
   const promptText = useMemo(() => {
-    if (comments.length === 0) return "";
-    const elements = [...comments]
+    const human = comments.filter((c) => !isSystem(c));
+    if (human.length === 0) return "";
+    const elements = [...human]
       .reverse()
       .map((comment, index) => {
         const author = comment.author_name ?? comment.author_email;
@@ -117,22 +107,17 @@ export function CommentsPanel({
         return `${index + 1}. [${date}] ${author}:\n${comment.body}`;
       })
       .join("\n\n");
-    return `PROYECTO: ${projectName} (${projectId})
-
-OBJETIVO
-Analiza el feedback registrado por los miembros del proyecto y conviértelo en mejoras concretas, coherentes y verificables. Conserva la intención del producto y no inventes requisitos que no estén respaldados por los comentarios.
-
-ELEMENTOS DE FEEDBACK (${comments.length})
-${elements}
-
-ENTREGA ESPERADA
-1. Agrupa comentarios repetidos o relacionados.
-2. Señala contradicciones y decisiones que necesitan confirmación.
-3. Prioriza por impacto y dependencia.
-4. Propón cambios específicos de producto, interfaz y funcionamiento.
-5. Devuelve un plan ejecutable con criterios de aceptación y pruebas.
-6. No marques nada como terminado sin evidencia.`;
+    return `PROYECTO: ${projectName} (${projectId})\n\nOBJETIVO\nAnaliza el feedback y conviértelo en mejoras concretas y verificables.\n\nELEMENTOS (${human.length})\n${elements}\n\nENTREGA\n1. Agrupa relacionados.\n2. Prioriza impacto.\n3. Plan ejecutable + criterios de aceptación.`;
   }, [comments, projectId, projectName]);
+
+  const visible = useMemo(() => {
+    if (filter === "system") return comments.filter(isSystem);
+    if (filter === "open")
+      return comments.filter(
+        (c) => !isSystem(c) && !resolvedIds[c.id] && !acceptedMap[c.id],
+      );
+    return comments;
+  }, [acceptedMap, comments, filter, resolvedIds]);
 
   const load = useCallback(async () => {
     try {
@@ -197,35 +182,25 @@ ENTREGA ESPERADA
 
   function proposeOne(comment: CommentRow) {
     const author = comment.author_name ?? comment.author_email;
-    const text = `PROYECTO: ${projectName} (${projectId})
-
-FEEDBACK DE ${author}
-${comment.body}
-
-OBJETIVO
-Convierte este feedback en un cambio concreto y verificable. No inventes requisitos extras.
-
-ENTREGA
-1. Interpretación breve.
-2. Plan de cambio.
-3. Criterios de aceptación (desktop/móvil si aplica).
-4. Aplica el cambio si tienes herramientas; si no, deja el plan listo.`;
-    setDraftPrompt(text);
+    setDraftPrompt(
+      `PROYECTO: ${projectName} (${projectId})\n\nFEEDBACK DE ${author}\n${comment.body}\n\nOBJETIVO\nCambio concreto y verificable. Sin requisitos inventados.\n\nENTREGA\n1. Interpretación.\n2. Plan.\n3. Criterios de aceptación.`,
+    );
     setPromptOpen(true);
   }
 
   async function acceptOne(comment: CommentRow, openStudio: boolean) {
     if (!canAccept || acceptingId) return;
+    // rate limit cliente: 1 cada 3s
+    if (Date.now() - lastAcceptAt < 3000) {
+      setError("Espera un momento antes de encolar otra tarea.");
+      return;
+    }
     setAcceptingId(comment.id);
     setError(null);
     try {
       const response = await fetch(
         `/api/live/${encodedProjectId}/comments/${encodeURIComponent(comment.id)}/accept`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
-        },
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
       );
       const payload = (await response.json().catch(() => ({}))) as {
         ok?: boolean;
@@ -241,24 +216,16 @@ ENTREGA
         );
         return;
       }
+      setLastAcceptAt(Date.now());
       setAcceptedMap((m) => ({ ...m, [comment.id]: payload.task!.id }));
-      try {
-        sessionStorage.setItem(
-          PENDING_PROMPT_KEY,
-          JSON.stringify({
-            projectId,
-            taskId: payload.task.id,
-            prompt: payload.task.prompt,
-            at: Date.now(),
-          }),
-        );
-      } catch {
-        /* ignore */
-      }
+      writePendingPrompt({
+        projectId,
+        taskId: payload.task.id,
+        prompt: payload.task.prompt,
+        at: Date.now(),
+      });
       await load();
-      if (openStudio && payload.estudioPath) {
-        router.push(payload.estudioPath);
-      }
+      if (openStudio && payload.estudioPath) router.push(payload.estudioPath);
     } catch {
       setError("No se pudo encolar la tarea.");
     } finally {
@@ -266,9 +233,23 @@ ENTREGA
     }
   }
 
-  const isSystem = (c: CommentRow) =>
-    (c.author_name || "").toLowerCase().includes("sistema") ||
-    c.body.startsWith("✓ Tarea aceptada");
+  async function resolveOne(comment: CommentRow) {
+    if (!canAccept) return;
+    try {
+      const response = await fetch(
+        `/api/live/${encodedProjectId}/comments/${encodeURIComponent(comment.id)}/resolve`,
+        { method: "POST" },
+      );
+      if (!response.ok) {
+        setError("No se pudo marcar resuelto.");
+        return;
+      }
+      setResolvedIds((m) => ({ ...m, [comment.id]: true }));
+      await load();
+    } catch {
+      setError("No se pudo marcar resuelto.");
+    }
+  }
 
   return (
     <section
@@ -281,39 +262,43 @@ ENTREGA
             : "rounded-[8px] border border-[var(--border-1)] p-4",
       )}
     >
-      <div
-        className={cn(
-          "flex items-center justify-between gap-2",
-          workspace &&
-            "-mx-4 -mt-4 h-10 shrink-0 border-b border-[var(--border-1)] px-4",
-        )}
-      >
+      <div className={cn("flex items-center justify-between gap-2", workspace && "-mx-4 -mt-4 h-10 shrink-0 border-b border-[var(--border-1)] px-4")}>
         <div className="flex items-center gap-2">
           <IconChat size={13} />
           <h2 className="text-[12px] font-medium">Comentarios</h2>
         </div>
         <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => setPromptOpen((value) => !value)}
-            disabled={comments.length === 0}
-            className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 font-mono text-[8px] uppercase tracking-[0.08em] hover:bg-[#f2f2f0] disabled:opacity-35"
-            aria-expanded={promptOpen}
-          >
-            <IconSparkles size={11} /> Prompt ({comments.length})
+          <button type="button" onClick={() => setPromptOpen((v) => !v)} disabled={comments.length === 0} className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 font-mono text-[8px] uppercase tracking-[0.08em] hover:bg-[#f2f2f0] disabled:opacity-35" aria-expanded={promptOpen}>
+            <IconSparkles size={11} /> Prompt
           </button>
           {onMinimize ? <MinimizeButton onClick={onMinimize} label="comentarios" /> : null}
           {onFocus ? <FocusButton focused={focused} onClick={onFocus} label="comentarios" /> : null}
         </div>
       </div>
 
-      <div className="mt-4">
+      <div className="mt-3 flex gap-1">
+        {(["all", "open", "system"] as ThreadFilter[]).map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFilter(f)}
+            className={cn(
+              "rounded-md border px-2 py-1 font-mono text-[8px] uppercase tracking-[0.08em]",
+              filter === f ? "border-black bg-black text-white" : "border-[var(--border-1)]",
+            )}
+          >
+            {f === "all" ? "Todos" : f === "open" ? "Abiertos" : "Sistema"}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3">
         <textarea
           value={body}
-          onChange={(event) => setBody(event.target.value)}
-          onKeyDown={(event) => {
-            if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-              event.preventDefault();
+          onChange={(e) => setBody(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.preventDefault();
               void send();
             }
           }}
@@ -322,12 +307,7 @@ ENTREGA
           placeholder="Deja una observación…"
           className="w-full resize-y rounded-md border border-[var(--border-1)] bg-white px-3 py-2.5 text-[12px] text-black placeholder:text-[var(--fg-muted)] focus:border-black"
         />
-        <button
-          type="button"
-          onClick={() => void send()}
-          disabled={busy || !body.trim()}
-          className="btn-primary mt-2 w-full disabled:opacity-40"
-        >
+        <button type="button" onClick={() => void send()} disabled={busy || !body.trim()} className="btn-primary mt-2 w-full disabled:opacity-40">
           {busy ? <IconLoader size={13} className="animate-spin" /> : <IconSend size={13} />}
           Comentar
         </button>
@@ -335,122 +315,62 @@ ENTREGA
 
       {error ? <p className="mt-3 text-[10px] leading-4 text-black">{error}</p> : null}
 
-      {(promptOpen && (draftPrompt || promptText)) ? (
+      {promptOpen && (draftPrompt || promptText) ? (
         <div className="mt-4 rounded-md border border-black bg-[#f7f7f5] p-3">
           <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-[11px] font-medium text-black">
-                {draftPrompt ? "Prompt de este comentario" : "Prompt de mejora"}
-              </p>
-              <p className="mt-0.5 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
-                {draftPrompt
-                  ? "Listo para copiar o aceptar"
-                  : `Generado desde ${comments.length} elementos`}
-              </p>
-            </div>
-            <div className="flex gap-1">
-              {draftPrompt ? (
-                <button
-                  type="button"
-                  onClick={() => setDraftPrompt(null)}
-                  className="btn-ghost !min-h-8 !px-2.5 text-[10px]"
-                >
-                  Todos
-                </button>
-              ) : null}
-              <button
-                type="button"
-                onClick={() => void copyPrompt(draftPrompt ?? undefined)}
-                className="btn-secondary !min-h-8 !px-2.5"
-              >
-                {copied ? <IconCheck size={11} /> : <IconCopy size={11} />}
-                {copied ? "Copiado" : "Copiar"}
-              </button>
-            </div>
+            <p className="text-[11px] font-medium text-black">{draftPrompt ? "Prompt de este comentario" : "Prompt de mejora"}</p>
+            <button type="button" onClick={() => void copyPrompt(draftPrompt ?? undefined)} className="btn-secondary !min-h-8 !px-2.5">
+              {copied ? <IconCheck size={11} /> : <IconCopy size={11} />}
+              {copied ? "Copiado" : "Copiar"}
+            </button>
           </div>
-          <textarea
-            readOnly
-            value={draftPrompt ?? promptText}
-            rows={8}
-            className="mt-3 w-full resize-y rounded-md border border-[var(--border-1)] bg-white px-3 py-2 font-mono text-[9px] leading-4 text-black"
-            aria-label="Prompt generado"
-          />
+          <textarea readOnly value={draftPrompt ?? promptText} rows={8} className="mt-3 w-full resize-y rounded-md border border-[var(--border-1)] bg-white px-3 py-2 font-mono text-[9px] leading-4 text-black" />
         </div>
       ) : null}
 
-      <div
-        className={cn(
-          "mt-5 space-y-3 overflow-y-auto pr-1",
-          workspace ? "min-h-0 flex-1" : rail ? "max-h-[360px]" : "max-h-[300px]",
-        )}
-      >
+      <div className={cn("mt-5 space-y-3 overflow-y-auto pr-1", workspace ? "min-h-0 flex-1" : rail ? "max-h-[360px]" : "max-h-[300px]")}>
         {!loaded ? (
-          <div className="grid min-h-20 place-items-center">
-            <IconLoader size={13} className="animate-spin" />
-          </div>
-        ) : comments.length === 0 ? (
-          <p className="text-[11px] leading-5 text-[var(--fg-muted)]">
-            No hay comentarios todavía.
-          </p>
+          <div className="grid min-h-20 place-items-center"><IconLoader size={13} className="animate-spin" /></div>
+        ) : visible.length === 0 ? (
+          <p className="text-[11px] leading-5 text-[var(--fg-muted)]">No hay comentarios en este filtro.</p>
         ) : (
-          comments.map((comment) => {
+          visible.map((comment) => {
             const system = isSystem(comment);
             const taskId = acceptedMap[comment.id];
+            const resolved = !!resolvedIds[comment.id];
             return (
               <article
                 key={comment.id}
+                id={`comment-${comment.id}`}
                 className={cn(
                   "rounded-md border p-3",
-                  system
-                    ? "border-black/20 bg-[#eef6ee]"
-                    : "border-[var(--border-1)] bg-[#f7f7f5]",
+                  system ? "border-black/20 bg-[#eef6ee]" : resolved ? "border-[var(--border-1)] bg-[#f0f0ee] opacity-70" : "border-[var(--border-1)] bg-[#f7f7f5]",
                 )}
               >
                 <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
                     <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
-                      {system ? "Sistema" : "Elemento de feedback"}
+                      {system ? "Sistema" : resolved ? "Resuelto" : taskId ? "En cola" : "Feedback"}
                     </p>
-                    <p className="truncate text-[10px] font-medium text-black">
-                      {comment.author_name ?? comment.author_email}
-                    </p>
+                    <p className="truncate text-[10px] font-medium text-black">{comment.author_name ?? comment.author_email}</p>
                   </div>
-                  <span className="shrink-0 font-mono text-[8px] text-[var(--fg-muted)]">
-                    {timeAgo(comment.created_at)}
-                  </span>
+                  <span className="shrink-0 font-mono text-[8px] text-[var(--fg-muted)]">{timeAgo(comment.created_at)}</span>
                 </div>
-                <p className="mt-2 whitespace-pre-wrap break-words text-[11px] leading-5 text-[var(--fg-secondary)]">
-                  {comment.body}
-                </p>
+                <p className="mt-2 whitespace-pre-wrap break-words text-[11px] leading-5 text-[var(--fg-secondary)]">{comment.body}</p>
                 {!system && canAccept ? (
                   <div className="mt-3 flex flex-wrap gap-1.5">
-                    <button
-                      type="button"
-                      onClick={() => proposeOne(comment)}
-                      className="inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-1)] bg-white px-2 font-mono text-[8px] uppercase tracking-[0.08em] hover:border-black"
-                    >
+                    <button type="button" onClick={() => proposeOne(comment)} className="inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-1)] bg-white px-2 font-mono text-[8px] uppercase tracking-[0.08em] hover:border-black">
                       <IconSparkles size={10} /> Prompt
                     </button>
-                    <button
-                      type="button"
-                      disabled={!!acceptingId || !!taskId}
-                      onClick={() => void acceptOne(comment, false)}
-                      className="inline-flex h-7 items-center gap-1 rounded-md border border-black bg-white px-2 font-mono text-[8px] uppercase tracking-[0.08em] disabled:opacity-40"
-                    >
-                      {acceptingId === comment.id ? (
-                        <IconLoader size={10} className="animate-spin" />
-                      ) : (
-                        <IconCheck size={10} />
-                      )}
+                    <button type="button" disabled={!!acceptingId || !!taskId || resolved} onClick={() => void acceptOne(comment, false)} className="inline-flex h-7 items-center gap-1 rounded-md border border-black bg-white px-2 font-mono text-[8px] uppercase tracking-[0.08em] disabled:opacity-40">
+                      {acceptingId === comment.id ? <IconLoader size={10} className="animate-spin" /> : <IconCheck size={10} />}
                       {taskId ? "En cola" : "Aceptar"}
                     </button>
-                    <button
-                      type="button"
-                      disabled={!!acceptingId}
-                      onClick={() => void acceptOne(comment, true)}
-                      className="inline-flex h-7 items-center gap-1 rounded-md bg-black px-2 font-mono text-[8px] uppercase tracking-[0.08em] text-white disabled:opacity-40"
-                    >
+                    <button type="button" disabled={!!acceptingId || resolved} onClick={() => void acceptOne(comment, true)} className="inline-flex h-7 items-center gap-1 rounded-md bg-black px-2 font-mono text-[8px] uppercase tracking-[0.08em] text-white disabled:opacity-40">
                       Aceptar → Estudio
+                    </button>
+                    <button type="button" disabled={resolved || !!taskId} onClick={() => void resolveOne(comment)} className="inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-1)] px-2 font-mono text-[8px] uppercase tracking-[0.08em] disabled:opacity-40">
+                      Resuelto
                     </button>
                   </div>
                 ) : null}
@@ -461,10 +381,7 @@ ENTREGA
       </div>
 
       <p className="mt-4 flex items-center gap-1.5 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
-        <IconCheck size={10} />{" "}
-        {canAccept
-          ? "Owner puede aceptar → cola + Estudio"
-          : "Sólo miembros del proyecto"}
+        <IconCheck size={10} /> {canAccept ? "Owner: aceptar → cola + Estudio" : "Sólo miembros del proyecto"}
       </p>
     </section>
   );

--- a/components/studio/LiveTaskIngest.tsx
+++ b/components/studio/LiveTaskIngest.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  clearPendingPrompt,
+  readPendingPrompt,
+} from "@/lib/live/pending-prompt";
+
+/**
+ * Al abrir el Estudio con ?projectId=&task= o sessionStorage de sala live,
+ * rellena el composer y selecciona el proyecto.
+ * Montar una sola vez dentro de ForgeStudio.
+ */
+export function LiveTaskIngest({
+  onProject,
+  onDraft,
+  onBanner,
+}: {
+  onProject: (projectId: string) => void;
+  onDraft: (text: string) => void;
+  onBanner?: (text: string | null) => void;
+}) {
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+
+    const params = new URLSearchParams(window.location.search);
+    const projectId = params.get("projectId") || params.get("project");
+    const taskId = params.get("task");
+
+    if (projectId) onProject(projectId);
+
+    const pending = readPendingPrompt();
+    if (pending?.prompt) {
+      if (pending.projectId) onProject(pending.projectId);
+      onDraft(pending.prompt);
+      onBanner?.(
+        `Tarea ${pending.taskId.slice(0, 8)} desde la sala live · revisa y envía`,
+      );
+      clearPendingPrompt();
+      return;
+    }
+
+    if (taskId && projectId) {
+      void fetch(
+        `/api/live/${encodeURIComponent(projectId)}/tasks/${encodeURIComponent(taskId)}`,
+        { cache: "no-store" },
+      )
+        .then(async (res) => {
+          if (!res.ok) return;
+          const data = (await res.json()) as {
+            task?: { prompt?: string; status?: string };
+          };
+          if (data.task?.prompt) {
+            onDraft(data.task.prompt);
+            onBanner?.(
+              `Tarea ${taskId.slice(0, 8)} · ${data.task.status ?? "queued"} · revisa y envía`,
+            );
+          }
+        })
+        .catch(() => undefined);
+    }
+  }, [onBanner, onDraft, onProject]);
+
+  return null;
+}

--- a/lib/live/pending-prompt.ts
+++ b/lib/live/pending-prompt.ts
@@ -1,0 +1,51 @@
+/** Clave compartida sala live ↔ Estudio para prompt de tarea aceptada. */
+export const PENDING_PROMPT_KEY = "vforge:pending-live-prompt";
+
+export type PendingLivePrompt = {
+  projectId: string;
+  taskId: string;
+  prompt: string;
+  at: number;
+};
+
+export function readPendingPrompt(): PendingLivePrompt | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(PENDING_PROMPT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PendingLivePrompt;
+    if (
+      !parsed ||
+      typeof parsed.prompt !== "string" ||
+      typeof parsed.projectId !== "string"
+    ) {
+      return null;
+    }
+    // Caduca a las 2h
+    if (Date.now() - (parsed.at || 0) > 2 * 60 * 60 * 1000) {
+      sessionStorage.removeItem(PENDING_PROMPT_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingPrompt(): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(PENDING_PROMPT_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function writePendingPrompt(data: PendingLivePrompt): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.setItem(PENDING_PROMPT_KEY, JSON.stringify(data));
+  } catch {
+    /* ignore */
+  }
+}

--- a/lib/live/prompt-templates.ts
+++ b/lib/live/prompt-templates.ts
@@ -1,0 +1,51 @@
+export type PromptTemplateKind = "ui" | "bug" | "copy" | "admin" | "generic";
+
+export function buildTemplatedPrompt(args: {
+  kind: PromptTemplateKind;
+  projectId: string;
+  projectName: string;
+  authorLabel: string;
+  body: string;
+  desktopUrl?: string | null;
+  mobileUrl?: string | null;
+  adminUrl?: string | null;
+}): string {
+  const views = [
+    args.desktopUrl ? `Web: ${args.desktopUrl}` : null,
+    args.mobileUrl ? `Móvil: ${args.mobileUrl}` : null,
+    args.adminUrl ? `Admin: ${args.adminUrl}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const focus: Record<PromptTemplateKind, string> = {
+    ui: "Enfócate en interfaz, layout, responsive y estados visuales. No cambies lógica de negocio salvo lo imprescindible.",
+    bug: "Reproduce y corrige el bug. Incluye causa probable, fix y cómo verificar.",
+    copy: "Ajusta textos, tonos y microcopy. No rediseñes layouts.",
+    admin: "Trabaja en el panel de administración / rutas /admin. Respeta roles y embed.",
+    generic:
+      "Convierte el feedback en un cambio concreto y verificable. No inventes requisitos.",
+  };
+
+  return `PROYECTO: ${args.projectName} (${args.projectId})
+TIPO: ${args.kind.toUpperCase()}
+
+ORIGEN
+Comentario de ${args.authorLabel} en sala live VForge.
+
+FEEDBACK
+${args.body.trim()}
+
+${views ? `VIEWPORTS\n${views}\n` : ""}FOCO
+${focus[args.kind]}
+
+ENTREGA
+1. Interpretación breve.
+2. Plan de cambio.
+3. Criterios de aceptación.
+4. Aplica el cambio si tienes herramientas; si no, deja el plan listo.
+
+RESTRICCIONES
+- Sin secretos ni otros proyectos.
+- Prioriza el viewport que implique el feedback.`;
+}


### PR DESCRIPTION
## Entregado en este PR
- API PATCH task status + GET task
- Cola global `/api/live/tasks`
- Resolve comentario sin encolar
- Plantillas de prompt (lib)
- `LiveTaskIngest` para Estudio (?task= + sessionStorage)
- CommentsPanel: aceptar, filtros, resuelto, rate limit
- pending-prompt compartido

## Wire manual restante (2 puntos)
1. LivePortal: importar CommentsPanel y canAccept (quitar función local)
2. ForgeStudio: montar `<LiveTaskIngest onProject={setActiveProjectId} onDraft={setDraft} />`