### PR TITLE
Fix GitHub App installation flow

### DIFF
--- a/app/api/auth/github/callback/route.ts
+++ b/app/api/auth/github/callback/route.ts
@@ -6,9 +6,25 @@ import { normalizarOAuthReturnPath } from "@/lib/connect/oauth-state";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+type GitHubInstallation = {
+  id: number;
+  app_id: number;
+  app_slug?: string;
+  account?: { login?: string } | null;
+  permissions?: Record<string, string>;
+};
+
+const githubHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "vforge",
+});
+
 /**
- * GET /api/auth/github/callback — intercambia code→token, guarda en vault,
- * redirige a /app/setup (stepper) o al puente si aplica.
+ * GET /api/auth/github/callback — intercambia code→token, valida que la
+ * GitHub App esté instalada con Administration:write y sólo entonces
+ * guarda la conexión en el vault.
  */
 export async function GET(req: Request) {
   const { userId } = await auth();
@@ -20,12 +36,15 @@ export async function GET(req: Request) {
   const state = url.searchParams.get("state");
   const jar = await cookies();
   const expected = jar.get("gh_oauth_state")?.value;
+  const installPending = jar.get("gh_install_pending")?.value;
   const bridgeReturnTo = jar.get("gh_bridge_return_to")?.value;
   const bridgeTenant = jar.get("gh_bridge_tenant")?.value;
   const internalReturnPath = normalizarOAuthReturnPath(
     jar.get("gh_oauth_return_path")?.value,
   );
+
   jar.delete("gh_oauth_state");
+  jar.delete("gh_install_pending");
   jar.delete("gh_bridge_return_to");
   jar.delete("gh_bridge_tenant");
   jar.delete("gh_oauth_return_path");
@@ -42,10 +61,16 @@ export async function GET(req: Request) {
   };
 
   if (!code) return back("error_no_code");
-  if (!state || !expected || state !== expected) return back("error_state");
+
+  const validOAuthState = Boolean(state && expected && state === expected);
+  const validInstallCallback = Boolean(
+    !state && expected && installPending && expected === installPending,
+  );
+  if (!validOAuthState && !validInstallCallback) return back("error_state");
 
   const clientId = process.env.GITHUB_APP_CLIENT_ID || "";
   const clientSecret = process.env.GITHUB_APP_CLIENT_SECRET;
+  if (!clientId) return back("error_no_client");
   if (!clientSecret) return back("error_no_secret");
 
   try {
@@ -64,29 +89,89 @@ export async function GET(req: Request) {
       refresh_token?: string;
       error?: string;
     };
-    if (!data.access_token) {
-      console.error("[gh oauth] sin access_token:", data.error);
+    if (!tokenRes.ok || !data.access_token) {
+      console.error("[gh oauth] token exchange failed", {
+        status: tokenRes.status,
+        error: data.error,
+      });
       return back("error_token");
     }
 
-    await saveUserSecret(userId, "GITHUB_USER_TOKEN", data.access_token, "github");
-    if (data.refresh_token) {
-      await saveUserSecret(userId, "GITHUB_REFRESH_TOKEN", data.refresh_token, "github");
+    const installationsRes = await fetch(
+      "https://api.github.com/user/installations?per_page=100",
+      { headers: githubHeaders(data.access_token) },
+    );
+    if (!installationsRes.ok) {
+      console.error("[gh oauth] installation lookup failed", {
+        status: installationsRes.status,
+      });
+      return back("error_installation_check");
+    }
+
+    const installationsData = (await installationsRes.json()) as {
+      installations?: GitHubInstallation[];
+    };
+    const appId = Number(process.env.GITHUB_APP_ID || "3696759");
+    const appSlug = process.env.GITHUB_APP_SLUG || "v-forge-momentum";
+    const installation = installationsData.installations?.find(
+      (item) => item.app_id === appId || item.app_slug === appSlug,
+    );
+
+    if (!installation) {
+      console.error("[gh oauth] app not installed for authorized user", {
+        userId,
+        appId,
+      });
+      return back("error_installation_required");
+    }
+    if (installation.permissions?.administration !== "write") {
+      console.error("[gh oauth] installation missing administration:write", {
+        userId,
+        installationId: installation.id,
+      });
+      return back("error_installation_permission");
     }
 
     let login: string | null = null;
     try {
       const who = await fetch("https://api.github.com/user", {
-        headers: { Authorization: `Bearer ${data.access_token}`, "User-Agent": "vforge" },
+        headers: githubHeaders(data.access_token),
       });
       if (who.ok) {
-        const u = (await who.json()) as { login?: string };
-        if (u.login) {
-          login = "@" + u.login;
-          await saveUserSecret(userId, "GITHUB_LOGIN", login, "github");
-        }
+        const githubUser = (await who.json()) as { login?: string };
+        if (githubUser.login) login = "@" + githubUser.login;
       }
-    } catch { /* no crítico */ }
+    } catch {
+      // El login es informativo; la instalación validada es la autoridad.
+    }
+
+    // Guardar únicamente después de validar instalación y permisos.
+    await saveUserSecret(userId, "GITHUB_USER_TOKEN", data.access_token, "github");
+    await saveUserSecret(
+      userId,
+      "GITHUB_INSTALLATION_ID",
+      String(installation.id),
+      "github",
+    );
+    if (installation.account?.login) {
+      await saveUserSecret(
+        userId,
+        "GITHUB_INSTALLATION_ACCOUNT",
+        installation.account.login,
+        "github",
+      );
+    }
+    if (data.refresh_token) {
+      await saveUserSecret(
+        userId,
+        "GITHUB_REFRESH_TOKEN",
+        data.refresh_token,
+        "github",
+      );
+    }
+    if (login) {
+      await saveUserSecret(userId, "GITHUB_LOGIN", login, "github");
+    }
 
     if (bridgeReturnTo && bridgeTenant) {
       try {
@@ -104,18 +189,24 @@ export async function GET(req: Request) {
               access_token: data.access_token,
               refresh_token: data.refresh_token || null,
               login,
+              installation_id: installation.id,
+              installation_account: installation.account?.login || null,
               source: "vforge-bridge",
             }),
           });
         }
-      } catch (e) {
-        console.error("[gh oauth bridge] fallo:", e);
+      } catch (error) {
+        console.error("[gh oauth bridge] delivery failed", {
+          message: error instanceof Error ? error.message : String(error),
+        });
       }
     }
 
     return back("connected");
