### PR TITLE
Fix stale workspace after production deploy

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // VForge minimal service worker — offline shell + network-first for documents
 // Bump VERSION on every deploy where you want forced cache invalidation
-const VERSION = "vforge-monochrome-stability-2026-08-23";
+const VERSION = "vforge-scoped-workspace-2026-08-30-1";
 const SHELL = ["/", "/app/chat", "/offline"];
 
 self.addEventListener("install", (event) => {
@@ -26,12 +26,15 @@ self.addEventListener("fetch", (event) => {
   const url = new URL(req.url);
   if (url.origin !== self.location.origin) return;
 
-  // NUNCA cachear /api/* — siempre red (los datos reales son críticos)
-  if (url.pathname.startsWith("/api/")) {
+  // Datos, bundles y respuestas RSC siempre pasan por red. Next.js ya publica
+  // sus assets con hashes; guardarlos aquí puede mezclar dos releases.
+  const isNextAsset = url.pathname.startsWith("/_next/");
+  const isRscRequest = url.searchParams.has("_rsc") || req.headers.get("RSC") === "1";
+  if (url.pathname.startsWith("/api/") || isNextAsset || isRscRequest) {
     return;
   }
 
-  // Network-first para HTML/navigation — siempre intenta versión nueva
+  // Network-first para HTML/navigation — siempre intenta versión nueva.
   if (req.mode === "navigate") {
     event.respondWith(
       fetch(req)
@@ -45,8 +48,7 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Stale-while-revalidate para assets estáticos — sirve del cache pero
-  // refresca en background para que la próxima vez sea versión nueva.
+  // Stale-while-revalidate sólo para assets propios no versionados.
   event.respondWith(
     caches.match(req).then((cached) => {
       const networkPromise = fetch(req).then((res) => {


### PR DESCRIPTION
## Resultado
- Invalida la caché PWA anterior.
- Evita almacenar bundles `/_next/*` y respuestas RSC.
- Mantiene navegación network-first y shell offline.

## Verificación
- `node --check public/sw.js`
- `npm run typecheck`
- `npx eslint . --ignore-pattern .vercel` (0 errores)
- `npm run build`
- Supervisor full: APROBADO

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Service worker fetch rules affect every production PWA session; mis-scoping could still leave edge cases stale, but the change reduces cross-release cache mixing rather than broadening cached surface.
> 
> **Overview**
> **Fixes stale workspace/UI after production deploy** by tightening what the service worker caches and forcing clients onto a new cache generation.
> 
> The cache **VERSION** is bumped so install/activate drops prior PWA caches. The fetch handler still bypasses `/api/*`, and now also skips **`/_next/*`** and **RSC** traffic (`_rsc` query or `RSC: 1` header) so hashed Next bundles and server-component payloads are not stored in the SW layer—avoiding a mix of two releases. **Network-first navigation** and the offline shell are unchanged; stale-while-revalidate applies only to remaining same-origin static assets that are not excluded above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6662d20a46700a87353c64b37b3df377d1d3557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->