### PR TITLE
fix: permitir cerrar sesión desde onboarding

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -3,7 +3,7 @@
 export const dynamic = "force-dynamic";
 
 import { useCallback, useEffect, useState } from "react";
-import { useUser } from "@clerk/nextjs";
+import { useClerk, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { VWordmark } from "@/components/brand/VMark";
 import { hasClerkPublishableKey } from "@/lib/auth/clerk-key";
@@ -36,10 +36,12 @@ export default function OnboardingPage() {
 
 function OnboardingWithClerk() {
   const { isLoaded, isSignedIn, user } = useUser();
+  const { signOut } = useClerk();
   const router = useRouter();
   const [connected, setConnected] = useState<Connection[]>([]);
   const [loadingStatus, setLoadingStatus] = useState(true);
   const [finishing, setFinishing] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
   const [finishError, setFinishError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -65,6 +67,18 @@ function OnboardingWithClerk() {
   useEffect(() => {
     if (isSignedIn) void loadStatus();
   }, [isSignedIn, loadStatus]);
+
+  async function leaveAccount() {
+    if (signingOut) return;
+    setSigningOut(true);
+    setFinishError(null);
+    try {
+      await signOut({ redirectUrl: "/sign-in" });
+    } catch {
+      setFinishError("No pudimos cerrar tu sesión. Intenta otra vez.");
+      setSigningOut(false);
+    }
+  }
 
   async function enterWorkspace() {
     if (finishing) return;
@@ -131,14 +145,24 @@ function OnboardingWithClerk() {
       <div className="mx-auto max-w-[980px]">
         <header className="flex items-center justify-between border-b border-[var(--border-1)] pb-6">
           <VWordmark />
-          <button
-            type="button"
-            onClick={enterWorkspace}
-            disabled={finishing}
-            className="text-[12px] font-medium text-[var(--fg-muted)] hover:text-black disabled:opacity-50"
-          >
-            Entrar sin conectar
-          </button>
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={leaveAccount}
+              disabled={signingOut || finishing}
+              className="text-[12px] font-medium text-[var(--fg-muted)] hover:text-black disabled:opacity-50"
+            >
+              {signingOut ? "Saliendo..." : "Cerrar sesión"}
+            </button>
+            <button
+              type="button"
+              onClick={enterWorkspace}
+              disabled={finishing || signingOut}
+              className="text-[12px] font-medium text-[var(--fg-muted)] hover:text-black disabled:opacity-50"
+            >
+              Entrar sin conectar
+            </button>
+          </div>
         </header>
 
         <section className="grid gap-12 py-14 lg:grid-cols-[0.9fr_1.1fr] lg:items-start lg:py-24">


### PR DESCRIPTION
Agrega cierre de sesión real con Clerk y redirección a `/sign-in`.

Validación:
- TypeScript ✅
- ESLint ✅
- Supervisor `--full` con Node 20 ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized onboarding UI using Clerk’s standard sign-out; no changes to onboarding completion APIs or session validation elsewhere.
> 
> **Overview**
> Users stuck on onboarding can **sign out** without finishing setup. The header now shows **Cerrar sesión** next to **Entrar sin conectar**, wired to Clerk’s `signOut` with redirect to `/sign-in`.
> 
> The new `leaveAccount` flow tracks a `signingOut` state (label **Saliendo...**), clears shared `finishError` on attempt, and surfaces a Spanish error if sign-out fails. Both header actions disable each other while sign-out or “enter workspace” is in progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f564bde9a656e82a6bb23d478e395660447090ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->