### PR TITLE
Fix GitHub repo permissions and upgrade scoped builder

### DIFF
--- a/app/api/forja/ship/route.ts
+++ b/app/api/forja/ship/route.ts
@@ -63,6 +63,7 @@ function gh(path: string, token: string, init: RequestInit = {}) {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",
       "User-Agent": "vforge",
+      "X-GitHub-Api-Version": "2026-03-10",
       ...(init.headers || {}),
     },
   });
@@ -96,7 +97,33 @@ export async function POST(req: Request) {
       method: "POST",
       body: JSON.stringify({ name: slug, description: (description || name) + " — creada con VForge", private: isPrivate, auto_init: true }),
     });
-    if (!repoRes.ok) return Response.json({ ok: false, error: "repo_create", detail: await repoRes.text() }, { status: 400 });
+    if (!repoRes.ok) {
+      const detail = await repoRes.text();
+      const acceptedPermissions =
+        repoRes.headers.get("x-accepted-github-permissions") || "";
+      const permissionDenied =
+        repoRes.status === 403 &&
+        (detail.includes("Resource not accessible by integration") ||
+          acceptedPermissions.includes("administration=write"));
+
+      console.error("[forja/ship] repo_create_failed", {
+        status: repoRes.status,
+        acceptedPermissions,
+        detail: detail.slice(0, 500),
+      });
+
+      return Response.json(
+        {
+          ok: false,
+          error: permissionDenied
+            ? "github_repo_permission"
+            : "repo_create",
+          detail,
+          acceptedPermissions,
+        },
+        { status: 400 },
+      );
+    }
     const repo = await repoRes.json();
     out.repo = { url: repo.html_url, full: repo.full_name };
 

--- a/components/workspace/ScopedCreateApp.tsx
+++ b/components/workspace/ScopedCreateApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   IconArrowR,
   IconCheck,
