### PR TITLE
fix: mantener VForge al crear cuentas externas

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -105,20 +105,23 @@ function OnboardingWithClerk() {
     title: string;
     body: string;
     href: string;
+    signupHref: string;
     icon: typeof IconGithub;
   }[] = [
     {
       id: "github",
       title: "GitHub",
-      body: "Conecta tu cuenta o crea una nueva. Quedará vinculada sólo a tu usuario.",
+      body: "¿No tienes cuenta? Créala en otra pestaña, vuelve aquí y conecta.",
       href: "/api/auth/github/start?return_to=%2Fonboarding",
+      signupHref: "https://github.com/signup",
       icon: IconGithub,
     },
     {
       id: "vercel",
       title: "Vercel",
-      body: "Conecta tu cuenta o crea una nueva. Quedará vinculada sólo a tu usuario.",
+      body: "¿No tienes cuenta? Créala en otra pestaña, vuelve aquí y conecta.",
       href: "/api/auth/vercel/start?return_to=%2Fonboarding",
+      signupHref: "https://vercel.com/signup",
       icon: IconRocket,
     },
   ];
@@ -157,12 +160,12 @@ function OnboardingWithClerk() {
               </p>
             </div>
 
-            {items.map(({ id, title, body, href, icon: Icon }) => {
+            {items.map(({ id, title, body, href, signupHref, icon: Icon }) => {
               const isConnected = connected.includes(id);
               return (
                 <div
                   key={id}
-                  className="flex items-center gap-4 border-b border-[var(--border-1)] px-5 py-5 last:border-b-0"
+                  className="flex flex-col gap-4 border-b border-[var(--border-1)] px-5 py-5 last:border-b-0 sm:flex-row sm:items-center"
                 >
                   <div className="grid h-10 w-10 shrink-0 place-items-center border border-black">
                     <Icon size={17} />
@@ -178,12 +181,22 @@ function OnboardingWithClerk() {
                       <IconCheck size={12} /> Conectado
                     </span>
                   ) : (
-                    <a
-                      href={href}
-                      className="btn-ghost !min-h-10 !px-3 text-center !leading-4"
-                    >
-                      Conectar o crear cuenta
-                    </a>
+                    <div className="flex w-full gap-2 sm:w-auto">
+                      <a
+                        href={href}
+                        className="btn-primary flex-1 !min-h-10 !px-3 text-center !leading-4 sm:flex-none"
+                      >
+                        Conectar
+                      </a>
+                      <a
+                        href={signupHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn-ghost flex-1 !min-h-10 !px-3 text-center !leading-4 sm:flex-none"
+                      >
+                        Crear cuenta
+                      </a>
+                    </div>
                   )}
                 </div>
               );

--- a/components/workspace/ScopedWorkspaceHome.tsx
+++ b/components/workspace/ScopedWorkspaceHome.tsx
@@ -43,6 +43,7 @@ export function ScopedWorkspaceHome({
       body: "Tu código, repositorios y cambios.",
       connected: githubConnected,
       href: "/api/auth/github/start?return_to=%2Fworkspace",
+      signupHref: "https://github.com/signup",
       icon: IconGithub,
     },
     {
@@ -51,6 +52,7 @@ export function ScopedWorkspaceHome({
       body: "Tus deployments, previews y dominios.",
       connected: vercelConnected,
       href: "/api/auth/vercel/start?return_to=%2Fworkspace",
+      signupHref: "https://vercel.com/signup",
       icon: IconRocket,
     },
   ];
@@ -103,13 +105,13 @@ export function ScopedWorkspaceHome({
               </h2>
             </div>
             <p className="hidden max-w-sm text-right text-[12px] leading-5 text-[var(--fg-secondary)] sm:block">
-              Entra con tu cuenta o crea una nueva. La conexión queda sólo en tu
-              usuario.
+              Si necesitas una cuenta, créala en otra pestaña. Luego vuelve y
+              conecta sólo para tu usuario.
             </p>
           </div>
           <div className="grid md:grid-cols-2">
             {connectionItems.map(
-              ({ id, title, body, connected, href, icon: Icon }) => (
+              ({ id, title, body, connected, href, signupHref, icon: Icon }) => (
                 <article
                   key={id}
                   className="flex min-h-[170px] flex-col border-b border-x border-[var(--border-1)] bg-[var(--color-surface)] p-5 sm:p-6 md:first:border-r-0"
@@ -130,19 +132,29 @@ export function ScopedWorkspaceHome({
                   <h3 className="mt-5 text-[21px] font-medium tracking-[-0.04em]">
                     {title}
                   </h3>
-                  <div className="mt-auto flex items-end justify-between gap-4 pt-3">
+                  <div className="mt-auto flex flex-col items-start justify-between gap-4 pt-3 sm:flex-row sm:items-end">
                     <p className="text-[12px] leading-5 text-[var(--fg-secondary)]">
                       {body}
                     </p>
                     {connected ? (
                       <span className="text-[11px] font-medium">Listo</span>
                     ) : (
-                      <a
-                        href={href}
-                        className="btn-ghost !min-h-10 !px-3 text-center !leading-4"
-                      >
-                        Conectar o crear cuenta <IconArrowR size={12} />
-                      </a>
+                      <div className="flex w-full gap-2 sm:w-auto">
+                        <a
+                          href={href}
+                          className="btn-primary flex-1 !min-h-10 !px-3 text-center !leading-4 sm:flex-none"
+                        >
+                          Conectar <IconArrowR size={12} />
+                        </a>
+                        <a
+                          href={signupHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn-ghost flex-1 !min-h-10 !px-3 text-center !leading-4 sm:flex-none"
+                        >
+                          Crear cuenta
+                        </a>
+                      </div>
                     )}
                   </div>
                 </article>


### PR DESCRIPTION
Separa Conectar de Crear cuenta en onboarding y workspace. El registro externo abre en otra pestaña para preservar el callback OAuth. Validado con ESLint, typecheck, build Node 20, preview READY y supervisor completo APROBADO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to links, copy, and layout; OAuth endpoints and connection logic are unchanged.
> 
> **Overview**
> **Onboarding** and **workspace** GitHub/Vercel rows no longer use a single “Conectar o crear cuenta” action. Users get **Conectar** (same OAuth start URLs as before) and **Crear cuenta** (GitHub/Vercel signup in a **new tab**) so VForge stays open and the OAuth `return_to` callback is not lost.
> 
> Copy now tells users to create an account in another tab and return to connect. Layout stacks the two buttons on small screens and uses primary styling for connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c462029cf53efdc32891e5f686e38fdb5046f176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->