### PR TITLE
fix(auth): new-user GitHub OAuth + tenant isolation

### DIFF
--- a/app/api/auth/github/callback/route.ts
+++ b/app/api/auth/github/callback/route.ts
@@ -1,30 +1,37 @@
 import { auth } from "@clerk/nextjs/server";
 import { cookies } from "next/headers";
 import { saveUserSecret } from "@/lib/connect/user-vault";
-import { normalizarOAuthReturnPath } from "@/lib/connect/oauth-state";
+import {
+  leerStateCompleto,
+  normalizarOAuthReturnPath,
+  resolverOAuthCallbackIdentity,
+} from "@/lib/connect/oauth-state";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
  * GET /api/auth/github/callback — intercambia code→token, guarda en vault,
- * redirige a /app/setup (stepper) o al puente si aplica.
+ * redirige al return_to permitido o al puente si aplica.
+ *
+ * El userId va firmado en `state` (igual que Vercel). Si la sesión de Clerk
+ * no viaja de vuelta desde github.com, el token igual se guarda al usuario
+ * que inició el flujo — no se tira el code a /sign-in.
  */
 export async function GET(req: Request) {
-  const { userId } = await auth();
   const site = process.env.NEXT_PUBLIC_SITE_URL || "https://vforge.site";
-  if (!userId) return Response.redirect(new URL("/sign-in", site), 302);
-
   const url = new URL(req.url);
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
+  const stateData = leerStateCompleto(state);
+
   const jar = await cookies();
   const expected = jar.get("gh_oauth_state")?.value;
   const bridgeReturnTo = jar.get("gh_bridge_return_to")?.value;
   const bridgeTenant = jar.get("gh_bridge_tenant")?.value;
-  const internalReturnPath = normalizarOAuthReturnPath(
-    jar.get("gh_oauth_return_path")?.value,
-  );
+  const internalReturnPath =
+    stateData?.returnPath ??
+    normalizarOAuthReturnPath(jar.get("gh_oauth_return_path")?.value);
   jar.delete("gh_oauth_state");
   jar.delete("gh_bridge_return_to");
   jar.delete("gh_bridge_tenant");
@@ -41,8 +48,27 @@ export async function GET(req: Request) {
     return Response.redirect(destination, 302);
   };
 
+  let sessionUserId: string | null = null;
+  try {
+    sessionUserId = (await auth()).userId ?? null;
+  } catch {
+    sessionUserId = null;
+  }
+  const identity = resolverOAuthCallbackIdentity(
+    sessionUserId,
+    stateData?.userId,
+  );
+  if (identity.mismatch) return back("error_state");
+  const userId = identity.userId;
+
   if (!code) return back("error_no_code");
-  if (!state || !expected || state !== expected) return back("error_state");
+  // Cookie presente y distinta → CSRF. State firmado válido basta si la
+  // cookie no viajó. States viejos (hex sin firma) siguen exigiendo cookie.
+  if (expected && state && expected !== state) return back("error_state");
+  if (!stateData && (!state || !expected || state !== expected)) {
+    return back("error_state");
+  }
+  if (!userId) return back("error_sin_sesion");
 
   const clientId = process.env.GITHUB_APP_CLIENT_ID || "";
   const clientSecret = process.env.GITHUB_APP_CLIENT_SECRET;

--- a/app/api/auth/github/start/route.ts
+++ b/app/api/auth/github/start/route.ts
@@ -1,7 +1,9 @@
 import { auth } from "@clerk/nextjs/server";
-import { randomBytes } from "node:crypto";
 import { cookies } from "next/headers";
-import { normalizarOAuthReturnPath } from "@/lib/connect/oauth-state";
+import {
+  firmarState,
+  normalizarOAuthReturnPath,
+} from "@/lib/connect/oauth-state";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -50,7 +52,9 @@ export async function GET(req: Request) {
   );
   const tenant = reqUrl.searchParams.get("tenant");
 
-  const state = randomBytes(16).toString("hex");
+  // State firmado con userId: el callback no depende de que la cookie de
+  // Clerk sobreviva el salto a github.com (el mismo fallo que tuvo Vercel).
+  const state = firmarState(userId, internalReturnTo);
   const jar = await cookies();
   jar.delete("gh_bridge_return_to");
   jar.delete("gh_bridge_tenant");

--- a/app/api/auth/vercel/callback/route.ts
+++ b/app/api/auth/vercel/callback/route.ts
@@ -1,7 +1,10 @@
 import { auth } from "@clerk/nextjs/server";
 import { cookies } from "next/headers";
 import { saveUserSecret } from "@/lib/connect/user-vault";
-import { leerStateCompleto } from "@/lib/connect/oauth-state";
+import {
+  leerStateCompleto,
+  resolverOAuthCallbackIdentity,
+} from "@/lib/connect/oauth-state";
 import { registrarIntento } from "@/lib/connect/attempt-log";
 
 export const runtime = "nodejs";
@@ -34,21 +37,26 @@ export async function GET(req: Request) {
   };
 
   // 1) Sesion de Clerk si existe; 2) si no, el userId firmado en el state.
-  let userId: string | null = null;
+  let sessionUserId: string | null = null;
   try {
-    userId = (await auth()).userId ?? null;
+    sessionUserId = (await auth()).userId ?? null;
   } catch {
-    userId = null;
+    sessionUserId = null;
   }
-  const desdeState = stateData?.userId ?? null;
-  if (!userId) userId = desdeState;
-
-  // Si hay sesion Y state, deben coincidir: evita que alguien pegue su code
-  // en la sesion de otro.
-  if (userId && desdeState && userId !== desdeState) {
-    await registrarIntento("vercel", "state_invalido", "sesion != state", userId);
+  const identity = resolverOAuthCallbackIdentity(
+    sessionUserId,
+    stateData?.userId,
+  );
+  if (identity.mismatch) {
+    await registrarIntento(
+      "vercel",
+      "state_invalido",
+      "sesion != state",
+      identity.userId,
+    );
     return back("error_state");
   }
+  const userId = identity.userId;
 
   const jar = await cookies();
   jar.delete("vc_oauth_state");

--- a/app/api/live/[projectId]/comments/[commentId]/accept/route.ts
+++ b/app/api/live/[projectId]/comments/[commentId]/accept/route.ts
@@ -14,6 +14,7 @@ import {
   insertTaskEvent,
 } from "@/lib/live/comment-tasks";
 import { resolveProjectViewportUrls } from "@/lib/projects/viewport-url";
+import { membershipBelongsToUserSql } from "@/lib/projects/membership-scope";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -39,10 +40,12 @@ export async function POST(
   if (!platformOwner) {
     const membership = await queryOne<{ role: string }>(
       `SELECT role FROM project_live_members
-        WHERE project_id = $1 AND lower(email) = lower($2) AND status = 'active'
+        WHERE project_id = $1
+          AND ${membershipBelongsToUserSql("project_live_members", "$2", "$3")}
+          AND status = 'active'
           AND (expires_at IS NULL OR expires_at > now())
         LIMIT 1`,
-      [projectId, identity.email],
+      [projectId, identity.userId, identity.email],
     ).catch(() => null);
     liveOwner = membership?.role === "owner";
   }

--- a/app/api/live/[projectId]/comments/[commentId]/resolve/route.ts
+++ b/app/api/live/[projectId]/comments/[commentId]/resolve/route.ts
@@ -4,6 +4,7 @@ import { getCurrentVForgeIdentity } from "@/lib/api/vforge-owned";
 import { isOwnerEmail } from "@/lib/auth/owner";
 import { queryOne } from "@/lib/db/client";
 import { insertSystemComment } from "@/lib/live/comment-tasks";
+import { membershipBelongsToUserSql } from "@/lib/projects/membership-scope";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,9 +22,11 @@ export async function POST(
   if (!platformOwner) {
     const m = await queryOne<{ role: string }>(
       `SELECT role FROM project_live_members
-        WHERE project_id = $1 AND lower(email) = lower($2) AND status = 'active'
+        WHERE project_id = $1
+          AND ${membershipBelongsToUserSql("project_live_members", "$2", "$3")}
+          AND status = 'active'
         LIMIT 1`,
-      [projectId, identity.email],
+      [projectId, identity.userId, identity.email],
     ).catch(() => null);
     if (m?.role !== "owner" && m?.role !== "reviewer") {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });

--- a/app/api/live/[projectId]/tasks/[taskId]/route.ts
+++ b/app/api/live/[projectId]/tasks/[taskId]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCurrentVForgeIdentity } from "@/lib/api/vforge-owned";
 import { isOwnerEmail } from "@/lib/auth/owner";
 import { queryOne } from "@/lib/db/client";
+import { membershipBelongsToUserSql } from "@/lib/projects/membership-scope";
 import {
   ensureCommentTasksTable,
   insertSystemComment,
@@ -13,13 +14,15 @@ export const dynamic = "force-dynamic";
 
 const ALLOWED = new Set(["queued", "running", "done", "cancelled", "failed"]);
 
-async function assertOwner(projectId: string, email: string) {
+async function assertOwner(projectId: string, userId: string, email: string) {
   if (isOwnerEmail(email)) return true;
   const m = await queryOne<{ role: string }>(
     `SELECT role FROM project_live_members
-      WHERE project_id = $1 AND lower(email) = lower($2) AND status = 'active'
+      WHERE project_id = $1
+        AND ${membershipBelongsToUserSql("project_live_members", "$2", "$3")}
+        AND status = 'active'
       LIMIT 1`,
-    [projectId, email],
+    [projectId, userId, email],
   ).catch(() => null);
   return m?.role === "owner";
 }
@@ -33,7 +36,7 @@ export async function PATCH(
   if (!identity) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
-  if (!(await assertOwner(projectId, identity.email))) {
+  if (!(await assertOwner(projectId, identity.userId, identity.email))) {
     return NextResponse.json({ error: "forbidden" }, { status: 403 });
   }
 

--- a/app/api/live/[projectId]/tasks/route.ts
+++ b/app/api/live/[projectId]/tasks/route.ts
@@ -4,6 +4,7 @@ import { getCurrentVForgeIdentity } from "@/lib/api/vforge-owned";
 import { isOwnerEmail } from "@/lib/auth/owner";
 import { queryAll, queryOne } from "@/lib/db/client";
 import { ensureCommentTasksTable } from "@/lib/live/comment-tasks";
+import { membershipBelongsToUserSql } from "@/lib/projects/membership-scope";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,9 +22,11 @@ export async function GET(
   if (!platformOwner) {
     const m = await queryOne<{ role: string }>(
       `SELECT role FROM project_live_members
-        WHERE project_id = $1 AND lower(email) = lower($2) AND status = 'active'
+        WHERE project_id = $1
+          AND ${membershipBelongsToUserSql("project_live_members", "$2", "$3")}
+          AND status = 'active'
         LIMIT 1`,
-      [projectId, identity.email],
+      [projectId, identity.userId, identity.email],
     ).catch(() => null);
     if (m?.role !== "owner" && m?.role !== "reviewer") {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });

--- a/app/api/my-project/route.ts
+++ b/app/api/my-project/route.ts
@@ -15,14 +15,14 @@ export async function GET() {
   const user = await currentUser();
   const email = user?.emailAddresses?.[0]?.emailAddress;
 
-  if (!email) {
+  if (!user?.id || !email) {
     return NextResponse.json(
       { error: "unauthorized" },
       { status: 401, headers: { "Cache-Control": "no-store" } },
     );
   }
 
-  const rows = await listScopedProjects(email);
+  const rows = await listScopedProjects({ clerkUserId: user.id, email });
 
   return NextResponse.json(
     { projects: rows },

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -7,6 +7,7 @@ import { useClerk, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { VWordmark } from "@/components/brand/VMark";
 import { hasClerkPublishableKey } from "@/lib/auth/clerk-key";
+import { oauthCallbackMessage } from "@/lib/connect/connection-scopes";
 import {
   IconArrowR,
   IconCheck,
@@ -43,6 +44,7 @@ function OnboardingWithClerk() {
   const [finishing, setFinishing] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
   const [finishError, setFinishError] = useState<string | null>(null);
+  const [oauthError, setOauthError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isLoaded && !isSignedIn) router.replace("/sign-in");
@@ -65,7 +67,22 @@ function OnboardingWithClerk() {
   }, []);
 
   useEffect(() => {
-    if (isSignedIn) void loadStatus();
+    if (!isSignedIn) return;
+    void loadStatus();
+    const params = new URLSearchParams(window.location.search);
+    setOauthError(
+      oauthCallbackMessage("GitHub", params.get("github")) ??
+        oauthCallbackMessage("Vercel", params.get("vercel")),
+    );
+  }, [isSignedIn, loadStatus]);
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    const onPageShow = () => {
+      void loadStatus();
+    };
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
   }, [isSignedIn, loadStatus]);
 
   async function leaveAccount() {
@@ -241,9 +258,9 @@ function OnboardingWithClerk() {
                   </>
                 )}
               </button>
-              {finishError ? (
+              {oauthError || finishError ? (
                 <p role="alert" className="mt-3 text-[12px] leading-5 text-black">
-                  {finishError}
+                  {oauthError ?? finishError}
                 </p>
               ) : null}
             </div>

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -18,9 +18,9 @@ export default async function WorkspacePage() {
 
   const name = user.firstName || user.username || "";
   const [projects, connections] = await Promise.all([
-    listScopedProjects(email).catch((error: unknown) => {
+    listScopedProjects({ clerkUserId: user.id, email }).catch((error: unknown) => {
       console.error("[workspace] scoped catalog failed", {
-        email,
+        userId: user.id,
         message: error instanceof Error ? error.message : String(error),
       });
       return [];

--- a/lib/connect/connection-scopes.ts
+++ b/lib/connect/connection-scopes.ts
@@ -1,0 +1,31 @@
+/**
+ * Scopes persistidos en user_secrets. El OAuth propio guarda "github" /
+ * "vercel"; el espejo de Clerk guarda "github-clerk" / "vercel-clerk".
+ * La UI de onboarding/workspace solo entiende los nombres canónicos.
+ */
+export function normalizeConnectionScopes(scopes: string[]): string[] {
+  const out = new Set<string>();
+  for (const raw of scopes) {
+    if (raw === "github" || raw === "github-clerk") out.add("github");
+    else if (raw === "vercel" || raw === "vercel-clerk") out.add("vercel");
+    else if (raw) out.add(raw);
+  }
+  return [...out];
+}
+
+export function oauthCallbackMessage(
+  provider: "GitHub" | "Vercel",
+  status: string | null,
+): string | null {
+  if (!status || status === "connected") return null;
+  if (status === "error_state" || status === "error_sin_sesion") {
+    return `No pudimos confirmar tu cuenta de ${provider}. Vuelve a conectar.`;
+  }
+  if (status === "error_no_code" || status === "error_token" || status === "error_exchange") {
+    return `${provider} no devolvió una conexión válida. Vuelve a intentar.`;
+  }
+  if (status.startsWith("err:") || status.startsWith("error_")) {
+    return `No se pudo conectar ${provider}. Vuelve a intentar.`;
+  }
+  return `No se pudo conectar ${provider}. Vuelve a intentar.`;
+}

--- a/lib/connect/oauth-state.ts
+++ b/lib/connect/oauth-state.ts
@@ -96,3 +96,20 @@ export function leerStateCompleto(
 export function leerState(state: string | null | undefined): string | null {
   return leerStateCompleto(state)?.userId ?? null;
 }
+
+/**
+ * Une la sesión de Clerk (si viajó) con el userId firmado en `state`.
+ * Si ambos existen y no coinciden, es un intento de pegar el code en otra
+ * sesión: se rechaza. Si la cookie de Clerk se perdió, el state basta.
+ */
+export function resolverOAuthCallbackIdentity(
+  sessionUserId: string | null | undefined,
+  stateUserId: string | null | undefined,
+): { userId: string | null; mismatch: boolean } {
+  const session = sessionUserId?.trim() || null;
+  const fromState = stateUserId?.trim() || null;
+  if (session && fromState && session !== fromState) {
+    return { userId: session, mismatch: true };
+  }
+  return { userId: session ?? fromState, mismatch: false };
+}

--- a/lib/connect/user-vault.ts
+++ b/lib/connect/user-vault.ts
@@ -1,6 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { encryptOperatorSecret } from "@/lib/vault/operator-crypto";
 import { decryptOperatorSecret } from "@/lib/vault/operator-crypto";
+import { normalizeConnectionScopes } from "@/lib/connect/connection-scopes";
 
 const getDb = () => {
   const url = process.env.DATABASE_URL;
@@ -90,7 +91,7 @@ export async function listUserConnections(userId: string): Promise<string[]> {
     SELECT DISTINCT scope FROM user_secrets
     WHERE user_id = ${userId} AND scope IS NOT NULL
   `) as Array<{ scope: string }>;
-  return rows.map((r) => r.scope).filter(Boolean);
+  return normalizeConnectionScopes(rows.map((r) => r.scope).filter(Boolean));
 }
 
 /**

--- a/lib/projects/access.ts
+++ b/lib/projects/access.ts
@@ -14,6 +14,10 @@ import {
   resolveMembership,
   roleAtLeast,
 } from "@/lib/projects/roles";
+import {
+  membershipBelongsToUserSql,
+  normalizeScopedIdentity,
+} from "@/lib/projects/membership-scope";
 
 export interface LiveAccess {
   projectId: string;
@@ -49,11 +53,11 @@ export async function resolveLiveAccessForIdentity(
   identity: LiveIdentity,
 ): Promise<LiveAccess | null> {
   const cleanProjectId = projectId?.trim();
-  const userId = identity.userId?.trim();
-  const email = identity.email?.trim().toLowerCase();
+  const scoped = normalizeScopedIdentity(identity.userId, identity.email);
+  if (!cleanProjectId || !scoped) return null;
+  const userId = scoped.clerkUserId;
+  const email = scoped.email;
   const name = identity.name?.trim().slice(0, 160) || email;
-
-  if (!cleanProjectId || !userId || !email || email.length > 320) return null;
 
   if (isOwnerEmail(email)) {
     return {
@@ -71,9 +75,10 @@ export async function resolveLiveAccessForIdentity(
     row = await queryOne<MembershipRow>(
       `SELECT role, status, expires_at
          FROM project_live_members
-        WHERE project_id = $1 AND lower(email) = lower($2)
+        WHERE project_id = $1
+          AND ${membershipBelongsToUserSql("project_live_members", "$2", "$3")}
         LIMIT 1`,
-      [cleanProjectId, email],
+      [cleanProjectId, userId, email],
     );
   } catch {
     return null;

--- a/lib/projects/membership-scope.ts
+++ b/lib/projects/membership-scope.ts
@@ -1,0 +1,33 @@
+/**
+ * Identidad fail-closed para consultas de membresía.
+ * Sin Clerk user id no se consulta nada — nunca se cae al catálogo global.
+ */
+export interface ScopedIdentity {
+  clerkUserId: string;
+  email: string;
+}
+
+export function normalizeScopedIdentity(
+  clerkUserId: string | null | undefined,
+  email: string | null | undefined,
+): ScopedIdentity | null {
+  const id = clerkUserId?.trim() ?? "";
+  const mail = email?.trim().toLowerCase() ?? "";
+  if (!id) return null;
+  if (!mail || mail.length > 320) return null;
+  return { clerkUserId: id, email: mail };
+}
+
+/**
+ * Predicado SQL: la fila pertenece a ESTE usuario.
+ * clerk_user_id gana. El email solo cubre filas legacy aún sin Clerk id.
+ * Nunca es un fallback a "todas las filas".
+ */
+export function membershipBelongsToUserSql(
+  tableAlias: string,
+  clerkUserIdParam: string,
+  emailParam: string,
+): string {
+  const col = (name: string) => `${tableAlias}.${name}`;
+  return `(${col("clerk_user_id")} = ${clerkUserIdParam} OR ((${col("clerk_user_id")} IS NULL OR ${col("clerk_user_id")} = '') AND lower(${col("email")}) = ${emailParam}))`;
+}

--- a/lib/projects/membership.ts
+++ b/lib/projects/membership.ts
@@ -5,6 +5,10 @@
 import { currentUser } from "@clerk/nextjs/server";
 import { queryOne } from "@/lib/db/client";
 import { isOwnerEmail } from "@/lib/auth/owner";
+import {
+  membershipBelongsToUserSql,
+  normalizeScopedIdentity,
+} from "@/lib/projects/membership-scope";
 
 export interface MemberContext {
   email: string;
@@ -17,31 +21,32 @@ export async function requireMember(
 ): Promise<MemberContext | null> {
   const user = await currentUser();
   const email = user?.emailAddresses?.[0]?.emailAddress;
-  if (!email) return null;
+  const identity = normalizeScopedIdentity(user?.id, email);
+  if (!identity) return null;
 
   // OWNER BYPASS: Luis (owner de la plataforma) ve el baúl/PROPOSITO de
   // CUALQUIER proyecto sin necesidad de ser miembro registrado.
-  if (isOwnerEmail(email)) {
+  if (isOwnerEmail(identity.email)) {
     const ownerName =
       [user?.firstName, user?.lastName].filter(Boolean).join(" ").trim() ||
       user?.username ||
-      email;
-    return { email, name: ownerName, role: "owner" };
+      identity.email;
+    return { email: identity.email, name: ownerName, role: "owner" };
   }
 
   const member = await queryOne<{ role: string }>(
     `SELECT role FROM project_members
       WHERE project_id = $1
-        AND lower(email) = lower($2)
+        AND ${membershipBelongsToUserSql("project_members", "$2", "$3")}
         AND status = 'active'
       LIMIT 1`,
-    [projectId, email],
+    [projectId, identity.clerkUserId, identity.email],
   );
   if (!member) return null;
 
   const name =
     [user?.firstName, user?.lastName].filter(Boolean).join(" ").trim() ||
     user?.username ||
-    email;
-  return { email, name, role: member.role };
+    identity.email;
+  return { email: identity.email, name, role: member.role };
 }

--- a/lib/projects/scoped-catalog.ts
+++ b/lib/projects/scoped-catalog.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
 import { queryAll, queryOne } from "@/lib/db/client";
+import {
+  membershipBelongsToUserSql,
+  normalizeScopedIdentity,
+} from "@/lib/projects/membership-scope";
 
 export interface ScopedProject {
   id: string;
@@ -15,14 +19,17 @@ export interface ScopedProject {
 }
 
 /**
- * Catálogo fail-closed para clientes. Sólo reúne membresías activas ligadas al
- * correo actual; nunca consulta ni devuelve el catálogo global del owner.
- * Si existen las dos membresías históricas para el mismo proyecto, preferimos
- * la sala live nueva porque aplica los roles observer/reviewer por endpoint.
+ * Catálogo fail-closed para clientes. Sólo reúne membresías activas ligadas
+ * al Clerk user id (email legacy sólo si la fila aún no tiene clerk_user_id).
+ * Sin identidad o sin membresías → lista vacía. Nunca el catálogo del owner.
  */
-export async function listScopedProjects(email: string): Promise<ScopedProject[]> {
-  const normalized = email.trim().toLowerCase();
-  if (!normalized || normalized.length > 320) return [];
+export async function listScopedProjects(input: {
+  clerkUserId: string;
+  email: string;
+}): Promise<ScopedProject[]> {
+  const identity = normalizeScopedIdentity(input.clerkUserId, input.email);
+  if (!identity) return [];
+  const normalized = identity.email;
 
   const tables = await queryOne<{
     has_workspace_members: boolean;
@@ -42,7 +49,7 @@ export async function listScopedProjects(email: string): Promise<ScopedProject[]
               'workspace'::text AS access_kind,
               1 AS priority
          FROM project_members pm
-        WHERE lower(pm.email) = $1
+        WHERE ${membershipBelongsToUserSql("pm", "$1", "$2")}
           AND pm.status = 'active'`,
     );
   }
@@ -53,7 +60,7 @@ export async function listScopedProjects(email: string): Promise<ScopedProject[]
               'live'::text AS access_kind,
               2 AS priority
          FROM project_live_members plm
-        WHERE lower(plm.email) = $1
+        WHERE ${membershipBelongsToUserSql("plm", "$1", "$2")}
           AND plm.status = 'active'
           AND (plm.expires_at IS NULL OR plm.expires_at > now())`,
     );
@@ -81,6 +88,6 @@ export async function listScopedProjects(email: string): Promise<ScopedProject[]
        FROM scoped
        JOIN projects p ON p.id = scoped.project_id
       ORDER BY p.name ASC`,
-    [normalized],
+    [identity.clerkUserId, normalized],
   );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -36,6 +36,13 @@ const isWorkspaceInvite = createRouteMatcher(["/workspace/join(.*)"]);
  * si no, cae al control normal de Clerk. Nunca expone la ruta: hace falta token
  * válido O sesión válida.
  */
+/** Same-origin bounce that keeps OAuth result flags (?github= / ?vercel=). */
+function redirectKeepingSearch(path: string, req: Request): NextResponse {
+  const url = new URL(path, req.url);
+  url.search = new URL(req.url).search;
+  return NextResponse.redirect(url);
+}
+
 function hasValidOperatorToken(req: Request): boolean {
   const expected = process.env.VFORGE_OPERATOR_TOKEN?.trim();
   if (!expected) return false;
@@ -208,17 +215,17 @@ export default hasClerk
       )?.onboardingComplete;
       const onboarded = await resolveOnboardingComplete(userId, claimOnboard);
       if (!onboarded && !onOnboarding) {
-        return NextResponse.redirect(new URL("/onboarding", req.url));
+        return redirectKeepingSearch("/onboarding", req);
       }
       if (onboarded && onOnboarding) {
-        return NextResponse.redirect(new URL("/workspace", req.url));
+        return redirectKeepingSearch("/workspace", req);
       }
 
       // Tipo 2 — Cliente intentando entrar a una ruta exclusiva del owner
       // (/app, /forge, /v): se le redirige a su propio workspace, pero sólo
       // después de completar su onboarding.
       if (isOwnerOnly(req)) {
-        return NextResponse.redirect(new URL("/workspace", req.url));
+        return redirectKeepingSearch("/workspace", req);
       }
     }, { signInUrl: "/sign-in", signUpUrl: "/sign-up" })
   : () => NextResponse.next();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/oauth-state.test.js\" \".test-dist/tests/connection-scopes.test.js\" \".test-dist/tests/membership-scope.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/connection-scopes.test.ts
+++ b/tests/connection-scopes.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeConnectionScopes,
+  oauthCallbackMessage,
+} from "../lib/connect/connection-scopes";
+
+test("normalizeConnectionScopes maps Clerk mirrors to canonical names", () => {
+  assert.deepEqual(
+    normalizeConnectionScopes(["github-clerk", "vercel-clerk", "stripe"]).sort(),
+    ["github", "stripe", "vercel"],
+  );
+  assert.deepEqual(normalizeConnectionScopes(["github", "github-clerk"]), [
+    "github",
+  ]);
+});
+
+test("oauthCallbackMessage stays quiet on success and explains failures", () => {
+  assert.equal(oauthCallbackMessage("GitHub", "connected"), null);
+  assert.equal(oauthCallbackMessage("GitHub", null), null);
+  assert.match(oauthCallbackMessage("GitHub", "error_state") ?? "", /GitHub/);
+  assert.match(oauthCallbackMessage("Vercel", "error_no_code") ?? "", /Vercel/);
+});

--- a/tests/membership-scope.test.ts
+++ b/tests/membership-scope.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  membershipBelongsToUserSql,
+  normalizeScopedIdentity,
+} from "../lib/projects/membership-scope";
+
+test("normalizeScopedIdentity is fail-closed without a Clerk user id", () => {
+  assert.equal(normalizeScopedIdentity("", "a@b.com"), null);
+  assert.equal(normalizeScopedIdentity(null, "a@b.com"), null);
+  assert.equal(normalizeScopedIdentity("user_1", ""), null);
+  assert.deepEqual(normalizeScopedIdentity("user_1", "  A@B.com "), {
+    clerkUserId: "user_1",
+    email: "a@b.com",
+  });
+});
+
+test("membership predicate never matches all rows", () => {
+  const sql = membershipBelongsToUserSql("pm", "$1", "$2");
+  assert.match(sql, /pm\.clerk_user_id = \$1/);
+  assert.match(sql, /lower\(pm\.email\) = \$2/);
+  assert.doesNotMatch(sql, /1\s*=\s*1/);
+  assert.doesNotMatch(sql, /true/i);
+});

--- a/tests/oauth-state.test.ts
+++ b/tests/oauth-state.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  firmarState,
+  leerState,
+  leerStateCompleto,
+  normalizarOAuthReturnPath,
+  resolverOAuthCallbackIdentity,
+} from "../lib/connect/oauth-state";
+
+process.env.VFORGE_MASTER_PEPPER = "test-pepper-oauth-state";
+
+test("normalizarOAuthReturnPath only allows the onboarding allowlist", () => {
+  assert.equal(normalizarOAuthReturnPath("/onboarding"), "/onboarding");
+  assert.equal(normalizarOAuthReturnPath("/workspace"), "/workspace");
+  assert.equal(
+    normalizarOAuthReturnPath("/app/integrations"),
+    "/app/integrations",
+  );
+  assert.equal(
+    normalizarOAuthReturnPath("https://evil.example/phish"),
+    "/app/integrations",
+  );
+  assert.equal(normalizarOAuthReturnPath("/app/chat"), "/app/integrations");
+  assert.equal(normalizarOAuthReturnPath(null), "/app/integrations");
+});
+
+test("firmarState embeds userId and return path; leerState rejects tampering", () => {
+  const state = firmarState("user_abc", "/onboarding");
+  const parsed = leerStateCompleto(state);
+  assert.ok(parsed);
+  assert.equal(parsed?.userId, "user_abc");
+  assert.equal(parsed?.returnPath, "/onboarding");
+  assert.equal(leerState(state), "user_abc");
+
+  assert.equal(leerStateCompleto(null), null);
+  assert.equal(leerStateCompleto("not-signed"), null);
+  assert.equal(leerStateCompleto(`${state}x`), null);
+  const [cuerpo] = state.split(".");
+  assert.equal(leerStateCompleto(`${cuerpo}.AAAA`), null);
+});
+
+test("resolverOAuthCallbackIdentity prefers a matching session and rejects mismatches", () => {
+  assert.deepEqual(resolverOAuthCallbackIdentity(null, "user_a"), {
+    userId: "user_a",
+    mismatch: false,
+  });
+  assert.deepEqual(resolverOAuthCallbackIdentity("user_a", null), {
+    userId: "user_a",
+    mismatch: false,
+  });
+  assert.deepEqual(resolverOAuthCallbackIdentity("user_a", "user_a"), {
+    userId: "user_a",
+    mismatch: false,
+  });
+  assert.deepEqual(resolverOAuthCallbackIdentity("user_a", "user_b"), {
+    userId: "user_a",
+    mismatch: true,
+  });
+  assert.deepEqual(resolverOAuthCallbackIdentity(null, null), {
+    userId: null,
+    mismatch: false,
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -16,6 +16,9 @@
   "include": [
     "tests/**/*.ts",
     "lib/auth/owner.ts",
+    "lib/connect/oauth-state.ts",
+    "lib/connect/connection-scopes.ts",
+    "lib/projects/membership-scope.ts",
     "lib/projects/roles.ts",
     "lib/projects/invite-token.ts",
     "lib/projects/viewport-url.ts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

A brand-new Clerk user (not the platform owner) could complete GitHub OAuth and still land back in VForge **without a saved connection**.

GitHub start/callback used an unsigned random `state` and **required a live Clerk session on callback**. If the session cookie did not survive the hop to github.com, the handler redirected to `/sign-in` and dropped the authorization `code`. That is the same failure already fixed for Vercel (`firmarState` + userId inside `state`). Luis’s existing session made GitHub look “already working”; a new user hits the cookie-loss path.

Two follow-on bugs made the return look empty even when a token was saved:

1. Middleware bounces (`/app/*` → `/workspace`, `/onboarding` ↔ `/workspace`) dropped `?github=` / `?vercel=`.
2. Onboarding did not surface OAuth errors and treated `github-clerk` / `vercel-clerk` as “not connected”.

Membership catalog/gates filtered only by email. A new user with zero memberships already got an empty list (no “return all” fallback). Queries now key on the real Clerk user id; email is only used for legacy rows that still have a null `clerk_user_id`. Direct URLs to someone else’s project stay 403/404.

## Verified, not assumed

- **Logout is on production.** `vforge.site` production deployment `dpl_stC5jxfMk7XUJx4WMqWSNgWish96` is SHA `396b512` (PR #142). Onboarding already calls Clerk `signOut({ redirectUrl: "/sign-in" })`.
- **Vercel scopes were not changed.** Start still only redirects to `https://vercel.com/integrations/v-forge/new?state=…`. No Billing / Drains / Pro scopes in this repo. Community-integration warning is Vercel UI, not treated as the Install-disabled cause.
- **Install disabled:** no in-repo cause found. VForge has start + callback only. Install stays on Vercel’s page. Typical disable reasons (unselected team/project, stale config, wrong Vercel account) cannot be proven from this codebase without a live Vercel login. Did not create another integration.

## Files

**`fix(auth)`** `e22a8e0`
- `app/api/auth/github/start/route.ts` — signed state with Clerk userId + allowlisted `return_to`
- `app/api/auth/github/callback/route.ts` — bind token to signed userId; no `/sign-in` dump of the code
- `app/api/auth/vercel/callback/route.ts` — same identity helper (session vs state mismatch still rejected)
- `lib/connect/oauth-state.ts` — `resolverOAuthCallbackIdentity`

**`fix(onboarding)`** `b636cb5`
- `middleware.ts` — keep search on onboarding/workspace bounces
- `app/onboarding/page.tsx` — refresh status after callback; show a useful error
- `lib/connect/connection-scopes.ts` + `user-vault.ts` — normalize Clerk-mirrored scopes

**`fix(onboarding)`** `f6b6282`
- `lib/projects/membership-scope.ts`, `scoped-catalog.ts`, `membership.ts`, `access.ts`
- workspace + `/api/my-project` + live membership queries

## Tests

Added:
- `tests/oauth-state.test.ts` — allowlist, signed state, tamper reject, identity mismatch
- `tests/connection-scopes.test.ts`
- `tests/membership-scope.test.ts` — fail-closed without Clerk id; predicate never matches all rows

Ran: `tsc --noEmit` ✅ · eslint on touched files ✅ · `next build` ✅ · Node 22.14  
`npm test`: new tests pass. Pre-existing `viewport-url` / `vforge-api-viewport` failures (admin `?embed=1`) are on `main` and untouched.

## Risks

- GitHub App “v-Forge-momentum” must stay public and its callback URL must remain `/api/auth/github/callback`. That is a GitHub App setting, not this PR.
- Vercel Install still happens on Vercel’s UI. If Install is disabled for a specific account, it is team/project selection or integration-dashboard config — not a new VForge route.
- Legacy memberships with only email and a null `clerk_user_id` still match that user’s email. Rows already bound to another Clerk id do not.

## Evidence

- Production logout SHA `396b512` on the current production deployment.
- Unauthenticated `/api/auth/github/start` and `/api/auth/vercel/start` already send the user to `/sign-in` (same-tab).
- Did not create extra clones, new Vercel integrations, or `/api/auth/vercel/install`.
- Could not complete a live third-party OAuth as a brand-new GitHub/Vercel user from this environment (no throwaway accounts). Code path is covered by the signed-state tests.

Do not merge unless asked.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-844969bf-c12a-414e-a47a-f5ec1cdac82e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-844969bf-c12a-414e-a47a-f5ec1cdac82e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