@@ -21,16 +21,63 @@ interface GeneratedApp {
 interface ShipResponse {
   ok?: boolean;
   error?: string;
+  detail?: unknown;
+  acceptedPermissions?: string;
   repo?: { url?: string };
   deploy?: { url?: string | null };
 }
 
+interface BuilderError {
+  title: string;
+  message: string;
+  permission?: boolean;
+}
+
 const templates = [
-  { value: "landing", label: "Landing" },
-  { value: "tienda", label: "Tienda" },
-  { value: "portafolio", label: "Portafolio" },
-  { value: "blanco", label: "Lienzo en blanco" },
-];
+  {
+    value: "landing",
+    label: "Landing",
+    eyebrow: "Presentar",
+    description: "Una página enfocada en comunicar y convertir.",
+  },
+  {
+    value: "tienda",
+    label: "Tienda",
+    eyebrow: "Vender",
+    description: "Catálogo y estructura inicial para comercio.",
+  },
+  {
+    value: "portafolio",
+    label: "Portafolio",
+    eyebrow: "Mostrar",
+    description: "Proyectos, casos y contacto en primer plano.",
+  },
+  {
+    value: "blanco",
+    label: "Desde cero",
+    eyebrow: "Explorar",
+    description: "Una base limpia para una idea distinta.",
+  },
+] as const;
+
+const capabilities = [
+  "Autenticación",
+  "Panel administrativo",
+  "Base de datos",
+  "Pagos",
+  "PWA",
+  "Mapas",
+] as const;
+
+function detailMessage(detail: unknown): string {
+  if (typeof detail !== "string") return "";
+  try {
+    const parsed = JSON.parse(detail) as { message?: string };
+    return typeof parsed.message === "string" ? parsed.message : "";
+  } catch {
+    return detail.slice(0, 180);
+  }
+}
 
 export function ScopedCreateApp() {
   const [apps, setApps] = useState<GeneratedApp[]>([]);
@@ -38,10 +85,16 @@ export function ScopedCreateApp() {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [template, setTemplate] = useState("landing");
+  const [modules, setModules] = useState<string[]>([]);
   const [isPrivate, setIsPrivate] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<BuilderError | null>(null);
   const [result, setResult] = useState<ShipResponse | null>(null);
+
+  const selectedTemplate = useMemo(
+    () => templates.find((item) => item.value === template) ?? templates[0],
+    [template],
+  );
 
   const loadApps = useCallback(async () => {
     try {
@@ -59,6 +112,14 @@ export function ScopedCreateApp() {
     void loadApps();
   }, [loadApps]);
 
+  function toggleModule(module: string) {
+    setModules((current) =>
+      current.includes(module)
+        ? current.filter((item) => item !== module)
+        : [...current, module],
+    );
+  }
+
   async function createApp() {
     if (!name.trim() || creating) return;
     setCreating(true);
@@ -74,191 +135,415 @@ export function ScopedCreateApp() {
           description: description.trim(),
           template,
           isPrivate,
-          modules: [],
+          modules,
         }),
       });
       const payload = (await response.json()) as ShipResponse;
 
       if (!response.ok || !payload.ok) {
-        const message =
-          payload.error === "connect_github"
-            ? "Conecta GitHub antes de crear una app."
-            : payload.error === "connect_vercel"
-              ? "Conecta Vercel antes de crear una app."
-              : payload.error === "repo_create"
-                ? "GitHub no permitió crear el repositorio."
-                : payload.error === "deploy"
-                  ? "El repositorio se creó, pero Vercel no pudo desplegarlo."
-                  : "No pudimos crear la app. Intenta nuevamente.";
-        setError(message);
+        if (payload.error === "connect_github") {
+          setError({
+            title: "Falta conectar GitHub",
+            message: "Conecta tu cuenta y vuelve a intentar desde este mismo espacio.",
+          });
+        } else if (payload.error === "connect_vercel") {
+          setError({
+            title: "Falta conectar Vercel",
+            message: "Conecta tu cuenta para que VForge pueda publicar el proyecto.",
+          });
+        } else if (payload.error === "github_repo_permission") {
+          setError({
+            title: "GitHub necesita un permiso adicional",
+            message:
+              "Tu cuenta está conectada, pero la instalación todavía no autoriza crear repositorios. Actualiza el acceso de VForge en GitHub y vuelve a publicar.",
+            permission: true,
+          });
+        } else if (payload.error === "repo_create") {
+          setError({
+            title: "GitHub rechazó el repositorio",
+            message:
+              detailMessage(payload.detail) ||
+              "Revisa el acceso de la integración e intenta nuevamente.",
+          });
+        } else if (payload.error === "deploy") {
+          setError({
+            title: "El repositorio se creó, pero falta publicar",
+            message:
+              "Vercel rechazó el despliegue. Tu código quedó seguro en GitHub para reintentarlo.",
+          });
+        } else {
+          setError({
+            title: "La construcción no terminó",
+            message: "VForge conservó tu brief. Intenta nuevamente en un momento.",
+          });
+        }
         return;
       }
 
       setResult(payload);
       setName("");
       setDescription("");
+      setModules([]);
       await loadApps();
     } catch {
-      setError("Se perdió la conexión durante la creación. Intenta nuevamente.");
+      setError({
+        title: "Se perdió la conexión",
+        message: "Tu brief sigue aquí. Reintenta cuando la red esté estable.",
+      });
     } finally {
       setCreating(false);
     }
   }
 
