### PR TITLE
feat: habilitar primera app en workspace independiente

### DIFF
--- a/app/api/forja/ship/route.ts
+++ b/app/api/forja/ship/route.ts
@@ -19,6 +19,19 @@ function slugify(s: string): string {
     .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 50) || "mi-app";
 }
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => {
+    const entities: Record<string, string> = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#039;",
+    };
+    return entities[character];
+  });
+}
+
 const TEMPLATES: Record<string, { sub: string; accent: string }> = {
   landing:    { sub: "Tu landing esta viva. Cuentale al mundo que haces.", accent: "#7c3aed" },
   tienda:     { sub: "Tu tienda esta lista. Conecta Stripe y empieza a vender.", accent: "#16a34a" },
@@ -27,9 +40,12 @@ const TEMPLATES: Record<string, { sub: string; accent: string }> = {
 };
 function starter(name: string, template: string, description?: string): string {
   const t = TEMPLATES[template] || TEMPLATES.blanco;
-  const sub = (description && description.trim()) ? description.trim() : t.sub;
+  const safeName = escapeHtml(name);
+  const safeSub = escapeHtml(
+    description && description.trim() ? description.trim() : t.sub,
+  );
   return `<!doctype html><html lang="es"><head><meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width,initial-scale=1"/><title>${name}</title>
+<meta name="viewport" content="width=device-width,initial-scale=1"/><title>${safeName}</title>
 <style>:root{color-scheme:dark}*{margin:0;box-sizing:border-box}
 body{min-height:100vh;display:grid;place-items:center;background:#0a0a0f;color:#f5f5f7;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto,sans-serif}
 .card{text-align:center;padding:48px 32px;border:1px solid rgba(255,255,255,.09);border-radius:24px;background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.015));box-shadow:inset 0 1px 0 rgba(255,255,255,.07),0 20px 60px -20px rgba(0,0,0,.7);max-width:520px}
@@ -37,7 +53,7 @@ h1{font-size:2rem;letter-spacing:-.03em;margin-bottom:12px}p{color:rgba(255,255,
 .b{display:inline-block;margin-bottom:20px;padding:6px 14px;border-radius:999px;border:1px solid ${t.accent};color:${t.accent};font-size:12px;font-weight:600}
 .d{display:inline-block;width:8px;height:8px;border-radius:50%;background:${t.accent};box-shadow:0 0 10px ${t.accent};margin-right:6px}</style></head>
 <body><div class="card"><span class="b"><span class="d"></span>En produccion</span>
-<h1>${name}</h1><p>${sub}</p></div></body></html>`;
+<h1>${safeName}</h1><p>${safeSub}</p></div></body></html>`;
 }
 
 function gh(path: string, token: string, init: RequestInit = {}) {
@@ -85,10 +101,16 @@ export async function POST(req: Request) {
     out.repo = { url: repo.html_url, full: repo.full_name };
 
     const content = Buffer.from(starter(name, template, description), "utf8").toString("base64");
-    await gh(`/repos/${owner}/${slug}/contents/index.html`, ghToken, {
+    const indexRes = await gh(`/repos/${owner}/${slug}/contents/index.html`, ghToken, {
       method: "PUT",
       body: JSON.stringify({ message: "VForge: app inicial", content }),
     });
+    if (!indexRes.ok) {
+      return Response.json(
+        { ok: false, error: "repo_content", detail: await indexRes.text(), repo: out.repo },
+        { status: 400 },
+      );
+    }
     const readme = `# ${name}\n\n${description || "App creada con VForge."}\n\n**Plantilla:** ${template}\n\n**Módulos solicitados:**\n${modules.length ? modules.map((m) => "- " + m).join("\n") : "- (ninguno)"}\n\n---\nGenerada con VForge.`;
     await gh(`/repos/${owner}/${slug}/contents/README.md`, ghToken, {
       method: "PUT",

--- a/app/api/forja/ship/route.ts
+++ b/app/api/forja/ship/route.ts
@@ -112,10 +112,36 @@ export async function POST(req: Request) {
       );
     }
     const readme = `# ${name}\n\n${description || "App creada con VForge."}\n\n**Plantilla:** ${template}\n\n**Módulos solicitados:**\n${modules.length ? modules.map((m) => "- " + m).join("\n") : "- (ninguno)"}\n\n---\nGenerada con VForge.`;
-    await gh(`/repos/${owner}/${slug}/contents/README.md`, ghToken, {
-      method: "PUT",
-      body: JSON.stringify({ message: "VForge: README/spec", content: Buffer.from(readme, "utf8").toString("base64") }),
-    }).catch(() => {});
+    const currentReadmeRes = await gh(
+      `/repos/${owner}/${slug}/contents/README.md`,
+      ghToken,
+    );
+    const currentReadme = currentReadmeRes.ok
+      ? ((await currentReadmeRes.json()) as { sha?: string })
+      : null;
+    const readmeRes = await gh(
+      `/repos/${owner}/${slug}/contents/README.md`,
+      ghToken,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          message: "VForge: README/spec",
+          content: Buffer.from(readme, "utf8").toString("base64"),
+          ...(currentReadme?.sha ? { sha: currentReadme.sha } : {}),
+        }),
+      },
+    );
+    if (!readmeRes.ok) {
+      return Response.json(
+        {
+          ok: false,
+          error: "repo_readme",
+          detail: await readmeRes.text(),
+          repo: out.repo,
+        },
+        { status: 400 },
+      );
+    }
 
 
     const q = vcTeam ? `?teamId=${encodeURIComponent(vcTeam)}&forceNew=1` : `?forceNew=1`;

