### PR TITLE
feat: onboarding autoservicio para cuentas nuevas

### DIFF
--- a/app/api/auth/github/callback/route.ts
+++ b/app/api/auth/github/callback/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { cookies } from "next/headers";
 import { saveUserSecret } from "@/lib/connect/user-vault";
+import { normalizarOAuthReturnPath } from "@/lib/connect/oauth-state";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,9 +22,13 @@ export async function GET(req: Request) {
   const expected = jar.get("gh_oauth_state")?.value;
   const bridgeReturnTo = jar.get("gh_bridge_return_to")?.value;
   const bridgeTenant = jar.get("gh_bridge_tenant")?.value;
+  const internalReturnPath = normalizarOAuthReturnPath(
+    jar.get("gh_oauth_return_path")?.value,
+  );
   jar.delete("gh_oauth_state");
   jar.delete("gh_bridge_return_to");
   jar.delete("gh_bridge_tenant");
+  jar.delete("gh_oauth_return_path");
 
   const back = (status: string) => {
     if (bridgeReturnTo) {
@@ -31,7 +36,9 @@ export async function GET(req: Request) {
       u.searchParams.set("github", status);
       return Response.redirect(u.toString(), 302);
     }
-    return Response.redirect(`${site}/app/setup?github=${status}`, 302);
+    const destination = new URL(internalReturnPath, site);
+    destination.searchParams.set("github", status);
+    return Response.redirect(destination, 302);
   };
 
   if (!code) return back("error_no_code");

--- a/app/api/auth/github/start/route.ts
+++ b/app/api/auth/github/start/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { randomBytes } from "node:crypto";
 import { cookies } from "next/headers";
+import { normalizarOAuthReturnPath } from "@/lib/connect/oauth-state";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -44,10 +45,16 @@ export async function GET(req: Request) {
 
   const reqUrl = new URL(req.url);
   const returnTo = returnToPermitido(reqUrl.searchParams.get("return_to"));
+  const internalReturnTo = normalizarOAuthReturnPath(
+    reqUrl.searchParams.get("return_to"),
+  );
   const tenant = reqUrl.searchParams.get("tenant");
 
   const state = randomBytes(16).toString("hex");
   const jar = await cookies();
+  jar.delete("gh_bridge_return_to");
+  jar.delete("gh_bridge_tenant");
+  jar.delete("gh_oauth_return_path");
   jar.set("gh_oauth_state", state, {
     httpOnly: true,
     secure: true,
@@ -73,6 +80,14 @@ export async function GET(req: Request) {
         path: "/",
       });
     }
+  } else {
+    jar.set("gh_oauth_return_path", internalReturnTo, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      maxAge: 600,
+      path: "/",
+    });
   }
 
   const redirectUri = `${siteUrl()}/api/auth/github/callback`;

--- a/app/api/auth/vercel/callback/route.ts
+++ b/app/api/auth/vercel/callback/route.ts
@@ -1,7 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { cookies } from "next/headers";
 import { saveUserSecret } from "@/lib/connect/user-vault";
-import { leerState } from "@/lib/connect/oauth-state";
+import { leerStateCompleto } from "@/lib/connect/oauth-state";
 import { registrarIntento } from "@/lib/connect/attempt-log";
 
 export const runtime = "nodejs";
@@ -26,8 +26,12 @@ export async function GET(req: Request) {
   const configurationId = url.searchParams.get("configurationId");
   const teamId = url.searchParams.get("teamId");
 
-  const back = (status: string) =>
-    Response.redirect(`${site}/app/integrations?vercel=${status}`, 302);
+  const stateData = leerStateCompleto(state);
+  const back = (status: string) => {
+    const destination = new URL(stateData?.returnPath ?? "/app/integrations", site);
+    destination.searchParams.set("vercel", status);
+    return Response.redirect(destination, 302);
+  };
 
   // 1) Sesion de Clerk si existe; 2) si no, el userId firmado en el state.
   let userId: string | null = null;
@@ -36,7 +40,7 @@ export async function GET(req: Request) {
   } catch {
     userId = null;
   }
-  const desdeState = leerState(state);
+  const desdeState = stateData?.userId ?? null;
   if (!userId) userId = desdeState;
 
   // Si hay sesion Y state, deben coincidir: evita que alguien pegue su code

--- a/app/api/auth/vercel/start/route.ts
+++ b/app/api/auth/vercel/start/route.ts
@@ -1,6 +1,9 @@
 import { auth } from "@clerk/nextjs/server";
 import { cookies } from "next/headers";
-import { firmarState } from "@/lib/connect/oauth-state";
+import {
+  firmarState,
+  normalizarOAuthReturnPath,
+} from "@/lib/connect/oauth-state";
 import { registrarIntento } from "@/lib/connect/attempt-log";
 
 export const runtime = "nodejs";
@@ -12,13 +15,16 @@ export const dynamic = "force-dynamic";
  * el callback no dependa de que la cookie de Clerk sobreviva el regreso
  * desde vercel.com. Ese era el motivo real de que nunca se guardara token.
  */
-export async function GET() {
+export async function GET(req: Request) {
   const site = process.env.NEXT_PUBLIC_SITE_URL || "https://vforge.site";
   const { userId } = await auth();
   if (!userId) return Response.redirect(new URL("/sign-in", site), 302);
 
   const slug = process.env.VERCEL_INTEGRATION_SLUG || "v-forge";
-  const state = firmarState(userId);
+  const returnPath = normalizarOAuthReturnPath(
+    new URL(req.url).searchParams.get("return_to"),
+  );
+  const state = firmarState(userId, returnPath);
 
   // La cookie se conserva como segundo cinturon, pero ya no es indispensable.
   const jar = await cookies();
@@ -30,7 +36,12 @@ export async function GET() {
     path: "/",
   });
 
-  await registrarIntento("vercel", "iniciado", `slug=${slug}`, userId);
+  await registrarIntento(
+    "vercel",
+    "iniciado",
+    `slug=${slug} return=${returnPath}`,
+    userId,
+  );
 
   const url = new URL(`https://vercel.com/integrations/${slug}/new`);
   url.searchParams.set("state", state);

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -40,6 +40,7 @@ function OnboardingWithClerk() {
   const [connected, setConnected] = useState<Connection[]>([]);
   const [loadingStatus, setLoadingStatus] = useState(true);
   const [finishing, setFinishing] = useState(false);
+  const [finishError, setFinishError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isLoaded && !isSignedIn) router.replace("/sign-in");
@@ -68,8 +69,9 @@ function OnboardingWithClerk() {
   async function enterWorkspace() {
     if (finishing) return;
     setFinishing(true);
+    setFinishError(null);
     try {
-      await fetch("/api/user/complete-onboarding", {
+      const response = await fetch("/api/user/complete-onboarding", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -77,9 +79,16 @@ function OnboardingWithClerk() {
           services: connected.length,
         }),
       });
-    } finally {
-      router.push("/app/chat");
+      if (!response.ok) throw new Error("No pudimos guardar tu configuración.");
+      router.push("/workspace");
       router.refresh();
+    } catch (error) {
+      setFinishError(
+        error instanceof Error
+          ? error.message
+          : "No pudimos abrir tu espacio. Intenta otra vez.",
+      );
+      setFinishing(false);
     }
   }
 
@@ -102,14 +111,14 @@ function OnboardingWithClerk() {
       id: "github",
       title: "GitHub",
       body: "Repositorios y cambios que alimentan el proyecto.",
-      href: "/api/auth/github/start",
+      href: "/api/auth/github/start?return_to=%2Fonboarding",
       icon: IconGithub,
     },
     {
       id: "vercel",
       title: "Vercel",
       body: "Previews y URLs que se muestran dentro del visor.",
-      href: "/api/auth/vercel/start",
+      href: "/api/auth/vercel/start?return_to=%2Fonboarding",
       icon: IconRocket,
     },
   ];
@@ -192,6 +201,11 @@ function OnboardingWithClerk() {
                   </>
                 )}
               </button>
+              {finishError ? (
+                <p role="alert" className="mt-3 text-[12px] leading-5 text-black">
+                  {finishError}
+                </p>
+              ) : null}
             </div>
           </div>
         </section>

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -2,6 +2,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { ScopedWorkspaceHome } from "@/components/workspace/ScopedWorkspaceHome";
 import { isOwnerUser } from "@/lib/auth/owner";
+import { listUserConnections } from "@/lib/connect/user-vault";
 import { listScopedProjects } from "@/lib/projects/scoped-catalog";
 
 export const dynamic = "force-dynamic";
@@ -16,12 +17,28 @@ export default async function WorkspacePage() {
   if (isOwnerUser(user)) redirect("/app/chat");
 
   const name = user.firstName || user.username || "";
-  const projects = await listScopedProjects(email).catch((error: unknown) => {
-    console.error("[workspace] scoped catalog failed", {
-      email,
-      message: error instanceof Error ? error.message : String(error),
-    });
-    return [];
-  });
-  return <ScopedWorkspaceHome name={name} email={email} projects={projects} />;
+  const [projects, connections] = await Promise.all([
+    listScopedProjects(email).catch((error: unknown) => {
+      console.error("[workspace] scoped catalog failed", {
+        email,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }),
+    listUserConnections(user.id).catch((error: unknown) => {
+      console.error("[workspace] connections failed", {
+        userId: user.id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }),
+  ]);
+  return (
+    <ScopedWorkspaceHome
+      name={name}
+      email={email}
+      projects={projects}
+      connections={connections}
+    />
+  );
 }

--- a/components/workspace/ScopedWorkspaceHome.tsx
+++ b/components/workspace/ScopedWorkspaceHome.tsx
@@ -5,8 +5,11 @@ import { UserButton } from "@clerk/nextjs";
 import { VWordmark } from "@/components/brand/VMark";
 import {
   IconArrowR,
+  IconCheck,
+  IconGithub,
   IconGlobe,
   IconLayout,
+  IconRocket,
   IconShield,
 } from "@/components/brand/VFIcons";
 import { monochromeClerkAppearance } from "@/components/auth/ClerkShell";
@@ -24,16 +27,39 @@ export function ScopedWorkspaceHome({
   name,
   email,
   projects,
+  connections,
 }: {
   name: string;
   email: string;
   projects: ScopedProject[];
+  connections: string[];
 }) {
+  const githubConnected = connections.includes("github");
+  const vercelConnected = connections.includes("vercel");
+  const connectionItems = [
+    {
+      id: "github",
+      title: "GitHub",
+      body: "Tu código, repositorios y cambios.",
+      connected: githubConnected,
+      href: "/api/auth/github/start?return_to=%2Fworkspace",
+      icon: IconGithub,
+    },
+    {
+      id: "vercel",
+      title: "Vercel",
+      body: "Tus deployments, previews y dominios.",
+      connected: vercelConnected,
+      href: "/api/auth/vercel/start?return_to=%2Fworkspace",
+      icon: IconRocket,
+    },
+  ];
+
   return (
     <main className="min-h-svh bg-[var(--color-background)] text-[var(--color-ink)]">
       <header className="border-b border-[var(--border-1)] bg-[var(--color-surface)]">
         <div className="mx-auto flex min-h-[64px] max-w-[1180px] items-center justify-between gap-4 px-4 sm:px-6">
-          <Link href="/workspace" aria-label="VForge, proyectos compartidos">
+          <Link href="/workspace" aria-label="VForge, tu espacio de trabajo">
             <VWordmark />
           </Link>
           <div className="flex items-center gap-2 rounded-full border border-[var(--border-1)] bg-[var(--color-surface)] py-1 pl-1 pr-3">
@@ -55,29 +81,96 @@ export function ScopedWorkspaceHome({
       </header>
 
       <div className="mx-auto max-w-[1180px] px-4 py-10 sm:px-6 sm:py-16">
-        <p className="mono-label">Acceso por membresía</p>
+        <p className="mono-label">Tu workspace</p>
         <h1 className="mt-4 max-w-3xl text-[clamp(2.8rem,8vw,6.8rem)] font-semibold leading-[0.88] tracking-[-0.07em]">
-          Tus proyectos autorizados.
+          Tu espacio ya está listo.
         </h1>
         <p className="mt-6 max-w-2xl break-words text-[15px] leading-7 text-[var(--fg-secondary)] sm:text-[17px]">
-          Aquí sólo aparecen las salas compartidas con {email}. Otros proyectos,
-          repositorios, secretos y administración permanecen fuera de alcance.
+          Esta cuenta pertenece a {email}. No necesitas una invitación: conecta
+          tus propias herramientas y VForge mantendrá tus accesos separados de
+          los de cualquier otra persona.
         </p>
 
-        {projects.length === 0 ? (
-          <section className="mt-10 border border-[var(--color-ink)] bg-[var(--color-surface)] p-6 sm:mt-14 sm:p-9">
-            <IconShield size={22} />
-            <h2 className="mt-5 text-[26px] font-medium tracking-[-0.045em]">
-              Todavía no tienes una sala compartida.
-            </h2>
-            <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--fg-secondary)]">
-              La invitación debe enviarse y aceptarse con este mismo correo. En
-              cuanto exista una membresía activa, el proyecto aparecerá aquí.
+        <section className="mt-10 sm:mt-14" aria-labelledby="connections-title">
+          <div className="flex items-end justify-between gap-4 border-b border-[var(--color-ink)] pb-4">
+            <div>
+              <p className="mono-label">Paso 01</p>
+              <h2
+                id="connections-title"
+                className="mt-2 text-[28px] font-medium tracking-[-0.05em]"
+              >
+                Tus conexiones
+              </h2>
+            </div>
+            <p className="hidden max-w-sm text-right text-[12px] leading-5 text-[var(--fg-secondary)] sm:block">
+              Si todavía no tienes cuenta, puedes crearla al continuar con cada
+              proveedor.
             </p>
-          </section>
-        ) : (
-          <section className="mt-10 grid gap-3 sm:mt-14 md:grid-cols-2">
-            {projects.map((project) => {
+          </div>
+          <div className="grid md:grid-cols-2">
+            {connectionItems.map(
+              ({ id, title, body, connected, href, icon: Icon }) => (
+                <article
+                  key={id}
+                  className="flex min-h-[170px] flex-col border-b border-x border-[var(--border-1)] bg-[var(--color-surface)] p-5 sm:p-6 md:first:border-r-0"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="grid h-10 w-10 place-items-center border border-[var(--color-ink)]">
+                      <Icon size={17} />
+                    </div>
+                    <span className="inline-flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.13em]">
+                      {connected ? (
+                        <IconCheck size={12} />
+                      ) : (
+                        <span className="status-shape" />
+                      )}
+                      {connected ? "Conectado" : "Sin conectar"}
+                    </span>
+                  </div>
+                  <h3 className="mt-5 text-[21px] font-medium tracking-[-0.04em]">
+                    {title}
+                  </h3>
+                  <div className="mt-auto flex items-end justify-between gap-4 pt-3">
+                    <p className="text-[12px] leading-5 text-[var(--fg-secondary)]">
+                      {body}
+                    </p>
+                    {connected ? (
+                      <span className="text-[11px] font-medium">Listo</span>
+                    ) : (
+                      <a href={href} className="btn-ghost !min-h-9 !px-3">
+                        Conectar <IconArrowR size={12} />
+                      </a>
+                    )}
+                  </div>
+                </article>
+              ),
+            )}
+          </div>
+        </section>
+
+        <section className="mt-12 sm:mt-16" aria-labelledby="projects-title">
+          <p className="mono-label">Paso 02</p>
+          <h2
+            id="projects-title"
+            className="mt-2 text-[28px] font-medium tracking-[-0.05em]"
+          >
+            Tus proyectos
+          </h2>
+          {projects.length === 0 ? (
+            <div className="mt-5 border border-[var(--color-ink)] bg-[var(--color-surface)] p-6 sm:p-9">
+              <IconShield size={22} />
+              <h3 className="mt-5 text-[26px] font-medium tracking-[-0.045em]">
+                Aún no hay proyectos en este espacio.
+              </h3>
+              <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--fg-secondary)]">
+                Puedes empezar desde cero con tus propias conexiones. Si alguien
+                comparte una sala con {email}, también aparecerá aquí sin mezclar
+                cuentas, repositorios ni secretos.
+              </p>
+            </div>
+          ) : (
+            <div className="mt-5 grid gap-3 md:grid-cols-2">
+              {projects.map((project) => {
               const href =
                 project.access_kind === "live"
                   ? `/app/live/${encodeURIComponent(project.id)}`
@@ -113,9 +206,10 @@ export function ScopedWorkspaceHome({
                   </div>
                 </Link>
               );
-            })}
-          </section>
-        )}
+              })}
+            </div>
+          )}
+        </section>
       </div>
     </main>
   );

--- a/lib/connect/oauth-state.ts
+++ b/lib/connect/oauth-state.ts
@@ -17,6 +17,23 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 const VENTANA_MS = 15 * 60 * 1000; // 15 min de vida
 
+export const OAUTH_RETURN_PATHS = [
+  "/onboarding",
+  "/workspace",
+  "/app/integrations",
+] as const;
+
+export type OAuthReturnPath = (typeof OAUTH_RETURN_PATHS)[number];
+
+export function normalizarOAuthReturnPath(
+  value: string | null | undefined,
+  fallback: OAuthReturnPath = "/app/integrations",
+): OAuthReturnPath {
+  return OAUTH_RETURN_PATHS.includes(value as OAuthReturnPath)
+    ? (value as OAuthReturnPath)
+    : fallback;
+}
+
 function llave(): Buffer {
   const s =
     process.env.VFORGE_MASTER_PEPPER ||
@@ -28,11 +45,19 @@ function llave(): Buffer {
 
 const b64u = (b: Buffer) => b.toString("base64url");
 
-/** Crea un state firmado que carga el userId. */
-export function firmarState(userId: string): string {
+/** Crea un state firmado que carga el userId y su destino interno permitido. */
+export function firmarState(
+  userId: string,
+  returnPath: OAuthReturnPath = "/app/integrations",
+): string {
   const cuerpo = b64u(
     Buffer.from(
-      JSON.stringify({ u: userId, n: randomBytes(8).toString("hex"), t: Date.now() }),
+      JSON.stringify({
+        u: userId,
+        n: randomBytes(8).toString("hex"),
+        t: Date.now(),
+        r: returnPath,
+      }),
       "utf8",
     ),
   );
@@ -44,7 +69,9 @@ export function firmarState(userId: string): string {
  * Verifica el state y devuelve el userId. `null` si viene manipulado,
  * caducado o con otro formato (p.ej. states viejos sin firma).
  */
-export function leerState(state: string | null | undefined): string | null {
+export function leerStateCompleto(
+  state: string | null | undefined,
+): { userId: string; returnPath: OAuthReturnPath } | null {
   if (!state || !state.includes(".")) return null;
   const [cuerpo, firma] = state.split(".");
   if (!cuerpo || !firma) return null;
@@ -56,8 +83,16 @@ export function leerState(state: string | null | undefined): string | null {
     const d = JSON.parse(Buffer.from(cuerpo, "base64url").toString("utf8"));
     if (!d?.u || typeof d.t !== "number") return null;
     if (Date.now() - d.t > VENTANA_MS) return null;
-    return String(d.u);
+    return {
+      userId: String(d.u),
+      returnPath: normalizarOAuthReturnPath(d.r),
+    };
   } catch {
     return null;
   }
+}
+
+/** Compatibilidad con consumidores que sólo necesitan el userId. */
+export function leerState(state: string | null | undefined): string | null {
+  return leerStateCompleto(state)?.userId ?? null;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -27,6 +27,7 @@ const isMcpRoute = createRouteMatcher(["/api/mcp", "/api/mcp/(.*)", "/api/mcp/pu
 // por proyecto y rol vive en la página (/app/live) y en /api/live/*, que
 // resuelven la membresía con fail-closed. Aquí solo exigimos sesión.
 const isLivePortal = createRouteMatcher(["/app/live(.*)", "/api/live(.*)"]);
+const isWorkspaceInvite = createRouteMatcher(["/workspace/join(.*)"]);
 
 /**
  * Valida el operator token del header Authorization en el edge. Comparación de
@@ -191,10 +192,10 @@ export default hasClerk
         return;
       }
 
-      // Tipo 2 — Cliente intentando entrar a una ruta exclusiva del owner
-      // (/app, /forge, /v): se le redirige a su propio workspace.
-      if (isOwnerOnly(req)) {
-        return NextResponse.redirect(new URL("/workspace", req.url));
+      // Una invitación debe poder aceptarse antes del onboarding. El acceso
+      // real al proyecto sigue verificándose dentro de la ruta de invitación.
+      if (isWorkspaceInvite(req)) {
+        return;
       }
 
       // Tipo 2 — Cliente en su propio espacio: gate de onboarding.
@@ -206,10 +207,17 @@ export default hasClerk
           | undefined
       )?.onboardingComplete;
       const onboarded = await resolveOnboardingComplete(userId, claimOnboard);
-      if (!onboarded && !onOnboarding && !req.nextUrl.pathname.startsWith("/workspace")) {
+      if (!onboarded && !onOnboarding) {
         return NextResponse.redirect(new URL("/onboarding", req.url));
       }
       if (onboarded && onOnboarding) {
+        return NextResponse.redirect(new URL("/workspace", req.url));
+      }
+
+      // Tipo 2 — Cliente intentando entrar a una ruta exclusiva del owner
+      // (/app, /forge, /v): se le redirige a su propio workspace, pero sólo
+      // después de completar su onboarding.
+      if (isOwnerOnly(req)) {
         return NextResponse.redirect(new URL("/workspace", req.url));
       }
     }, { signInUrl: "/sign-in", signUpUrl: "/sign-up" })


### PR DESCRIPTION
## Qué cambia
- obliga a cuentas nuevas a completar onboarding antes de entrar al workspace
- devuelve GitHub y Vercel a onboarding/workspace según el origen
- permite conectar cuentas propias sin invitaciones ni proyectos compartidos
- mantiene separados los proyectos recibidos por membresía
- conserva las rutas de invitación y el visor en vivo

## Validación local
- `npm run typecheck` ✅
- `npm run lint` ✅ (solo advertencias preexistentes)
- `npm run build` ✅
- `npm test` ⚠️ 23 pasan / 7 fallan en pruebas históricas de viewport no modificadas por este PR