+  const githubState = error?.permission
+    ? "error"
+    : result?.ok
+      ? "done"
+      : creating
+        ? "active"
+        : "idle";
+  const vercelState = result?.ok
+    ? "done"
+    : creating
+      ? "waiting"
+      : "idle";
+
   return (
     <section className="mt-12 sm:mt-16" aria-labelledby="create-app-title">
-      <div className="border-b border-[var(--color-ink)] pb-4">
-        <p className="mono-label">Paso 02</p>
-        <h2
-          id="create-app-title"
-          className="mt-2 text-[28px] font-medium tracking-[-0.05em]"
-        >
-          Crea tu primera app
-        </h2>
-        <p className="mt-2 max-w-2xl text-[12px] leading-5 text-[var(--fg-secondary)]">
-          Esta primera prueba crea un repositorio en tu GitHub y una URL publicada
-          en tu Vercel. Todavía es una base inicial, no una aplicación completa.
+      <div className="flex flex-col gap-4 border-b border-[var(--color-ink)] pb-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="mono-label">Paso 02 · Constructor</p>
+          <h2
+            id="create-app-title"
+            className="mt-2 max-w-3xl text-[34px] font-medium leading-[0.98] tracking-[-0.06em] sm:text-[46px]"
+          >
+            Dale forma a tu primera app.
+          </h2>
+        </div>
+        <p className="max-w-sm text-[12px] leading-5 text-[var(--fg-secondary)] sm:text-right">
+          Elige una dirección, define lo necesario y VForge prepara el repo y
+          la publicación con tus propias cuentas.
         </p>
       </div>
 
-      <div className="border-x border-b border-[var(--color-ink)] bg-[var(--color-surface)] p-5 sm:p-7">
-        <div className="grid gap-5 md:grid-cols-2">
-          <label className="grid gap-2">
+      <div className="grid border-x border-b border-[var(--color-ink)] bg-[var(--color-surface)] lg:grid-cols-[minmax(0,1.55fr)_minmax(280px,.75fr)]">
+        <div className="p-5 sm:p-8 lg:border-r lg:border-[var(--color-ink)]">
+          <div className="flex items-center justify-between border-b border-[var(--border-1)] pb-3">
+            <p className="font-mono text-[9px] uppercase tracking-[0.16em]">
+              01 / Dirección
+            </p>
+            <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+              {selectedTemplate.eyebrow}
+            </p>
+          </div>
+
+          <div className="mt-4 grid gap-2 sm:grid-cols-2">
+            {templates.map((item, index) => {
+              const active = template === item.value;
+              return (
+                <button
+                  key={item.value}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setTemplate(item.value)}
+                  className={`group min-h-28 border p-4 text-left transition duration-200 ${
+                    active
+                      ? "border-[var(--color-ink)] bg-[var(--color-ink)] text-[var(--color-background)]"
+                      : "border-[var(--border-1)] bg-[var(--color-background)] hover:border-[var(--color-ink)]"
+                  }`}
+                >
+                  <span
+                    className={`font-mono text-[9px] tracking-[0.16em] ${
+                      active ? "opacity-60" : "text-[var(--fg-muted)]"
+                    }`}
+                  >
+                    0{index + 1}
+                  </span>
+                  <span className="mt-5 block text-[18px] font-medium tracking-[-0.03em]">
+                    {item.label}
+                  </span>
+                  <span
+                    className={`mt-1 block text-[11px] leading-4 ${
+                      active ? "opacity-65" : "text-[var(--fg-secondary)]"
+                    }`}
+                  >
+                    {item.description}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="mt-8 flex items-center justify-between border-b border-[var(--border-1)] pb-3">
+            <p className="font-mono text-[9px] uppercase tracking-[0.16em]">
+              02 / Brief
+            </p>
+            <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+              Escribe como hablas
+            </p>
+          </div>
+
+          <label className="mt-4 grid gap-2">
             <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
-              Nombre
+              Nombre del proyecto
             </span>
             <input
               value={name}
               onChange={(event) => setName(event.target.value)}
-              placeholder="Mi primera app"
+              placeholder="Ej. Estudio Norte"
               maxLength={60}
-              className="min-h-12 w-full border border-[var(--border-1)] bg-[var(--color-background)] px-4 text-[14px] outline-none transition focus:border-[var(--color-ink)]"
+              className="min-h-14 w-full border border-[var(--border-1)] bg-[var(--color-background)] px-4 text-[17px] tracking-[-0.02em] outline-none transition placeholder:text-[var(--fg-muted)] focus:border-[var(--color-ink)]"
             />
           </label>
 
-          <label className="grid gap-2">
+          <label className="mt-4 grid gap-2">
             <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
-              Plantilla
+              ¿Qué quieres construir?
             </span>
-            <select
-              value={template}
-              onChange={(event) => setTemplate(event.target.value)}
-              className="min-h-12 w-full border border-[var(--border-1)] bg-[var(--color-background)] px-4 text-[14px] outline-none transition focus:border-[var(--color-ink)]"
-            >
-              {templates.map((item) => (
-                <option key={item.value} value={item.value}>
-                  {item.label}
-                </option>
-              ))}
-            </select>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Cuéntale a VForge qué debe hacer, para quién es y qué sensación debe transmitir."
+              maxLength={600}
+              rows={5}
+              className="w-full resize-y border border-[var(--border-1)] bg-[var(--color-background)] px-4 py-4 text-[14px] leading-6 outline-none transition placeholder:text-[var(--fg-muted)] focus:border-[var(--color-ink)]"
+            />
+            <span className="text-right font-mono text-[9px] text-[var(--fg-muted)]">
+              {description.length}/600
+            </span>
           </label>
+
+          <div className="mt-8 flex items-center justify-between border-b border-[var(--border-1)] pb-3">
+            <p className="font-mono text-[9px] uppercase tracking-[0.16em]">
+              03 / Necesidades
+            </p>
+            <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+              Selección múltiple
+            </p>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {capabilities.map((item) => {
+              const active = modules.includes(item);
+              return (
+                <button
+                  key={item}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => toggleModule(item)}
+                  className={`min-h-10 border px-3 text-[11px] transition ${
+                    active
+                      ? "border-[var(--color-ink)] bg-[var(--color-ink)] text-[var(--color-background)]"
+                      : "border-[var(--border-1)] bg-[var(--color-background)] hover:border-[var(--color-ink)]"
+                  }`}
+                >
+                  {active ? "✓ " : "+ "}
+                  {item}
+                </button>
+              );
+            })}
+          </div>
         </div>
 
-        <label className="mt-5 grid gap-2">
-          <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
-            Descripción
-          </span>
-          <textarea
-            value={description}
-            onChange={(event) => setDescription(event.target.value)}
-            placeholder="Describe en una frase qué debe comunicar."
-            maxLength={600}
-            rows={4}
-            className="w-full resize-y border border-[var(--border-1)] bg-[var(--color-background)] px-4 py-3 text-[14px] leading-6 outline-none transition focus:border-[var(--color-ink)]"
-          />
-        </label>
+        <aside className="flex flex-col bg-[var(--color-background)] p-5 sm:p-7">
+          <div>
+            <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-[var(--fg-muted)]">
+              Plan de construcción
+            </p>
+            <p className="mt-3 text-[24px] font-medium leading-7 tracking-[-0.045em]">
+              {name.trim() || "Proyecto sin nombre"}
+            </p>
+            <p className="mt-2 text-[12px] leading-5 text-[var(--fg-secondary)]">
+              {selectedTemplate.label}
+              {modules.length ? ` · ${modules.length} necesidades` : " · Base inicial"}
+            </p>
+          </div>
 
-        <div className="mt-5 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-          <label className="inline-flex items-center gap-3 text-[12px] text-[var(--fg-secondary)]">
+          <div className="my-7 border-y border-[var(--border-1)]">
+            <div className="grid grid-cols-[22px_1fr_auto] items-center gap-3 border-b border-[var(--border-1)] py-4">
+              <span
+                className={`h-2 w-2 rounded-full ${
+                  githubState === "done"
+                    ? "bg-emerald-500"
+                    : githubState === "error"
+                      ? "bg-red-500"
+                      : githubState === "active"
+                        ? "animate-pulse bg-[var(--color-ink)]"
+                        : "border border-[var(--color-ink)]"
+                }`}
+              />
+              <span className="text-[12px]">Crear repositorio</span>
+              <span className="font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
+                GitHub
+              </span>
+            </div>
+            <div className="grid grid-cols-[22px_1fr_auto] items-center gap-3 py-4">
+              <span
+                className={`h-2 w-2 rounded-full ${
+                  vercelState === "done"
+                    ? "bg-emerald-500"
+                    : vercelState === "waiting"
+                      ? "animate-pulse border border-[var(--color-ink)]"
+                      : "border border-[var(--color-ink)]"
+                }`}
+              />
+              <span className="text-[12px]">Publicar preview</span>
+              <span className="font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
+                Vercel
+              </span>
+            </div>
+          </div>
+
+          <label className="inline-flex items-start gap-3 text-[11px] leading-4 text-[var(--fg-secondary)]">
             <input
               type="checkbox"
               checked={isPrivate}
               onChange={(event) => setIsPrivate(event.target.checked)}
-              className="h-4 w-4 accent-black"
+              className="mt-0.5 h-4 w-4 accent-black"
             />
-            Repositorio privado
+            <span>
+              Repositorio privado
+              <span className="mt-0.5 block text-[var(--fg-muted)]">
+                Sólo tú podrás ver el código en GitHub.
+              </span>
+            </span>
           </label>
+
           <button
             type="button"
             onClick={createApp}
             disabled={creating || !name.trim()}
-            className="btn-primary !min-h-11 disabled:opacity-50"
+            className="mt-6 flex min-h-14 w-full items-center justify-center gap-2 bg-[var(--color-ink)] px-5 text-[12px] font-medium text-[var(--color-background)] transition hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-30"
           >
             {creating ? (
               <>
-                <IconLoader size={13} className="animate-spin" /> Creando
+                <IconLoader size={14} className="animate-spin" />
+                VForge está construyendo
               </>
             ) : (
               <>
-                Crear repo y publicar <IconArrowR size={12} />
+                Construir y publicar <IconArrowR size={13} />
               </>
             )}
           </button>
-        </div>
+          <p className="mt-3 text-center font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
+            Tus cuentas · tus repos · tus deployments
+          </p>
 
-        <div aria-live="polite">
-          {error ? (
-            <p role="alert" className="mt-4 text-[12px] leading-5">
-              {error}
-            </p>
-          ) : null}
-
-          {result?.ok ? (
-            <div className="mt-5 border border-[var(--color-ink)] p-4">
-              <p className="inline-flex items-center gap-2 text-[13px] font-medium">
-                <IconCheck size={13} /> App creada
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {result.repo?.url ? (
+          <div aria-live="polite" className="mt-auto pt-6">
+            {error ? (
+              <div
+                role="alert"
+                className="border border-[var(--color-ink)] bg-[var(--color-surface)] p-4"
+              >
+                <p className="text-[13px] font-medium">{error.title}</p>
+                <p className="mt-2 text-[11px] leading-5 text-[var(--fg-secondary)]">
+                  {error.message}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {error.permission ? (
+                    <a
+                      href="https://github.com/settings/installations"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn-primary !min-h-9 !px-3"
+                    >
+                      Revisar acceso en GitHub
+                    </a>
+                  ) : null}
                   <a
-                    href={result.repo.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn-ghost !min-h-10 !px-3"
+                    href="/api/auth/github/start?return_to=/workspace"
+                    className="btn-ghost !min-h-9 !px-3"
                   >
-                    <IconGithub size={12} /> Abrir repositorio
+                    Reconectar
                   </a>
-                ) : null}
-                {result.deploy?.url ? (
-                  <a
-                    href={result.deploy.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn-primary !min-h-10 !px-3"
-                  >
-                    <IconRocket size={12} /> Abrir publicación
-                  </a>
-                ) : null}
+                </div>
               </div>
-            </div>
-          ) : null}
-        </div>
+            ) : null}
+
+            {result?.ok ? (
+              <div className="border border-[var(--color-ink)] bg-[var(--color-surface)] p-4">
+                <p className="inline-flex items-center gap-2 text-[13px] font-medium">
+                  <IconCheck size={13} /> Proyecto publicado
+                </p>
+                <p className="mt-2 text-[11px] leading-5 text-[var(--fg-secondary)]">
+                  Ya vive en tus cuentas. Puedes abrir el código o revisar la
+                  publicación.
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {result.repo?.url ? (
+                    <a
+                      href={result.repo.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn-ghost !min-h-9 !px-3"
+                    >
+                      <IconGithub size={12} /> Repositorio
+                    </a>
+                  ) : null}
+                  {result.deploy?.url ? (
+                    <a
+                      href={result.deploy.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn-primary !min-h-9 !px-3"
+                    >
+                      <IconRocket size={12} /> Ver app
+                    </a>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </aside>
       </div>
 
-      <div className="mt-5">
-        <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
-          Apps generadas
-        </p>
+      <div className="mt-8">
+        <div className="flex items-end justify-between border-b border-[var(--color-ink)] pb-3">
+          <div>
+            <p className="mono-label">Historial</p>
+            <h3 className="mt-1 text-[22px] font-medium tracking-[-0.04em]">
+              Apps generadas
+            </h3>
+          </div>
+          <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+            {apps.length} proyectos
+          </span>
+        </div>
+
         {loadingApps ? (
-          <div className="mt-3 grid min-h-24 place-items-center border border-[var(--border-1)]">
+          <div className="grid min-h-28 place-items-center border-x border-b border-[var(--border-1)]">
             <IconLoader size={14} className="animate-spin" />
           </div>
         ) : apps.length === 0 ? (
-          <p className="mt-3 border border-[var(--border-1)] p-4 text-[12px] text-[var(--fg-secondary)]">
-            Tu primera app aparecerá aquí después de publicarla.
-          </p>
+          <div className="border-x border-b border-[var(--border-1)] p-5">
+            <p className="text-[13px]">Tu primera publicación aparecerá aquí.</p>
+            <p className="mt-1 text-[11px] text-[var(--fg-muted)]">
+              Sin proyectos heredados ni cuentas mezcladas.
+            </p>
+          </div>
         ) : (
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
+          <div className="grid border-l border-[var(--border-1)] md:grid-cols-2">
             {apps.map((app) => (
               <article
                 key={app.id}
-                className="border border-[var(--border-1)] bg-[var(--color-surface)] p-4"
+                className="border-b border-r border-[var(--border-1)] bg-[var(--color-surface)] p-5 transition hover:bg-[var(--color-background)]"
               >
-                <p className="text-[16px] font-medium">{app.name}</p>
-                <p className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
-                  {app.template || "base"}
-                </p>
-                <div className="mt-4 flex flex-wrap gap-2">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-[17px] font-medium tracking-[-0.03em]">
+                      {app.name}
+                    </p>
+                    <p className="mt-1 font-mono text-[8px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
+                      {app.template || "base"}
+                    </p>
+                  </div>
+                  <span className="inline-flex items-center gap-2 font-mono text-[8px] uppercase tracking-[0.12em]">
+                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                    En línea
+                  </span>
+                </div>
+                <div className="mt-6 flex flex-wrap gap-2">
                   {app.repo_url ? (
                     <a
                       href={app.repo_url}
@@ -276,7 +561,7 @@ export function ScopedCreateApp() {
                       rel="noopener noreferrer"
                       className="btn-primary !min-h-9 !px-3"
                     >
-                      Publicación
+                      Abrir app
                     </a>
                   ) : null}
                 </div>


### PR DESCRIPTION
## Resultado
- Diagnostica el permiso `Administration: write` requerido por GitHub para crear repositorios.
- Registra respuesta segura de GitHub y muestra recuperación específica.
- Sustituye el formulario básico por un constructor guiado blanco y negro con plantillas, brief, necesidades, plan GitHub→Vercel, estados y mejor historial.

## Verificación
- TypeScript: OK
- ESLint de archivos modificados: OK
- Build: OK
- Supervisor full: APROBADO

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the critical `/api/forja/ship` GitHub integration and error contract users see when publishing; mostly additive UX and clearer permission handling, but misclassification of 403s could still mislead recovery steps.
> 
> **Overview**
> **GitHub ship API** now pins `X-GitHub-Api-Version: 2026-03-10` and treats failed repo creation as a first-class case: it logs a trimmed failure payload, surfaces `x-accepted-github-permissions`, and returns `github_repo_permission` when a 403 looks like missing **administration=write** (vs a generic `repo_create`).
> 
> **Scoped create-app UI** is reworked into a stepped constructor (template cards, brief, multi-select “necesidades”) with a sidebar **plan de construcción** and live GitHub→Vercel status. Errors use titled copy; permission failures link to GitHub app settings and reconnect. The client sends selected `modules` in the ship request (still reflected in README on the server). History and success states get matching layout/copy updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe487435c01f013f151adfb89277b15a9ee148b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->