### PR TITLE
feat(live): cola global + mobile accept + live MCP tools module

### DIFF
--- a/app/api/live/tasks/route.ts
+++ b/app/api/live/tasks/route.ts
@@ -2,8 +2,7 @@
 import { NextResponse } from "next/server";
 import { getCurrentVForgeIdentity } from "@/lib/api/vforge-owned";
 import { isOwnerEmail } from "@/lib/auth/owner";
-import { queryAll } from "@/lib/db/client";
-import { ensureCommentTasksTable } from "@/lib/live/comment-tasks";
+import { listGlobalOpenTasks } from "@/lib/live/comment-tasks";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,16 +12,6 @@ export async function GET() {
   if (!identity || !isOwnerEmail(identity.email)) {
     return NextResponse.json({ error: "forbidden" }, { status: 403 });
   }
-  await ensureCommentTasksTable();
-  const tasks = await queryAll(
-    `SELECT t.id, t.project_id, t.comment_id, t.status, t.created_at,
-            t.result_summary, p.name AS project_name,
-            left(t.source_body, 160) AS source_preview
-       FROM project_comment_tasks t
-       LEFT JOIN projects p ON p.id = t.project_id
-      WHERE t.status IN ('queued', 'running')
-      ORDER BY t.created_at ASC
-      LIMIT 100`,
-  ).catch(() => []);
+  const tasks = await listGlobalOpenTasks(100);
   return NextResponse.json({ tasks }, { headers: { "Cache-Control": "no-store" } });
 }

--- a/app/app/chat/page.tsx
+++ b/app/app/chat/page.tsx
@@ -2,11 +2,15 @@
 
 import { ForgeStudio } from "@/components/studio/ForgeStudio";
 import { PendingTaskRunner } from "@/components/studio/PendingTaskRunner";
+import { TaskQueuePanel } from "@/components/live/TaskQueuePanel";
 
 export default function ChatPage() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <PendingTaskRunner />
+      <div className="shrink-0 border-b border-[var(--border-1)] bg-white px-3 py-2">
+        <TaskQueuePanel compact />
+      </div>
       <div className="min-h-0 flex-1">
         <ForgeStudio />
       </div>