-  } catch (e) {
-    console.error("[gh oauth] fallo:", e);
+  } catch (error) {
+    console.error("[gh oauth] callback failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return back("error_exchange");
   }
 }

--- a/app/api/auth/github/start/route.ts
+++ b/app/api/auth/github/start/route.ts
@@ -25,23 +25,25 @@ function returnToPermitido(url: string | null): string | null {
 }
 
 /**
- * GET /api/auth/github/start — inicia el OAuth de la GitHub App
- * "v-Forge-momentum". Redirige al usuario a GitHub para autorizar con un
- * click (sin pegar tokens). Guarda un `state` anti-CSRF en cookie.
+ * GET /api/auth/github/start — inicia la instalación de la GitHub App
+ * "v-Forge-momentum". GitHub instala la App y, con "Request user
+ * authorization during installation" habilitado, continúa al OAuth.
  *
- * Puente multi-app: si llega ?return_to=&tenant=, ademas de guardar el
- * token para VForge (comportamiento de siempre, sin cambios), el callback
- * tambien lo entrega server-a-server a la app que lo pidio (ej V-Admin)
- * y regresa al usuario a esa app en vez de a /onboarding. Esto evita
- * registrar una GitHub App nueva o tocar el Callback URL (un solo campo,
- * ya en uso por VForge) — VForge sigue siendo el unico dueno del flujo.
+ * Puente multi-app: si llega ?return_to=&tenant=, además de guardar el
+ * token para VForge, el callback lo entrega server-a-server a la app que
+ * lo pidió y regresa al usuario a esa app.
  */
 export async function GET(req: Request) {
   const { userId } = await auth();
   if (!userId) return Response.redirect(new URL("/sign-in", siteUrl()), 302);
 
   const clientId = process.env.GITHUB_APP_CLIENT_ID || "";
-  if (!clientId) return Response.redirect(new URL("/onboarding?github=error_no_client", siteUrl()), 302);
+  if (!clientId) {
+    return Response.redirect(
+      new URL("/onboarding?github=error_no_client", siteUrl()),
+      302,
+    );
+  }
 
   const reqUrl = new URL(req.url);
   const returnTo = returnToPermitido(reqUrl.searchParams.get("return_to"));
@@ -55,48 +57,31 @@ export async function GET(req: Request) {
   jar.delete("gh_bridge_return_to");
   jar.delete("gh_bridge_tenant");
   jar.delete("gh_oauth_return_path");
-  jar.set("gh_oauth_state", state, {
+  jar.delete("gh_install_pending");
+
+  const cookieOptions = {
     httpOnly: true,
     secure: true,
-    sameSite: "lax",
+    sameSite: "lax" as const,
     maxAge: 600,
     path: "/",
-  });
+  };
+  jar.set("gh_oauth_state", state, cookieOptions);
+  // GitHub no siempre devuelve state en el OAuth iniciado automáticamente
+  // después de instalar. Esta cookie liga el callback al inicio hecho en
+  // el mismo navegador y a la sesión Clerk ya autenticada.
+  jar.set("gh_install_pending", state, cookieOptions);
 
   if (returnTo) {
-    jar.set("gh_bridge_return_to", returnTo, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "lax",
-      maxAge: 600,
-      path: "/",
-    });
-    if (tenant) {
-      jar.set("gh_bridge_tenant", tenant, {
-        httpOnly: true,
-        secure: true,
-        sameSite: "lax",
-        maxAge: 600,
-        path: "/",
-      });
-    }
+    jar.set("gh_bridge_return_to", returnTo, cookieOptions);
+    if (tenant) jar.set("gh_bridge_tenant", tenant, cookieOptions);
   } else {
-    jar.set("gh_oauth_return_path", internalReturnTo, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "lax",
-      maxAge: 600,
-      path: "/",
-    });
+    jar.set("gh_oauth_return_path", internalReturnTo, cookieOptions);
   }
 