--- a/components/workspace/ScopedCreateApp.tsx
+++ b/components/workspace/ScopedCreateApp.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  IconArrowR,
+  IconCheck,
+  IconGithub,
+  IconLoader,
+  IconRocket,
+} from "@/components/brand/VFIcons";
+
+interface GeneratedApp {
+  id: string;
+  name: string;
+  repo_url: string | null;
+  deploy_url: string | null;
+  template: string | null;
+  created_at: string;
+}
+
+interface ShipResponse {
+  ok?: boolean;
+  error?: string;
+  repo?: { url?: string };
+  deploy?: { url?: string | null };
+}
+
+const templates = [
+  { value: "landing", label: "Landing" },
+  { value: "tienda", label: "Tienda" },
+  { value: "portafolio", label: "Portafolio" },
+  { value: "blanco", label: "Lienzo en blanco" },
+];
+
+export function ScopedCreateApp() {
+  const [apps, setApps] = useState<GeneratedApp[]>([]);
+  const [loadingApps, setLoadingApps] = useState(true);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [template, setTemplate] = useState("landing");
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ShipResponse | null>(null);
+
+  const loadApps = useCallback(async () => {
+    try {
+      const response = await fetch("/api/forja/apps", { cache: "no-store" });
+      const payload = (await response.json()) as { apps?: GeneratedApp[] };
+      setApps(response.ok ? payload.apps ?? [] : []);
+    } catch {
+      setApps([]);
+    } finally {
+      setLoadingApps(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadApps();
+  }, [loadApps]);
+
+  async function createApp() {
+    if (!name.trim() || creating) return;
+    setCreating(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await fetch("/api/forja/ship", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim(),
+          template,
+          isPrivate,
+          modules: [],
+        }),
+      });
+      const payload = (await response.json()) as ShipResponse;
+
+      if (!response.ok || !payload.ok) {
+        const message =
+          payload.error === "connect_github"
+            ? "Conecta GitHub antes de crear una app."
+            : payload.error === "connect_vercel"
+              ? "Conecta Vercel antes de crear una app."
+              : payload.error === "repo_create"
+                ? "GitHub no permitió crear el repositorio."
+                : payload.error === "deploy"
+                  ? "El repositorio se creó, pero Vercel no pudo desplegarlo."
+                  : "No pudimos crear la app. Intenta nuevamente.";
+        setError(message);
+        return;
+      }
+
+      setResult(payload);
+      setName("");
+      setDescription("");
+      await loadApps();
+    } catch {
+      setError("Se perdió la conexión durante la creación. Intenta nuevamente.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <section className="mt-12 sm:mt-16" aria-labelledby="create-app-title">
+      <div className="border-b border-[var(--color-ink)] pb-4">
+        <p className="mono-label">Paso 02</p>
+        <h2
+          id="create-app-title"
+          className="mt-2 text-[28px] font-medium tracking-[-0.05em]"
+        >
+          Crea tu primera app
+        </h2>
+        <p className="mt-2 max-w-2xl text-[12px] leading-5 text-[var(--fg-secondary)]">
+          Esta primera prueba crea un repositorio en tu GitHub y una URL publicada
+          en tu Vercel. Todavía es una base inicial, no una aplicación completa.
+        </p>
+      </div>
+
+      <div className="border-x border-b border-[var(--color-ink)] bg-[var(--color-surface)] p-5 sm:p-7">
+        <div className="grid gap-5 md:grid-cols-2">
+          <label className="grid gap-2">
+            <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+              Nombre
+            </span>
+            <input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Mi primera app"
+              maxLength={60}
+              className="min-h-12 w-full border border-[var(--border-1)] bg-[var(--color-background)] px-4 text-[14px] outline-none transition focus:border-[var(--color-ink)]"
+            />
+          </label>
+
+          <label className="grid gap-2">
+            <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+              Plantilla
+            </span>
+            <select
+              value={template}
+              onChange={(event) => setTemplate(event.target.value)}
+              className="min-h-12 w-full border border-[var(--border-1)] bg-[var(--color-background)] px-4 text-[14px] outline-none transition focus:border-[var(--color-ink)]"
+            >
+              {templates.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <label className="mt-5 grid gap-2">
+          <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+            Descripción
+          </span>
+          <textarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Describe en una frase qué debe comunicar."
+            maxLength={600}
+            rows={4}
+            className="w-full resize-y border border-[var(--border-1)] bg-[var(--color-background)] px-4 py-3 text-[14px] leading-6 outline-none transition focus:border-[var(--color-ink)]"
+          />
+        </label>
+
+        <div className="mt-5 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+          <label className="inline-flex items-center gap-3 text-[12px] text-[var(--fg-secondary)]">
+            <input
+              type="checkbox"
+              checked={isPrivate}
+              onChange={(event) => setIsPrivate(event.target.checked)}
+              className="h-4 w-4 accent-black"
+            />
+            Repositorio privado
+          </label>
+          <button
+            type="button"
+            onClick={createApp}
+            disabled={creating || !name.trim()}
+            className="btn-primary !min-h-11 disabled:opacity-50"
+          >
+            {creating ? (
+              <>
+                <IconLoader size={13} className="animate-spin" /> Creando
+              </>
+            ) : (
+              <>
+                Crear repo y publicar <IconArrowR size={12} />
+              </>
+            )}
+          </button>
+        </div>
+
+        <div aria-live="polite">
+          {error ? (
+            <p role="alert" className="mt-4 text-[12px] leading-5">
+              {error}
+            </p>
+          ) : null}
+
+          {result?.ok ? (
+            <div className="mt-5 border border-[var(--color-ink)] p-4">
+              <p className="inline-flex items-center gap-2 text-[13px] font-medium">
+                <IconCheck size={13} /> App creada
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {result.repo?.url ? (
+                  <a
+                    href={result.repo.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn-ghost !min-h-10 !px-3"
+                  >
+                    <IconGithub size={12} /> Abrir repositorio
+                  </a>
+                ) : null}
+                {result.deploy?.url ? (
+                  <a
+                    href={result.deploy.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn-primary !min-h-10 !px-3"
+                  >
+                    <IconRocket size={12} /> Abrir publicación
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+          Apps generadas
+        </p>
+        {loadingApps ? (
+          <div className="mt-3 grid min-h-24 place-items-center border border-[var(--border-1)]">
+            <IconLoader size={14} className="animate-spin" />
+          </div>
+        ) : apps.length === 0 ? (
+          <p className="mt-3 border border-[var(--border-1)] p-4 text-[12px] text-[var(--fg-secondary)]">
+            Tu primera app aparecerá aquí después de publicarla.
+          </p>
+        ) : (
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            {apps.map((app) => (
+              <article
+                key={app.id}
+                className="border border-[var(--border-1)] bg-[var(--color-surface)] p-4"
+              >
+                <p className="text-[16px] font-medium">{app.name}</p>
+                <p className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
+                  {app.template || "base"}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {app.repo_url ? (
+                    <a
+                      href={app.repo_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn-ghost !min-h-9 !px-3"
+                    >
+                      GitHub
+                    </a>
+                  ) : null}
+                  {app.deploy_url ? (
+                    <a
+                      href={app.deploy_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn-primary !min-h-9 !px-3"
+                    >
+                      Publicación
+                    </a>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/workspace/ScopedWorkspaceHome.tsx
+++ b/components/workspace/ScopedWorkspaceHome.tsx
@@ -13,6 +13,7 @@ import {
   IconShield,
 } from "@/components/brand/VFIcons";
 import { monochromeClerkAppearance } from "@/components/auth/ClerkShell";
+import { ScopedCreateApp } from "@/components/workspace/ScopedCreateApp";
 import type { ScopedProject } from "@/lib/projects/scoped-catalog";
 
 const ROLE_LABEL: Record<string, string> = {
@@ -163,8 +164,10 @@ export function ScopedWorkspaceHome({
           </div>
         </section>
 
+        <ScopedCreateApp />
+
         <section className="mt-12 sm:mt-16" aria-labelledby="projects-title">
-          <p className="mono-label">Paso 02</p>
+          <p className="mono-label">Paso 03</p>
           <h2
             id="projects-title"
             className="mt-2 text-[28px] font-medium tracking-[-0.05em]"


### PR DESCRIPTION
Expone el motor real `GitHub → Vercel` a usuarios nuevos, conserva la interfaz blanco y negro, lista apps persistidas y endurece la escritura de archivos.

Validación: TypeScript, ESLint y supervisor `--full` con Node 20 aprobados.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ship orchestrates user GitHub/Vercel tokens and external API calls; README/index failures are now surfaced but a repo can still be left created if a later step fails.
> 
> **Overview**
> Adds **Paso 02 — Crea tu primera app** to the scoped workspace: a new `ScopedCreateApp` UI that posts to `/api/forja/ship`, shows Spanish error states for missing GitHub/Vercel or partial failures, and lists persisted apps from `/api/forja/apps`. The projects section is renumbered to **Paso 03**.
> 
> The **ship** route is hardened: user-supplied name and description in the generated `index.html` are passed through **`escapeHtml`**, `index.html` and **README** GitHub writes now check API responses (including README **SHA** when `auto_init` already created the file) and return `repo_content` / `repo_readme` instead of ignoring failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2227e6fc72451ee04988a0bc169b996f0f4f7673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->