--- a/components/live/LivePortalMobileEntry.tsx
+++ b/components/live/LivePortalMobileEntry.tsx
@@ -33,6 +33,8 @@ export function LivePortalMobileEntry({
 }) {
   const canSeeAdmin = me.role === "owner" || me.role === "reviewer";
   const canInvite = me.role === "owner";
+  // Accept → cola solo owner de plataforma o role owner del proyecto
+  const canAccept = me.isPlatformOwner || me.role === "owner";
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -67,7 +69,11 @@ export function LivePortalMobileEntry({
       </header>
 
       <div className="min-h-0 flex-1">
-        <MobileLiveShell project={project} canSeeAdmin={canSeeAdmin} />
+        <MobileLiveShell
+          project={project}
+          canSeeAdmin={canSeeAdmin}
+          canAccept={canAccept}
+        />
       </div>
 
       {menuOpen ? (

--- a/components/live/MobileLiveShell.tsx
+++ b/components/live/MobileLiveShell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   IconChat,
+  IconCheck,
   IconExtLink,
   IconLayout,
   IconLoader,
@@ -12,6 +14,7 @@ import {
   IconShield,
   IconX,
 } from "@/components/brand/VFIcons";
+import { writePendingPrompt } from "@/lib/live/pending-prompt";
 
 type ViewId = "mobile" | "desktop" | "admin";
 
@@ -55,12 +58,23 @@ function timeAgo(iso: string) {
   return `hace ${Math.floor(hours / 24)} d`;
 }
 
+function isSystemComment(c: CommentRow) {
+  return (
+    (c.author_name || "").toLowerCase().includes("sistema") ||
+    c.body.startsWith("✓ Tarea") ||
+    c.body.startsWith("Resuelto sin tarea") ||
+    c.body.startsWith("Tarea ")
+  );
+}
+
 export function MobileLiveShell({
   project,
   canSeeAdmin,
+  canAccept = false,
 }: {
   project: MobileLiveProject;
   canSeeAdmin: boolean;
+  canAccept?: boolean;
 }) {
   const [expanded, setExpanded] = useState<ViewId | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
@@ -229,7 +243,12 @@ export function MobileLiveShell({
       </div>
 
       {chatOpen ? (
-        <ChatSheet projectId={project.id} onClose={() => setChatOpen(false)} />
+        <ChatSheet
+          projectId={project.id}
+          projectName={project.name}
+          canAccept={canAccept}
+          onClose={() => setChatOpen(false)}
+        />
       ) : null}
     </div>
   );
@@ -325,7 +344,14 @@ function DeviceCard({
         ) : null}
 
         {url ? (
-          <div className="absolute left-0 top-0 origin-top-left" style={{ width: designW, height: designH, transform: `scale(${scale})` }}>
+          <div
+            className="absolute left-0 top-0 origin-top-left"
+            style={{
+              width: designW,
+              height: designH,
+              transform: `scale(${scale})`,
+            }}
+          >
             <iframe
               key={`${label}-${refreshKey}`}
               src={url}
@@ -344,7 +370,9 @@ function DeviceCard({
               <IconLayout size={20} className="mx-auto text-[var(--fg-muted)]" />
             )}
             <p className="mt-2 text-[12px] text-[var(--fg-muted)]">Sin URL aún</p>
-            <p className="mt-1 text-[10px] text-[var(--fg-muted)]">Se genera cuando haya URL</p>
+            <p className="mt-1 text-[10px] text-[var(--fg-muted)]">
+              Se genera cuando haya URL
+            </p>
           </div>
         )}
 
@@ -370,21 +398,31 @@ function EmptyView({ label }: { label: string }) {
 
 function ChatSheet({
   projectId,
+  projectName,
+  canAccept,
   onClose,
 }: {
   projectId: string;
+  projectName: string;
+  canAccept: boolean;
   onClose: () => void;
 }) {
+  const router = useRouter();
   const encoded = encodeURIComponent(projectId);
   const [comments, setComments] = useState<CommentRow[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [body, setBody] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [acceptingId, setAcceptingId] = useState<string | null>(null);
+  const [acceptedMap, setAcceptedMap] = useState<Record<string, string>>({});
+  const [lastAcceptAt, setLastAcceptAt] = useState(0);
 
   const load = useCallback(async () => {
     try {
-      const res = await fetch(`/api/live/${encoded}/comments`, { cache: "no-store" });
+      const res = await fetch(`/api/live/${encoded}/comments`, {
+        cache: "no-store",
+      });
       if (!res.ok) {
         setError("No se pudieron cargar los mensajes.");
         return;
@@ -428,12 +466,75 @@ function ChatSheet({
     }
   }
 
+  async function acceptOne(comment: CommentRow, openStudio: boolean) {
+    if (!canAccept || acceptingId) return;
+    if (Date.now() - lastAcceptAt < 3000) {
+      setError("Espera un momento antes de encolar otra tarea.");
+      return;
+    }
+    setAcceptingId(comment.id);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/live/${encoded}/comments/${encodeURIComponent(comment.id)}/accept`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{}",
+        },
+      );
+      const payload = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+        task?: { id: string; prompt: string };
+        estudioPath?: string;
+      };
+      if (!response.ok || !payload.ok || !payload.task) {
+        setError(
+          payload.error === "forbidden"
+            ? "Solo el owner puede aceptar."
+            : "No se pudo encolar.",
+        );
+        return;
+      }
+      setLastAcceptAt(Date.now());
+      setAcceptedMap((m) => ({ ...m, [comment.id]: payload.task!.id }));
+      writePendingPrompt({
+        projectId,
+        taskId: payload.task.id,
+        prompt: payload.task.prompt,
+        at: Date.now(),
+      });
+      await load();
+      if (openStudio) {
+        onClose();
+        router.push(payload.estudioPath || `/app/chat?projectId=${encoded}`);
+      }
+    } catch {
+      setError("No se pudo encolar.");
+    } finally {
+      setAcceptingId(null);
+    }
+  }
+
   return (
     <div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
-      <button type="button" className="absolute inset-0 bg-black/40" onClick={onClose} aria-label="Cerrar chat" />
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-label="Cerrar chat"
+      />
       <div className="absolute inset-x-0 bottom-0 flex max-h-[88dvh] flex-col rounded-t-2xl bg-white pb-[env(safe-area-inset-bottom,0px)] shadow-2xl">
         <div className="flex h-12 shrink-0 items-center justify-between border-b border-[var(--border-1)] px-4">
-          <p className="text-[14px] font-medium">Mensajes</p>
+          <div>
+            <p className="text-[14px] font-medium">Mensajes</p>
+            {canAccept ? (
+              <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
+                Owner · aceptar → cola
+              </p>
+            ) : null}
+          </div>
           <button
             type="button"
             onClick={onClose}
@@ -453,23 +554,61 @@ function ChatSheet({
               Aún no hay mensajes. Escribe el primero.
             </p>
           ) : (
-            comments.map((c) => (
-              <article key={c.id} className="rounded-xl border border-[var(--border-1)] bg-[#f7f7f5] p-3">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="truncate text-[12px] font-medium">
-                    {c.author_name ?? c.author_email}
+            comments.map((c) => {
+              const system = isSystemComment(c);
+              const taskId = acceptedMap[c.id];
+              return (
+                <article
+                  key={c.id}
+                  className={
+                    system
+                      ? "rounded-xl border border-black/20 bg-[#eef6ee] p-3"
+                      : "rounded-xl border border-[var(--border-1)] bg-[#f7f7f5] p-3"
+                  }
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="truncate text-[12px] font-medium">
+                      {system
+                        ? "Sistema"
+                        : c.author_name ?? c.author_email}
+                    </p>
+                    <span className="shrink-0 font-mono text-[8px] text-[var(--fg-muted)]">
+                      {timeAgo(c.created_at)}
+                    </span>
+                  </div>
+                  <p className="mt-1 whitespace-pre-wrap break-words text-[13px] leading-5 text-[var(--fg-secondary)]">
+                    {c.body}
                   </p>
-                  <span className="shrink-0 font-mono text-[8px] text-[var(--fg-muted)]">
-                    {timeAgo(c.created_at)}
-                  </span>
-                </div>
-                <p className="mt-1 whitespace-pre-wrap break-words text-[13px] leading-5 text-[var(--fg-secondary)]">
-                  {c.body}
-                </p>
-              </article>
-            ))
+                  {!system && canAccept ? (
+                    <div className="mt-3 flex flex-col gap-2">
+                      <button
+                        type="button"
+                        disabled={!!acceptingId || !!taskId}
+                        onClick={() => void acceptOne(c, false)}
+                        className="flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-black bg-white text-[13px] font-medium disabled:opacity-40"
+                      >
+                        {acceptingId === c.id ? (
+                          <IconLoader size={16} className="animate-spin" />
+                        ) : (
+                          <IconCheck size={16} />
+                        )}
+                        {taskId ? "En cola" : "Aceptar → cola"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={!!acceptingId || !!taskId}
+                        onClick={() => void acceptOne(c, true)}
+                        className="flex h-11 w-full items-center justify-center gap-2 rounded-xl bg-black text-[13px] font-medium text-white disabled:opacity-40"
+                      >
+                        Aceptar → Estudio
+                      </button>
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })
           )}
-          {error ? <p className="text-[12px]">{error}</p> : null}
+          {error ? <p className="text-[12px] text-black">{error}</p> : null}
         </div>
 
         <div className="shrink-0 border-t border-[var(--border-1)] p-3">
@@ -489,7 +628,11 @@ function ChatSheet({
               className="grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-black text-white disabled:opacity-40"
               aria-label="Enviar"
             >
-              {busy ? <IconLoader size={16} className="animate-spin" /> : <IconSend size={16} />}
+              {busy ? (
+                <IconLoader size={16} className="animate-spin" />
+              ) : (
+                <IconSend size={16} />
+              )}
             </button>
           </div>
         </div>

--- a/components/live/TaskQueuePanel.tsx
+++ b/components/live/TaskQueuePanel.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { IconLoader, IconCheck, IconSparkles } from "@/components/brand/VFIcons";
+import { writePendingPrompt } from "@/lib/live/pending-prompt";
+
+interface QueueTask {
+  id: string;
+  project_id: string;
+  comment_id: string;
+  status: string;
+  created_at: string;
+  result_summary: string | null;
+  project_name: string | null;
+  source_preview: string | null;
+}
+
+function timeAgo(iso: string) {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "?";
+  const m = Math.max(0, Math.floor((Date.now() - t) / 60_000));
+  if (m < 1) return "ahora";
+  if (m < 60) return `hace ${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `hace ${h}h`;
+  return `hace ${Math.floor(h / 24)}d`;
+}
+
+/** Cola global de tareas live (solo owner). Muestra queued/running de todos los proyectos. */
+export function TaskQueuePanel({
+  compact = false,
+  className,
+}: {
+  compact?: boolean;
+  className?: string;
+}) {
+  const router = useRouter();
+  const [tasks, setTasks] = useState<QueueTask[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/live/tasks", { cache: "no-store" });
+      if (res.status === 403) {
+        setError(null);
+        setTasks([]);
+        setLoaded(true);
+        return;
+      }
+      if (!res.ok) {
+        setError("No se pudo cargar la cola");
+        return;
+      }
+      const data = (await res.json()) as { tasks?: QueueTask[] };
+      setTasks(Array.isArray(data.tasks) ? data.tasks : []);
+      setError(null);
+    } catch {
+      setError("Cola no disponible");
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    const timer = window.setInterval(() => void load(), 12_000);
+    return () => window.clearInterval(timer);
+  }, [load]);
+
+  async function openInStudio(task: QueueTask) {
+    if (busyId) return;
+    setBusyId(task.id);
+    try {
+      const res = await fetch(
+        `/api/live/${encodeURIComponent(task.project_id)}/tasks/${encodeURIComponent(task.id)}`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) {
+        setError("No se pudo leer la tarea");
+        return;
+      }
+      const data = (await res.json()) as { task?: { id: string; prompt?: string } };
+      if (!data.task?.prompt) {
+        setError("La tarea no tiene prompt");
+        return;
+      }
+      writePendingPrompt({
+        projectId: task.project_id,
+        taskId: data.task.id || task.id,
+        prompt: data.task.prompt,
+        at: Date.now(),
+      });
+      router.push(
+        `/app/chat?projectId=${encodeURIComponent(task.project_id)}&task=${encodeURIComponent(task.id)}`,
+      );
+    } catch {
+      setError("Error al abrir en Estudio");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function cancelTask(task: QueueTask) {
+    if (busyId) return;
+    setBusyId(task.id);
+    try {
+      await fetch(
+        `/api/live/${encodeURIComponent(task.project_id)}/tasks/${encodeURIComponent(task.id)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            status: "cancelled",
+            result_summary: "Cancelada desde cola global",
+          }),
+        },
+      );
+      await load();
+    } catch {
+      setError("No se pudo cancelar");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (!loaded) {
+    return (
+      <div className={cn("flex items-center gap-2 p-3 text-[11px]", className)}>
+        <IconLoader size={12} className="animate-spin" /> Cargando cola…
+      </div>
+    );
+  }
+
+  // Si 403 o vacío y no owner, no mostrar nada ruidoso
+  if (tasks.length === 0 && !error) {
+    return compact ? null : (
+      <div className={cn("rounded-md border border-[var(--border-1)] bg-white p-3", className)}>
+        <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
+          Cola global
+        </p>
+        <p className="mt-1 text-[11px] text-[var(--fg-muted)]">Sin tareas en cola.</p>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      className={cn(
+        "rounded-md border border-black/20 bg-[#f7f7f5]",
+        compact ? "p-2" : "p-3",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="font-mono text-[9px] uppercase tracking-[0.12em]">
+          Cola global · {tasks.length} activa{tasks.length === 1 ? "" : "s"}
+        </p>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)] hover:text-black"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {error ? <p className="mt-2 text-[10px] text-black">{error}</p> : null}
+
+      <div className={cn("mt-2 space-y-2", compact ? "max-h-40" : "max-h-72", "overflow-y-auto")}>
+        {tasks.map((t) => (
+          <article
+            key={t.id}
+            className="rounded border border-[var(--border-1)] bg-white p-2.5"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="truncate text-[11px] font-medium">
+                  {t.project_name || t.project_id}
+                </p>
+                <p className="mt-0.5 font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">
+                  {t.status} · {timeAgo(t.created_at)} · {t.id.slice(0, 8)}
+                </p>
+              </div>
+              <span
+                className={cn(
+                  "shrink-0 rounded px-1.5 py-0.5 font-mono text-[8px] uppercase",
+                  t.status === "running"
+                    ? "bg-black text-white"
+                    : "border border-black/30",
+                )}
+              >
+                {t.status}
+              </span>
+            </div>
+            {t.source_preview ? (
+              <p className="mt-1.5 line-clamp-2 text-[10px] leading-4 text-[var(--fg-secondary)]">
+                {t.source_preview}
+              </p>
+            ) : null}
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              <button
+                type="button"
+                disabled={!!busyId}
+                onClick={() => void openInStudio(t)}
+                className="inline-flex h-7 items-center gap-1 rounded-md bg-black px-2 font-mono text-[8px] uppercase tracking-[0.08em] text-white disabled:opacity-40"
+              >
+                {busyId === t.id ? (
+                  <IconLoader size={10} className="animate-spin" />
+                ) : (
+                  <IconSparkles size={10} />
+                )}
+                Abrir en Estudio
+              </button>
+              <button
+                type="button"
+                disabled={!!busyId}
+                onClick={() => void cancelTask(t)}
+                className="inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-1)] px-2 font-mono text-[8px] uppercase tracking-[0.08em] disabled:opacity-40"
+              >
+                <IconCheck size={10} /> Cancelar
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/docs/live-embed-csp.md
+++ b/docs/live-embed-csp.md
@@ -1,0 +1,37 @@
+# Live embed + CSP checklist
+
+## Modo embed
+
+- URL: `/live/[projectId]?embed=1` (o detección iframe en LivePortal).
+- Objetivo: preview embebible en Studio / demos sin chrome completo.
+- Sandbox iframe recomendado en el host:
+  ```
+  sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+  ```
+- Mobile shell ya usa sandbox restringido en previews (`allow-scripts allow-same-origin`).
+
+## CSP (producción Vercel / headers)
+
+Verificar en `next.config` / Vercel headers:
+
+1. **frame-ancestors** — si quieres que terceros embebban VForge live:
+   - Restringir a dominios conocidos (Studio, clientes VIP), no `*`.
+2. **frame-src / child-src** — URLs de preview de proyectos (Vercel, custom domains).
+3. **connect-src** — `/api/live/*`, SSE events, Clerk, Neon no aplica en browser.
+4. **No** abrir `unsafe-eval` salvo necesidad real de un runtime.
+
+## Owner-only
+
+- Accept → task solo si `isOwnerEmail` / `isPlatformOwner` o role `owner` del proyecto.
+- Guests / observers: solo comentan y ven previews.
+- No shell privilegiado a invitados (sin `hetzner_exec`, sin tools write).
+
+## Checklist rápido pre-merge
+
+- [ ] Accept en desktop CommentsPanel
+- [ ] Accept en mobile ChatSheet (botones grandes)
+- [ ] Cola global en `/app/chat` (TaskQueuePanel)
+- [ ] PendingTaskRunner ejecuta SSE y marca done
+- [ ] `live_list_*` tools registradas en `tools.ts` (módulo listo en `lib/forge/live-tools.ts`)
+- [ ] Embed `?embed=1` no rompe layout móvil
+- [ ] Headers CSP no bloquean previews de proyectos del owner

--- a/lib/forge/live-tools.ts
+++ b/lib/forge/live-tools.ts
@@ -1,6 +1,7 @@
 /**
  * Live room tools for V — list comments & tasks from salas live.
- * Wired into lib/forge/tools.ts TOOLS + dispatch (observe ring).
+ * Wire into lib/forge/tools.ts: spread LIVE_TOOLS into TOOLS and
+ * call executeLiveTool at the top of dispatch (or in default).
  */
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import { queryAll } from "@/lib/db/client";
@@ -10,7 +11,12 @@ import {
   listProjectTasks,
   type CommentTaskStatus,
 } from "@/lib/live/comment-tasks";
-import type { ToolExecutionResult } from "@/lib/forge/tools";
+
+export interface LiveToolResult {
+  ok: boolean;
+  content: string;
+  summary: string;
+}
 
 export const LIVE_TOOLS: Tool[] = [
   {
@@ -66,7 +72,7 @@ function clamp(n: unknown, min: number, max: number, def: number): number {
 export async function executeLiveTool(
   name: string,
   input: Record<string, unknown>,
-): Promise<ToolExecutionResult | null> {
+): Promise<LiveToolResult | null> {
   if (name === "live_list_comments") {
     const projectId =
       typeof input.projectId === "string" ? input.projectId.trim() : "";
@@ -78,13 +84,13 @@ export async function executeLiveTool(
       };
     }
     const limit = clamp(input.limit, 1, 100, 40);
-    const rows = await queryAll<{{
+    const rows = await queryAll<{
       id: string;
       author_email: string;
       author_name: string | null;
       body: string;
       created_at: string;
-    }}>(
+    }>(
       `SELECT id, author_email, author_name, body, created_at
          FROM project_comments
         WHERE project_id = $1
@@ -97,12 +103,12 @@ export async function executeLiveTool(
       content: JSON.stringify({
         projectId,
         total: rows.length,
-        comments: rows.map((c) => ({{
+        comments: rows.map((c) => ({
           id: c.id,
           author: c.author_name ?? c.author_email,
           body: c.body.slice(0, 800),
           created_at: c.created_at,
-        }})),
+        })),
       }),
       summary: `${rows.length} comentarios en ${projectId}`,
     };
@@ -123,7 +129,7 @@ export async function executeLiveTool(
         content: JSON.stringify({
           scope: "global_open",
           total: tasks.length,
-          tasks: tasks.map((t) => ({{
+          tasks: tasks.map((t) => ({
             id: t.id,
             project_id: t.project_id,
             project_name: t.project_name,
@@ -131,7 +137,7 @@ export async function executeLiveTool(
             source_preview: t.source_preview,
             created_at: t.created_at,
             prompt_preview: (t.prompt ?? "").slice(0, 240),
-          }})),
+          })),
         }),
         summary: `cola global: ${tasks.length} abiertas`,
       };
@@ -147,7 +153,7 @@ export async function executeLiveTool(
       content: JSON.stringify({
         projectId,
         total: tasks.length,
-        tasks: tasks.map((t) => ({{
+        tasks: tasks.map((t) => ({
           id: t.id,
           comment_id: t.comment_id,
           status: t.status,
@@ -155,7 +161,7 @@ export async function executeLiveTool(
           created_at: t.created_at,
           result_summary: t.result_summary,
           prompt_preview: t.prompt.slice(0, 240),
-        }})),
+        })),
       }),
       summary: `${tasks.length} tareas en ${projectId}`,
     };

--- a/lib/forge/live-tools.ts
+++ b/lib/forge/live-tools.ts
@@ -1,0 +1,165 @@
+/**
+ * Live room tools for V — list comments & tasks from salas live.
+ * Wired into lib/forge/tools.ts TOOLS + dispatch (observe ring).
+ */
+import type { Tool } from "@anthropic-ai/sdk/resources/messages";
+import { queryAll } from "@/lib/db/client";
+import {
+  ensureCommentTasksTable,
+  listGlobalOpenTasks,
+  listProjectTasks,
+  type CommentTaskStatus,
+} from "@/lib/live/comment-tasks";
+import type { ToolExecutionResult } from "@/lib/forge/tools";
+
+export const LIVE_TOOLS: Tool[] = [
+  {
+    name: "live_list_comments",
+    description:
+      "Lista comentarios de la sala live de un proyecto. Devuelve autor, body, fecha. Úsala cuando Luis pregunte qué feedback hay en un live room, qué dijeron los revisores, o antes de aceptar/encolar.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: {
+          type: "string",
+          description: "Slug / id del proyecto en vForge",
+        },
+        limit: {
+          type: "number",
+          description: "Máximo de comentarios (1-100, default 40)",
+        },
+      },
+      required: ["projectId"],
+    },
+  },
+  {
+    name: "live_list_tasks",
+    description:
+      "Lista tareas generadas desde comentarios live (accept → cola). Sin projectId = cola global queued+running (owner). Con projectId filtra ese proyecto. status opcional: queued|running|done|cancelled|failed.",
+    input_schema: {
+      type: "object",
+      properties: {
+        projectId: {
+          type: "string",
+          description: "Opcional. Si se omite, cola global abierta.",
+        },
+        status: {
+          type: "string",
+          enum: ["queued", "running", "done", "cancelled", "failed"],
+          description: "Filtro de status (solo con projectId)",
+        },
+        limit: {
+          type: "number",
+          description: "1-200, default 50",
+        },
+      },
+    },
+  },
+];
+
+function clamp(n: unknown, min: number, max: number, def: number): number {
+  const v = typeof n === "number" ? n : parseInt(String(n ?? ""), 10);
+  if (Number.isNaN(v)) return def;
+  return Math.min(Math.max(v, min), max);
+}
+
+export async function executeLiveTool(
+  name: string,
+  input: Record<string, unknown>,
+): Promise<ToolExecutionResult | null> {
+  if (name === "live_list_comments") {
+    const projectId =
+      typeof input.projectId === "string" ? input.projectId.trim() : "";
+    if (!projectId) {
+      return {
+        ok: false,
+        content: JSON.stringify({ error: "projectId requerido" }),
+        summary: "live_list_comments: falta projectId",
+      };
+    }
+    const limit = clamp(input.limit, 1, 100, 40);
+    const rows = await queryAll<{{
+      id: string;
+      author_email: string;
+      author_name: string | null;
+      body: string;
+      created_at: string;
+    }}>(
+      `SELECT id, author_email, author_name, body, created_at
+         FROM project_comments
+        WHERE project_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2`,
+      [projectId, limit],
+    ).catch(() => []);
+    return {
+      ok: true,
+      content: JSON.stringify({
+        projectId,
+        total: rows.length,
+        comments: rows.map((c) => ({{
+          id: c.id,
+          author: c.author_name ?? c.author_email,
+          body: c.body.slice(0, 800),
+          created_at: c.created_at,
+        }})),
+      }),
+      summary: `${rows.length} comentarios en ${projectId}`,
+    };
+  }
+
+  if (name === "live_list_tasks") {
+    await ensureCommentTasksTable();
+    const limit = clamp(input.limit, 1, 200, 50);
+    const projectId =
+      typeof input.projectId === "string" && input.projectId.trim()
+        ? input.projectId.trim()
+        : null;
+
+    if (!projectId) {
+      const tasks = await listGlobalOpenTasks(limit);
+      return {
+        ok: true,
+        content: JSON.stringify({
+          scope: "global_open",
+          total: tasks.length,
+          tasks: tasks.map((t) => ({{
+            id: t.id,
+            project_id: t.project_id,
+            project_name: t.project_name,
+            status: t.status,
+            source_preview: t.source_preview,
+            created_at: t.created_at,
+            prompt_preview: (t.prompt ?? "").slice(0, 240),
+          }})),
+        }),
+        summary: `cola global: ${tasks.length} abiertas`,
+      };
+    }
+
+    const status =
+      typeof input.status === "string"
+        ? (input.status as CommentTaskStatus)
+        : undefined;
+    const tasks = await listProjectTasks(projectId, { status, limit });
+    return {
+      ok: true,
+      content: JSON.stringify({
+        projectId,
+        total: tasks.length,
+        tasks: tasks.map((t) => ({{
+          id: t.id,
+          comment_id: t.comment_id,
+          status: t.status,
+          source_preview: t.source_body.slice(0, 160),
+          created_at: t.created_at,
+          result_summary: t.result_summary,
+          prompt_preview: t.prompt.slice(0, 240),
+        }})),
+      }),
+      summary: `${tasks.length} tareas en ${projectId}`,
+    };
+  }
+
+  return null;
+}

--- a/lib/live/comment-tasks.ts
+++ b/lib/live/comment-tasks.ts
@@ -123,6 +123,66 @@ export async function listTasksForComments(
   ).catch(() => []);
 }
 
+/** Lista tareas de un proyecto (cualquier status o filtrado). */
+export async function listProjectTasks(
+  projectId: string,
+  opts?: { status?: CommentTaskStatus | CommentTaskStatus[]; limit?: number },
+): Promise<CommentTaskRow[]> {
+  await ensureCommentTasksTable();
+  const limit = Math.min(Math.max(opts?.limit ?? 50, 1), 200);
+  const statuses = opts?.status
+    ? Array.isArray(opts.status)
+      ? opts.status
+      : [opts.status]
+    : null;
+
+  if (statuses && statuses.length > 0) {
+    return queryAll<CommentTaskRow>(
+      `SELECT id, project_id, comment_id, status, prompt, source_body,
+              created_by, created_by_email, created_at, result_summary
+         FROM project_comment_tasks
+        WHERE project_id = $1 AND status = ANY($2::text[])
+        ORDER BY created_at DESC
+        LIMIT $3`,
+      [projectId, statuses, limit],
+    ).catch(() => []);
+  }
+
+  return queryAll<CommentTaskRow>(
+    `SELECT id, project_id, comment_id, status, prompt, source_body,
+            created_by, created_by_email, created_at, result_summary
+       FROM project_comment_tasks
+      WHERE project_id = $1
+      ORDER BY created_at DESC
+      LIMIT $2`,
+    [projectId, limit],
+  ).catch(() => []);
+}
+
+/** Cola global (owner): queued + running de todos los proyectos. */
+export async function listGlobalOpenTasks(limit = 100): Promise<
+  Array<
+    CommentTaskRow & {
+      project_name: string | null;
+      source_preview: string | null;
+    }
+  >
+> {
+  await ensureCommentTasksTable();
+  return queryAll(
+    `SELECT t.id, t.project_id, t.comment_id, t.status, t.prompt, t.source_body,
+            t.created_by, t.created_by_email, t.created_at, t.result_summary,
+            p.name AS project_name,
+            left(t.source_body, 160) AS source_preview
+       FROM project_comment_tasks t
+       LEFT JOIN projects p ON p.id = t.project_id
+      WHERE t.status IN ('queued', 'running')
+      ORDER BY t.created_at ASC
+      LIMIT $1`,
+    [Math.min(Math.max(limit, 1), 200)],
+  ).catch(() => []);
+}
+
 export async function insertSystemComment(args: {
   projectId: string;
   body: string;

--- a/lib/live/comment-tasks.ts
+++ b/lib/live/comment-tasks.ts
@@ -169,7 +169,12 @@ export async function listGlobalOpenTasks(limit = 100): Promise<
   >
 > {
   await ensureCommentTasksTable();
-  return queryAll(
+  return queryAll<
+    CommentTaskRow & {
+      project_name: string | null;
+      source_preview: string | null;
+    }
+  >(
     `SELECT t.id, t.project_id, t.comment_id, t.status, t.prompt, t.source_body,
             t.created_by, t.created_by_email, t.created_at, t.result_summary,
             p.name AS project_name,


### PR DESCRIPTION
## Qué trae (todo el pack)

### Cola global
- **TaskQueuePanel** en `/app/chat` (owner): queued/running, abrir Estudio, cancelar
- Helpers `listProjectTasks` / `listGlobalOpenTasks`

### Mobile accept
- **ChatSheet** con botones grandes: **Aceptar → cola** y **Aceptar → Estudio**
- `canAccept` desde role owner / isPlatformOwner
- pending-prompt + rate limit 3s

### MCP tools (módulo listo)
- `lib/forge/live-tools.ts` → `live_list_comments` + `live_list_tasks`
- **Falta un wire de 3 líneas en `tools.ts`** (core protegido, archivo enorme):
  ```ts
  import { LIVE_TOOLS, executeLiveTool } from "./live-tools";
  // TOOLS: [...existing, ...LIVE_TOOLS]
  // al inicio de dispatch:
  const live = await executeLiveTool(name, input); if (live) return live;
  ```

### Docs
- `docs/live-embed-csp.md` checklist embed + CSP

## Cómo probar
1. Mobile live → Mensajes → Aceptar (como owner)
2. `/app/chat` → cola arriba → Abrir en Estudio
3. Desktop CommentsPanel sigue igual

## Post-merge
- Cablear LIVE_TOOLS en tools.ts (Claude Code / PR chico)
- Merge y deploy Vercel