### PR TITLE
fix: return Vercel OAuth to canonical integrations

### DIFF
--- a/app/api/auth/vercel/callback/route.ts
+++ b/app/api/auth/vercel/callback/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: Request) {
   const teamId = url.searchParams.get("teamId");
 
   const back = (status: string) =>
-    Response.redirect(`${site}/workspace/conexiones?vercel=${status}`, 302);
+    Response.redirect(`${site}/app/integrations?vercel=${status}`, 302);
 
   // 1) Sesion de Clerk si existe; 2) si no, el userId firmado en el state.
   let userId: string | null = null;


### PR DESCRIPTION
Validado: preview Vercel READY, supervisor APROBADO, TypeScript limpio y build Node 20 con BUILD_ID. Reemplaza al borrador #133, cerrado por fallo del conector al marcar Ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the post-OAuth redirect URL changes; token exchange and vault logic are untouched.
> 
> **Overview**
> After Vercel OAuth finishes (success or error), the callback **redirects users to `/app/integrations`** with the same `vercel=` query status, instead of **`/workspace/conexiones`**.
> 
> This aligns Vercel with other integration OAuth handlers (e.g. MindContext) and the documented integrations entry point, so users land on the canonical integrations UI after connecting Vercel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a07b2c46c9251b03fcb90aea8a7da7c670e636f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->