-  const redirectUri = `${siteUrl()}/api/auth/github/callback`;
-  const url = new URL("https://github.com/login/oauth/authorize");
-  url.searchParams.set("client_id", clientId);
-  url.searchParams.set("redirect_uri", redirectUri);
+  const appSlug = process.env.GITHUB_APP_SLUG || "v-forge-momentum";
+  const url = new URL(`https://github.com/apps/${appSlug}/installations/new`);
   url.searchParams.set("state", state);
-  // La GitHub App pide autorización OAuth del usuario; los scopes los
-  // define la app. No mandamos scope extra (lo gobierna la App).
   return Response.redirect(url.toString(), 302);
 }
 

--- a/lib/connect/clerk-oauth-sync.ts
+++ b/lib/connect/clerk-oauth-sync.ts
@@ -4,11 +4,10 @@ import { getUserSecret, saveUserSecret } from "@/lib/connect/user-vault";
 /**
  * Mirror de tokens OAuth de Clerk → user_vault.
  *
- * Cuando un usuario conecta GitHub/Vercel como social connection de Clerk,
- * Clerk custodia el access token y lo entrega (refrescado) vía Backend API.
- * Aquí lo copiamos a user_secrets (GITHUB_USER_TOKEN / VERCEL_USER_TOKEN) para
- * que VForge lo use directamente —igual que un token pegado a mano o por el
- * flujo OAuth propio— sin pedirle al usuario un segundo OAuth.
+ * Vercel sí puede reutilizar su conexión social de Clerk. GitHub no: el token
+ * social no prueba que la GitHub App de VForge esté instalada ni que tenga
+ * Administration:write, por lo que GitHub sólo se considera disponible tras
+ * completar el flujo propio de instalación + OAuth.
  */
 
 // Respuesta de cc.users.getUserOauthAccessToken según versión del SDK:
