### PR TITLE
fix: return Vercel OAuth to canonical integrations

### DIFF
--- a/app/api/auth/vercel/callback/route.ts
+++ b/app/api/auth/vercel/callback/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: Request) {
   const teamId = url.searchParams.get("teamId");
 
   const back = (status: string) =>
-    Response.redirect(`${site}/workspace/conexiones?vercel=${status}`, 302);
+    Response.redirect(`${site}/app/integrations?vercel=${status}`, 302);
 
   // 1) Sesion de Clerk si existe; 2) si no, el userId firmado en el state.
   let userId: string | null = null;


### PR DESCRIPTION
Validación completada. Se cierra este borrador porque el conector GraphQL no pudo cambiarlo a Ready; el cambio se reabre como PR normal para fusionarlo.