### PR TITLE
fix: aclarar conexión o creación de cuentas personales

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -110,14 +110,14 @@ function OnboardingWithClerk() {
     {
       id: "github",
       title: "GitHub",
-      body: "Repositorios y cambios que alimentan el proyecto.",
+      body: "Conecta tu cuenta o crea una nueva. Quedará vinculada sólo a tu usuario.",
       href: "/api/auth/github/start?return_to=%2Fonboarding",
       icon: IconGithub,
     },
     {
       id: "vercel",
       title: "Vercel",
-      body: "Previews y URLs que se muestran dentro del visor.",
+      body: "Conecta tu cuenta o crea una nueva. Quedará vinculada sólo a tu usuario.",
       href: "/api/auth/vercel/start?return_to=%2Fonboarding",
       icon: IconRocket,
     },
@@ -178,8 +178,11 @@ function OnboardingWithClerk() {
                       <IconCheck size={12} /> Conectado
                     </span>
                   ) : (
-                    <a href={href} className="btn-ghost !min-h-9 !px-3">
-                      Conectar
+                    <a
+                      href={href}
+                      className="btn-ghost !min-h-10 !px-3 text-center !leading-4"
+                    >
+                      Conectar o crear cuenta
                     </a>
                   )}
                 </div>

--- a/components/workspace/ScopedWorkspaceHome.tsx
+++ b/components/workspace/ScopedWorkspaceHome.tsx
@@ -103,8 +103,8 @@ export function ScopedWorkspaceHome({
               </h2>
             </div>
             <p className="hidden max-w-sm text-right text-[12px] leading-5 text-[var(--fg-secondary)] sm:block">
-              Si todavía no tienes cuenta, puedes crearla al continuar con cada
-              proveedor.
+              Entra con tu cuenta o crea una nueva. La conexión queda sólo en tu
+              usuario.
             </p>
           </div>
           <div className="grid md:grid-cols-2">
@@ -137,8 +137,11 @@ export function ScopedWorkspaceHome({
                     {connected ? (
                       <span className="text-[11px] font-medium">Listo</span>
                     ) : (
-                      <a href={href} className="btn-ghost !min-h-9 !px-3">
-                        Conectar <IconArrowR size={12} />
+                      <a
+                        href={href}
+                        className="btn-ghost !min-h-10 !px-3 text-center !leading-4"
+                      >
+                        Conectar o crear cuenta <IconArrowR size={12} />
                       </a>
                     )}
                   </div>


### PR DESCRIPTION
Reemplaza al borrador #137 por limitación del conector.

- CTA visible: “Conectar o crear cuenta”
- aclara que la conexión pertenece sólo al usuario actual
- Supervisor --full: APROBADO
- TypeScript: OK
- Vercel preview: READY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and button styling only; no auth, API, or data-handling logic changes.
> 
> **Overview**
> **Onboarding** and **workspace home** connection cards now tell users they can sign in with an existing GitHub or Vercel account or create one during the OAuth flow, and that the link applies **only to their user**—not shared org-wide.
> 
> Visible CTAs change from “Conectar” to **“Conectar o crear cuenta”**, with slightly taller ghost buttons (`min-h-10`, centered line height) so the longer label fits. Onboarding card descriptions replace repo/preview blurbs with the same personal-account message; the workspace connections section header copy is aligned to that wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6917051a4be114acfd756c81869f72bfddf8074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->