@@ -56,29 +55,19 @@ export interface ClerkSyncResult {
 }
 
 /**
- * Espeja a user_vault los tokens OAuth que el usuario ya tenga conectados en
- * Clerk. Idempotente y best-effort: si el vault ya tiene el token NO llama a
- * Clerk (evita latencia); si no, lo trae y lo guarda. Devuelve qué proveedores
- * quedaron disponibles tras el sync.
+ * Espeja a user_vault el token de Vercel que el usuario ya tenga conectado en
+ * Clerk. Para GitHub únicamente reporta true si ya existe una conexión propia
+ * validada (token + installation ID); nunca importa el token social de Clerk.
  */
 export async function syncClerkOAuthTokens(userId: string): Promise<ClerkSyncResult> {
-  const [ghExisting, vcExisting] = await Promise.all([
+  const [ghExisting, ghInstallation, vcExisting] = await Promise.all([
     getUserSecret(userId, "GITHUB_USER_TOKEN"),
+    getUserSecret(userId, "GITHUB_INSTALLATION_ID"),
     getUserSecret(userId, "VERCEL_USER_TOKEN"),
   ]);
 
-  let github = Boolean(ghExisting);
+  const github = Boolean(ghExisting && ghInstallation);
   let vercel = Boolean(vcExisting);
-
-  if (!github) {
-    const token = await getClerkOauthToken(userId, ["github", "oauth_github"]);
-    if (token) {
-      await saveUserSecret(userId, "GITHUB_USER_TOKEN", token, "github-clerk").catch(
-        () => {},
-      );
-      github = true;
-    }
-  }
 
   if (!vercel) {
     const token = await getClerkOauthToken(userId, [

--- a/lib/connect/user-vault.ts
+++ b/lib/connect/user-vault.ts
@@ -73,8 +73,8 @@ export async function getUserSecret(
   try {
     return decryptOperatorSecret({
       ciphertext: Buffer.from(rows[0].ciphertext, "hex"),
-      iv:         Buffer.from(rows[0].iv, "hex"),
-      authTag:    Buffer.from(rows[0].auth_tag, "hex"),
+      iv: Buffer.from(rows[0].iv, "hex"),
+      authTag: Buffer.from(rows[0].auth_tag, "hex"),
     });
   } catch {
     return null;
@@ -82,15 +82,30 @@ export async function getUserSecret(
 }
 
 /**
- * Lista los servicios conectados del usuario.
+ * Lista los servicios realmente conectados del usuario.
+ * GitHub sólo cuenta cuando existen tanto el token OAuth como una instalación
+ * validada de la App; un token aislado ya no produce un falso "Conectado".
  */
 export async function listUserConnections(userId: string): Promise<string[]> {
   const sql = getDb();
   const rows = (await sql`
-    SELECT DISTINCT scope FROM user_secrets
+    SELECT name, scope FROM user_secrets
     WHERE user_id = ${userId} AND scope IS NOT NULL
-  `) as Array<{ scope: string }>;
-  return rows.map((r) => r.scope).filter(Boolean);
+  `) as Array<{ name: string; scope: string }>;
+
+  const names = new Set(rows.map((row) => row.name));
+  const scopes = new Set(rows.map((row) => row.scope).filter(Boolean));
+
+  scopes.delete("github");
+  scopes.delete("github-clerk");
+  if (
+    names.has("GITHUB_USER_TOKEN") &&
+    names.has("GITHUB_INSTALLATION_ID")
+  ) {
+    scopes.add("github");
+  }
+
+  return Array.from(scopes);
 }
 
 /**
@@ -101,7 +116,9 @@ export async function markOnboardingDone(clerkId: string): Promise<void> {
   // Columna onboarding_done puede no existir — silencioso si falla
   try {
     await sql`UPDATE users SET role = 'member' WHERE id = ${clerkId}`;
-  } catch { /* ok */ }
+  } catch {
+    /* ok */
+  }
 }
 
 /**


### PR DESCRIPTION
## Qué corrige
- Instala `v-forge-momentum` antes de iniciar OAuth.
- Valida la instalación de la App y `Administration: write` antes de guardar el token.
- Guarda `GITHUB_INSTALLATION_ID` y cuenta de instalación.
- Evita el falso estado “Conectado” cuando sólo existe un token.
- Impide que el token social de Clerk sustituya la conexión validada de la GitHub App.

## Verificación
- `npm run typecheck`
- ESLint de archivos modificados
- `npm run build`
- Revisión integral del supervisor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, token storage, and what counts as a valid GitHub integration; existing users with Clerk-only or legacy tokens may need to reconnect through the new install flow.
> 
> **Overview**
> **GitHub connect now goes through App installation first**, then OAuth, instead of starting at the standard OAuth authorize URL. The start route redirects to `github.com/apps/.../installations/new` and sets a **`gh_install_pending`** cookie so the callback can still validate CSRF when GitHub omits `state` after install.
> 
> **The callback refuses to persist credentials until the App is really usable:** after code→token it loads the user’s installations, finds the configured VForge app, and requires **`administration: write`**. Only then it writes **`GITHUB_USER_TOKEN`**, **`GITHUB_INSTALLATION_ID`**, optional installation account/login/refresh, and forwards **`installation_id`** on the multi-app bridge. New redirect statuses cover missing client, failed installation lookup, missing install, and insufficient permissions.
> 
> **“Connected” for GitHub is tightened everywhere:** Clerk social GitHub tokens are no longer mirrored into the vault; sync and **`listUserConnections`** treat GitHub as connected only when both a user token and an installation ID exist, so orphan tokens no longer show as connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32fa53b1710c8c20c2c5d76124fb62d588257f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->