### PR TITLE
fix(vercel): land new users on onboarding if state is missing

### DIFF
--- a/app/api/auth/vercel/callback/route.ts
+++ b/app/api/auth/vercel/callback/route.ts
@@ -1,7 +1,10 @@
 import { auth } from "@clerk/nextjs/server";
 import { cookies } from "next/headers";
 import { saveUserSecret } from "@/lib/connect/user-vault";
-import { leerStateCompleto } from "@/lib/connect/oauth-state";
+import {
+  destinoCallbackVercel,
+  leerStateCompleto,
+} from "@/lib/connect/oauth-state";
 import { registrarIntento } from "@/lib/connect/attempt-log";
 
 export const runtime = "nodejs";
@@ -28,7 +31,10 @@ export async function GET(req: Request) {
 
   const stateData = leerStateCompleto(state);
   const back = (status: string) => {
-    const destination = new URL(stateData?.returnPath ?? "/app/integrations", site);
+    const destination = new URL(
+      destinoCallbackVercel(stateData?.returnPath),
+      site,
+    );
     destination.searchParams.set("vercel", status);
     return Response.redirect(destination, 302);
   };

--- a/lib/connect/oauth-state.ts
+++ b/lib/connect/oauth-state.ts
@@ -96,3 +96,22 @@ export function leerStateCompleto(
 export function leerState(state: string | null | undefined): string | null {
   return leerStateCompleto(state)?.userId ?? null;
 }
+
+/**
+ * Destino después del callback de Vercel.
+ *
+ * Si el state firmado trae return_to (/onboarding, /workspace o
+ * /app/integrations) se respeta — el owner sigue volviendo a su consola.
+ * Si el state no viajó o no se pudo leer, NO caemos en /app/integrations:
+ * esa ruta es owner-only y manda al usuario nuevo a /sign-in con
+ * redirect_url del cockpit. /onboarding es seguro para cliente y el
+ * middleware del owner lo reenvía a /app/chat.
+ *
+ * No se usa el `next` de Vercel: es vercel.com y dejaría al usuario
+ * fuera de VForge en el flujo externo (same-tab desde onboarding).
+ */
+export function destinoCallbackVercel(
+  stateReturnPath: OAuthReturnPath | null | undefined,
+): OAuthReturnPath {
+  return stateReturnPath ?? "/onboarding";
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/vercel-callback-return.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/vercel-callback-return.test.ts
+++ b/tests/vercel-callback-return.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { destinoCallbackVercel } from "../lib/connect/oauth-state";
+
+test("missing Vercel state returns the new user to onboarding, not the owner console", () => {
+  assert.equal(destinoCallbackVercel(null), "/onboarding");
+  assert.equal(destinoCallbackVercel(undefined), "/onboarding");
+});
+
+test("signed Vercel return_to is preserved for owner and client", () => {
+  assert.equal(destinoCallbackVercel("/app/integrations"), "/app/integrations");
+  assert.equal(destinoCallbackVercel("/onboarding"), "/onboarding");
+  assert.equal(destinoCallbackVercel("/workspace"), "/workspace");
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -16,6 +16,7 @@
   "include": [
     "tests/**/*.ts",
     "lib/auth/owner.ts",
+    "lib/connect/oauth-state.ts",
     "lib/projects/roles.ts",
     "lib/projects/invite-token.ts",
     "lib/projects/viewport-url.ts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause (VForge-side, proven)

Production `GET /api/auth/vercel/callback` (no `code`, no `state`) returns:

```
Location: https://vforge.site/app/integrations?vercel=error_no_code
```

`/app/integrations` is owner-only. The next hop is:

```
Location: /sign-in?redirect_url=https://vforge.site/app/integrations?vercel=error_no_code
```

That matches the owner-console evidence. A new user who reaches the callback without a readable signed `state` (expired, dropped, or Configure via Configuration URL) is sent to the owner cockpit instead of `/onboarding`.

Onboarding start already signs `return_to=/onboarding` into `state`. The owner start (no `return_to`) still signs `/app/integrations`. Only the **missing-state fallback** was wrong.

## What this is not

Published scopes match the intended minimum. They are **not** treated as the Install-disabled cause. Community/Third Party badge is expected.

Vercel’s Install button lives on `https://vercel.com/integrations/v-forge/new`. This repo cannot enable it. Hunch (not proven from code): a brand-new Hobby account with **zero projects** cannot select a project, and project-level scopes (Projects / Env Vars / Deployments R/W) keep Install disabled until a project exists. That is Vercel’s UI, not a VForge route.

Vercel’s `next` query is `vercel.com/.../installed`. We do **not** follow it on the external/same-tab flow so the user returns to VForge, not to Vercel.

Did not create a second integration. Did not add Billing/Pro/Drains scopes. Did not change start URL or Redirect URL.

## Files

- `app/api/auth/vercel/callback/route.ts` — fallback destination `/onboarding`
- `lib/connect/oauth-state.ts` — `destinoCallbackVercel`
- `tests/vercel-callback-return.test.ts`

## Tests

`tsc --noEmit` ✅ · eslint on touched files ✅ · `next build` ✅ · new unit tests ✅

## Risks

- Owner callback **with** valid signed state still returns to `/app/integrations`.
- Owner callback **without** state now hits `/onboarding`, then middleware sends the owner to `/app/chat`. That path is the error case (no state), not the happy path.
- This does not flip a disabled Install button on vercel.com.

Do not merge unless asked.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-844969bf-c12a-414e-a47a-f5ec1cdac82e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-844969bf-c12a-414e-a47a-f5ec1cdac82e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

