### PR TITLE
fix: keep push prompt clear of workspace controls

### DIFF
--- a/components/pwa/EnablePush.tsx
+++ b/components/pwa/EnablePush.tsx
@@ -116,9 +116,13 @@ export function EnablePush({ compact = false }: { compact?: boolean }) {
         type="button"
         onClick={() => void subscribe()}
         disabled={status === "loading"}
-        className="btn-primary !min-h-10 w-full justify-center text-[13px] disabled:opacity-50"
+        className={
+          compact
+            ? "btn-primary !min-h-8 w-auto shrink-0 justify-center px-3 text-[10px] disabled:opacity-50"
+            : "btn-primary !min-h-10 w-full justify-center text-[13px] disabled:opacity-50"
+        }
       >
-        {status === "loading" ? "Activando…" : "Activar avisos push"}
+        {status === "loading" ? "Activando…" : compact ? "Activar" : "Activar avisos push"}
       </button>
       {message ? <p className="mt-1 text-[11px] text-[var(--fg-muted)]">{message}</p> : null}
       {status === "no_vapid" ? (

--- a/components/pwa/OwnerPushBanner.tsx
+++ b/components/pwa/OwnerPushBanner.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
+import { usePathname } from "next/navigation";
 import { EnablePush } from "@/components/pwa/EnablePush";
+const STUDIO_ROUTE = "/app/chat";
 
 /**
  * Banner flotante para activar push cuando hay sesión.
@@ -10,6 +12,9 @@ import { EnablePush } from "@/components/pwa/EnablePush";
  */
 export function OwnerPushBanner() {
   const { isSignedIn, isLoaded } = useAuth();
+  const pathname = usePathname() ?? "";
+  const isStudioRoute =
+    pathname === STUDIO_ROUTE || pathname.startsWith(STUDIO_ROUTE + "/");
   const [dismissed, setDismissed] = useState(true);
   const [mounted, setMounted] = useState(false);
 
@@ -46,31 +51,36 @@ export function OwnerPushBanner() {
   if (!mounted || !isLoaded || !isSignedIn || dismissed) return null;
 
   return (
-    <div className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))] right-3 z-40 w-[min(100%-1.5rem,320px)] rounded-2xl border border-black bg-white p-3 shadow-[0_12px_40px_rgba(0,0,0,0.12)]">
-      <div className="mb-2 flex items-start justify-between gap-2">
-        <div>
-          <p className="text-[13px] font-medium">Avisos en el teléfono</p>
-          <p className="mt-0.5 text-[11px] leading-4 text-[var(--fg-muted)]">
-            Te avisamos cuando un cliente escribe en la sala o en el link público.
-          </p>
-        </div>
-        <button
-          type="button"
-          className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-[var(--border-1)] text-[12px]"
-          aria-label="Cerrar"
-          onClick={() => {
-            setDismissed(true);
-            try {
-              sessionStorage.setItem("vforge_push_dismiss", "1");
-            } catch {
-              /* ignore */
-            }
-          }}
-        >
-          ×
-        </button>
+    <div
+      className={`fixed right-2 z-40 flex w-[calc(100%-1rem)] max-w-[360px] items-center gap-2 rounded-xl border border-black bg-white p-2 shadow-[0_12px_32px_rgba(0,0,0,0.12)] sm:right-4 sm:w-auto sm:min-w-[320px] ${
+        isStudioRoute
+          ? "bottom-[calc(8rem+env(safe-area-inset-bottom,0px))] md:bottom-14"
+          : "bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))] md:bottom-4"
+      }`}
+      role="status"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[11px] font-medium">Avisos en el teléfono</p>
+        <p className="hidden text-[9px] leading-4 text-[var(--fg-muted)] sm:block">
+          Mensajes de clientes y salas, al momento.
+        </p>
       </div>
       <EnablePush compact />
+      <button
+        type="button"
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-[var(--border-1)] text-[12px]"
+        aria-label="Cerrar avisos"
+        onClick={() => {
+          setDismissed(true);
+          try {
+            sessionStorage.setItem("vforge_push_dismiss", "1");
+          } catch {
+            /* ignore */
+          }
+        }}
+      >
+        ×
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Alcance
- compacta el aviso push en el interior
- libera compositor y bottom-nav en móvil
- conserva estilo blanco y negro y funcionalidad existente

## Verificación
- lint dirigido: aprobado
- TypeScript: aprobado
- Next.js build: aprobado con Node 20
- supervisor: APROBADO

No toca landing, autenticación, backend ni producción.