### PR TITLE
Improve non-owner workspace UX

### DIFF
--- a/components/workspace/ScopedCreateApp.tsx
+++ b/components/workspace/ScopedCreateApp.tsx
@@ -213,13 +213,16 @@ export function ScopedCreateApp({
   const connectionsReady = githubConnected && vercelConnected;
   const githubState = error?.permission
     ? "error"
-    : result?.ok || githubConnected
-      ? "done"
-      : creating
-        ? "active"
+    : creating
+      ? "active"
+      : result?.ok || githubConnected
+        ? "done"
         : "idle";
-  const vercelState =
-    result?.ok || vercelConnected ? "done" : creating ? "waiting" : "idle";
+  const vercelState = creating
+    ? "waiting"
+    : result?.ok || vercelConnected
+      ? "done"
+      : "idle";
 
   return (
     <section className="mt-12 sm:mt-16" aria-labelledby="create-app-title">

--- a/components/workspace/ScopedCreateApp.tsx
+++ b/components/workspace/ScopedCreateApp.tsx
@@ -31,6 +31,7 @@ interface BuilderError {
   title: string;
   message: string;
   permission?: boolean;
+  service?: "github" | "vercel";
 }
 
 const templates = [
@@ -79,7 +80,13 @@ function detailMessage(detail: unknown): string {
   }
 }
 
-export function ScopedCreateApp() {
+export function ScopedCreateApp({
+  githubConnected,
+  vercelConnected,
+}: {
+  githubConnected: boolean;
+  vercelConnected: boolean;
+}) {
   const [apps, setApps] = useState<GeneratedApp[]>([]);
   const [loadingApps, setLoadingApps] = useState(true);
   const [name, setName] = useState("");
@@ -100,7 +107,7 @@ export function ScopedCreateApp() {
     try {
       const response = await fetch("/api/forja/apps", { cache: "no-store" });
       const payload = (await response.json()) as { apps?: GeneratedApp[] };
-      setApps(response.ok ? payload.apps ?? [] : []);
+      setApps(response.ok ? (payload.apps ?? []) : []);
     } catch {
       setApps([]);
     } finally {
@@ -144,12 +151,16 @@ export function ScopedCreateApp() {
         if (payload.error === "connect_github") {
           setError({
             title: "Falta conectar GitHub",
-            message: "Conecta tu cuenta y vuelve a intentar desde este mismo espacio.",
+            message:
+              "Conecta tu cuenta y vuelve a intentar desde este mismo espacio.",
+            service: "github",
           });
         } else if (payload.error === "connect_vercel") {
           setError({
             title: "Falta conectar Vercel",
-            message: "Conecta tu cuenta para que VForge pueda publicar el proyecto.",
+            message:
+              "Conecta tu cuenta para que VForge pueda publicar el proyecto.",
+            service: "vercel",
           });
         } else if (payload.error === "github_repo_permission") {
           setError({
@@ -157,10 +168,12 @@ export function ScopedCreateApp() {
             message:
               "Tu cuenta está conectada, pero la instalación todavía no autoriza crear repositorios. Actualiza el acceso de VForge en GitHub y vuelve a publicar.",
             permission: true,
+            service: "github",
           });
         } else if (payload.error === "repo_create") {
           setError({
             title: "GitHub rechazó el repositorio",
+            service: "github",
             message:
               detailMessage(payload.detail) ||
               "Revisa el acceso de la integración e intenta nuevamente.",
@@ -168,13 +181,15 @@ export function ScopedCreateApp() {
         } else if (payload.error === "deploy") {
           setError({
             title: "El repositorio se creó, pero falta publicar",
+            service: "vercel",
             message:
               "Vercel rechazó el despliegue. Tu código quedó seguro en GitHub para reintentarlo.",
           });
         } else {
           setError({
             title: "La construcción no terminó",
-            message: "VForge conservó tu brief. Intenta nuevamente en un momento.",
+            message:
+              "VForge conservó tu brief. Intenta nuevamente en un momento.",
           });
         }
         return;
@@ -195,18 +210,16 @@ export function ScopedCreateApp() {
     }
   }
 
+  const connectionsReady = githubConnected && vercelConnected;
   const githubState = error?.permission
     ? "error"
-    : result?.ok
+    : result?.ok || githubConnected
       ? "done"
       : creating
         ? "active"
         : "idle";
-  const vercelState = result?.ok
-    ? "done"
-    : creating
-      ? "waiting"
-      : "idle";
+  const vercelState =
+    result?.ok || vercelConnected ? "done" : creating ? "waiting" : "idle";
 
   return (
     <section className="mt-12 sm:mt-16" aria-labelledby="create-app-title">
@@ -221,8 +234,8 @@ export function ScopedCreateApp() {
           </h2>
         </div>
         <p className="max-w-sm text-[12px] leading-5 text-[var(--fg-secondary)] sm:text-right">
-          Elige una dirección, define lo necesario y VForge prepara el repo y
-          la publicación con tus propias cuentas.
+          Elige una dirección, define lo necesario y VForge prepara el repo y la
+          publicación con tus propias cuentas.
         </p>
       </div>
 
@@ -355,7 +368,9 @@ export function ScopedCreateApp() {
             </p>
             <p className="mt-2 text-[12px] leading-5 text-[var(--fg-secondary)]">
               {selectedTemplate.label}
-              {modules.length ? ` · ${modules.length} necesidades` : " · Base inicial"}
+              {modules.length
+                ? ` · ${modules.length} necesidades`
+                : " · Base inicial"}
             </p>
           </div>
 
@@ -394,6 +409,34 @@ export function ScopedCreateApp() {
             </div>
           </div>
 
+          {!connectionsReady ? (
+            <div className="mb-5 border border-[var(--color-ink)] bg-[var(--color-surface)] p-4">
+              <p className="text-[13px] font-medium">Termina tus conexiones</p>
+              <p className="mt-1 text-[11px] leading-5 text-[var(--fg-secondary)]">
+                VForge necesita ambas cuentas antes de crear y publicar. Tu
+                brief no se perderá.
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {!githubConnected ? (
+                  <a
+                    href="/api/auth/github/start?return_to=/workspace"
+                    className="btn-primary !min-h-9 !px-3"
+                  >
+                    Conectar GitHub
+                  </a>
+                ) : null}
+                {!vercelConnected ? (
+                  <a
+                    href="/api/auth/vercel/start?return_to=/workspace"
+                    className="btn-primary !min-h-9 !px-3"
+                  >
+                    Conectar Vercel
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+
           <label className="inline-flex items-start gap-3 text-[11px] leading-4 text-[var(--fg-secondary)]">
             <input
               type="checkbox"
@@ -412,7 +455,7 @@ export function ScopedCreateApp() {
           <button
             type="button"
             onClick={createApp}
-            disabled={creating || !name.trim()}
+            disabled={creating || !name.trim() || !connectionsReady}
             className="mt-6 flex min-h-14 w-full items-center justify-center gap-2 bg-[var(--color-ink)] px-5 text-[12px] font-medium text-[var(--color-background)] transition hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-30"
           >
             {creating ? (
@@ -420,6 +463,8 @@ export function ScopedCreateApp() {
                 <IconLoader size={14} className="animate-spin" />
                 VForge está construyendo
               </>
+            ) : !connectionsReady ? (
+              <>Completa GitHub y Vercel primero</>
             ) : (
               <>
                 Construir y publicar <IconArrowR size={13} />
@@ -440,24 +485,21 @@ export function ScopedCreateApp() {
                 <p className="mt-2 text-[11px] leading-5 text-[var(--fg-secondary)]">
                   {error.message}
                 </p>
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {error.permission ? (
+                {error.service ? (
+                  <div className="mt-4">
                     <a
-                      href="https://github.com/settings/installations"
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      href={
+                        error.service === "github"
+                          ? "/api/auth/github/start?return_to=/workspace"
+                          : "/api/auth/vercel/start?return_to=/workspace"
+                      }
                       className="btn-primary !min-h-9 !px-3"
                     >
-                      Revisar acceso en GitHub
+                      Reparar conexión de{" "}
+                      {error.service === "github" ? "GitHub" : "Vercel"}
                     </a>
-                  ) : null}
-                  <a
-                    href="/api/auth/github/start?return_to=/workspace"
-                    className="btn-ghost !min-h-9 !px-3"
-                  >
-                    Reconectar
-                  </a>
-                </div>
+                  </div>
+                ) : null}
               </div>
             ) : null}
 
@@ -517,7 +559,9 @@ export function ScopedCreateApp() {
           </div>
         ) : apps.length === 0 ? (
           <div className="border-x border-b border-[var(--border-1)] p-5">
-            <p className="text-[13px]">Tu primera publicación aparecerá aquí.</p>
+            <p className="text-[13px]">
+              Tu primera publicación aparecerá aquí.
+            </p>
             <p className="mt-1 text-[11px] text-[var(--fg-muted)]">
               Sin proyectos heredados ni cuentas mezcladas.
             </p>

--- a/components/workspace/ScopedWorkspaceHome.tsx
+++ b/components/workspace/ScopedWorkspaceHome.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { UserButton } from "@clerk/nextjs";
+import { SignOutButton, UserButton } from "@clerk/nextjs";
 import { VWordmark } from "@/components/brand/VMark";
 import {
   IconArrowR,
@@ -37,6 +37,7 @@ export function ScopedWorkspaceHome({
 }) {
   const githubConnected = connections.includes("github");
   const vercelConnected = connections.includes("vercel");
+  const connectedCount = Number(githubConnected) + Number(vercelConnected);
   const connectionItems = [
     {
       id: "github",
@@ -65,34 +66,66 @@ export function ScopedWorkspaceHome({
           <Link href="/workspace" aria-label="VForge, tu espacio de trabajo">
             <VWordmark />
           </Link>
-          <div className="flex items-center gap-2 rounded-full border border-[var(--border-1)] bg-[var(--color-surface)] py-1 pl-1 pr-3">
-            <UserButton
-              afterSignOutUrl="/"
-              appearance={{
-                ...monochromeClerkAppearance,
-                elements: {
-                  ...monochromeClerkAppearance.elements,
-                  avatarBox: "h-7 w-7",
-                },
-              }}
-            />
-            <span className="hidden max-w-[150px] truncate text-[11px] font-medium sm:block">
-              {name || email}
-            </span>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 rounded-full border border-[var(--border-1)] bg-[var(--color-surface)] py-1 pl-1 pr-3">
+              <UserButton
+                afterSignOutUrl="/"
+                appearance={{
+                  ...monochromeClerkAppearance,
+                  elements: {
+                    ...monochromeClerkAppearance.elements,
+                    avatarBox: "h-7 w-7",
+                  },
+                }}
+              />
+              <span className="hidden max-w-[150px] truncate text-[11px] font-medium sm:block">
+                {name || email}
+              </span>
+            </div>
+            <SignOutButton redirectUrl="/">
+              <button
+                type="button"
+                className="min-h-9 border border-[var(--border-1)] px-3 text-[10px] font-medium transition hover:border-[var(--color-ink)]"
+              >
+                Cerrar sesión
+              </button>
+            </SignOutButton>
           </div>
         </div>
       </header>
 
-      <div className="mx-auto max-w-[1180px] px-4 py-10 sm:px-6 sm:py-16">
+      <div className="mx-auto max-w-[1180px] px-4 py-8 sm:px-6 sm:py-12">
         <p className="mono-label">Tu workspace</p>
-        <h1 className="mt-4 max-w-3xl text-[clamp(2.8rem,8vw,6.8rem)] font-semibold leading-[0.88] tracking-[-0.07em]">
-          Tu espacio ya está listo.
+        <h1 className="mt-3 max-w-4xl text-[clamp(2.6rem,6vw,5.4rem)] font-semibold leading-[0.9] tracking-[-0.065em]">
+          Construye con tus propias cuentas.
         </h1>
         <p className="mt-6 max-w-2xl break-words text-[15px] leading-7 text-[var(--fg-secondary)] sm:text-[17px]">
           Esta cuenta pertenece a {email}. No necesitas una invitación: conecta
           tus propias herramientas y VForge mantendrá tus accesos separados de
           los de cualquier otra persona.
         </p>
+
+        <div className="mt-7 grid border border-[var(--color-ink)] bg-[var(--color-surface)] sm:grid-cols-[180px_1fr_auto] sm:items-center">
+          <div className="border-b border-[var(--border-1)] p-4 sm:border-b-0 sm:border-r">
+            <p className="font-mono text-[9px] uppercase tracking-[0.15em] text-[var(--fg-muted)]">
+              Preparación
+            </p>
+            <p className="mt-1 text-[24px] font-medium tracking-[-0.04em]">
+              {connectedCount}/2 listas
+            </p>
+          </div>
+          <p className="border-b border-[var(--border-1)] p-4 text-[12px] leading-5 text-[var(--fg-secondary)] sm:border-b-0">
+            {connectedCount === 2
+              ? "GitHub y Vercel están listos. Ya puedes construir y publicar."
+              : "Completa las conexiones pendientes. Puedes reconectar cualquiera en todo momento."}
+          </p>
+          <a
+            href="#connections-title"
+            className="m-3 inline-flex min-h-10 items-center justify-center border border-[var(--color-ink)] px-4 text-[11px] font-medium"
+          >
+            Gestionar conexiones
+          </a>
+        </div>
 
         <section className="mt-10 sm:mt-14" aria-labelledby="connections-title">
           <div className="flex items-end justify-between gap-4 border-b border-[var(--color-ink)] pb-4">
@@ -112,7 +145,15 @@ export function ScopedWorkspaceHome({
           </div>
           <div className="grid md:grid-cols-2">
             {connectionItems.map(
-              ({ id, title, body, connected, href, signupHref, icon: Icon }) => (
+              ({
+                id,
+                title,
+                body,
+                connected,
+                href,
+                signupHref,
+                icon: Icon,
+              }) => (
                 <article
                   key={id}
                   className="flex min-h-[170px] flex-col border-b border-x border-[var(--border-1)] bg-[var(--color-surface)] p-5 sm:p-6 md:first:border-r-0"
@@ -138,7 +179,17 @@ export function ScopedWorkspaceHome({
                       {body}
                     </p>
                     {connected ? (
-                      <span className="text-[11px] font-medium">Listo</span>
+                      <div className="flex w-full items-center justify-between gap-3 sm:w-auto">
+                        <span className="inline-flex items-center gap-1 text-[11px] font-medium">
+                          <IconCheck size={11} /> Listo
+                        </span>
+                        <a
+                          href={href}
+                          className="btn-ghost !min-h-10 !px-3 text-center !leading-4"
+                        >
+                          Reconectar
+                        </a>
+                      </div>
                     ) : (
                       <div className="flex w-full gap-2 sm:w-auto">
                         <a
@@ -164,7 +215,10 @@ export function ScopedWorkspaceHome({
           </div>
         </section>
 
-        <ScopedCreateApp />
+        <ScopedCreateApp
+          githubConnected={githubConnected}
+          vercelConnected={vercelConnected}
+        />
 
         <section className="mt-12 sm:mt-16" aria-labelledby="projects-title">
           <p className="mono-label">Paso 03</p>
@@ -182,48 +236,54 @@ export function ScopedWorkspaceHome({
               </h3>
               <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--fg-secondary)]">
                 Puedes empezar desde cero con tus propias conexiones. Si alguien
-                comparte una sala con {email}, también aparecerá aquí sin mezclar
-                cuentas, repositorios ni secretos.
+                comparte una sala con {email}, también aparecerá aquí sin
+                mezclar cuentas, repositorios ni secretos.
               </p>
             </div>
           ) : (
             <div className="mt-5 grid gap-3 md:grid-cols-2">
               {projects.map((project) => {
-              const href =
-                project.access_kind === "live"
-                  ? `/app/live/${encodeURIComponent(project.id)}`
-                  : `/workspace/proyecto/${encodeURIComponent(project.id)}`;
-              const destination = project.domain || project.vercel_url;
-              return (
-                <Link
-                  key={project.id}
-                  href={href}
-                  className="group flex min-h-[210px] flex-col border border-[var(--border-1)] bg-[var(--color-surface)] p-5 transition-colors hover:border-[var(--color-ink)] sm:p-6"
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <span className="inline-flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.13em] text-[var(--fg-muted)]">
-                      <span className="status-shape" data-active="true" />
-                      {ROLE_LABEL[project.member_role] ?? project.member_role}
-                    </span>
-                    <IconLayout size={15} />
-                  </div>
-                  <h2 className="mt-8 text-[28px] font-medium tracking-[-0.05em]">
-                    {project.name}
-                  </h2>
-                  <p className="mt-2 font-mono text-[9px] uppercase tracking-[0.11em] text-[var(--fg-muted)]">
-                    {project.status}
-                  </p>
-                  <div className="mt-auto flex items-end justify-between gap-4 pt-8">
-                    <span className="flex min-w-0 items-center gap-2 text-[10px] text-[var(--fg-secondary)]">
-                      <IconGlobe size={11} className="shrink-0" />
-                      <span className="truncate">{destination || "Sala privada"}</span>
-                    </span>
-                    <span className="inline-flex shrink-0 items-center gap-2 text-[11px] font-medium">
-                      Abrir <IconArrowR size={12} className="transition-transform group-hover:translate-x-1" />
-                    </span>
-                  </div>
-                </Link>
-              );
+                const href =
+                  project.access_kind === "live"
+                    ? `/app/live/${encodeURIComponent(project.id)}`
+                    : `/workspace/proyecto/${encodeURIComponent(project.id)}`;
+                const destination = project.domain || project.vercel_url;
+                return (
+                  <Link
+                    key={project.id}
+                    href={href}
+                    className="group flex min-h-[210px] flex-col border border-[var(--border-1)] bg-[var(--color-surface)] p-5 transition-colors hover:border-[var(--color-ink)] sm:p-6"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <span className="inline-flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.13em] text-[var(--fg-muted)]">
+                        <span className="status-shape" data-active="true" />
+                        {ROLE_LABEL[project.member_role] ?? project.member_role}
+                      </span>
+                      <IconLayout size={15} />
+                    </div>
+                    <h2 className="mt-8 text-[28px] font-medium tracking-[-0.05em]">
+                      {project.name}
+                    </h2>
+                    <p className="mt-2 font-mono text-[9px] uppercase tracking-[0.11em] text-[var(--fg-muted)]">
+                      {project.status}
+                    </p>
+                    <div className="mt-auto flex items-end justify-between gap-4 pt-8">
+                      <span className="flex min-w-0 items-center gap-2 text-[10px] text-[var(--fg-secondary)]">
+                        <IconGlobe size={11} className="shrink-0" />
+                        <span className="truncate">
+                          {destination || "Sala privada"}
+                        </span>
+                      </span>
+                      <span className="inline-flex shrink-0 items-center gap-2 text-[11px] font-medium">
+                        Abrir{" "}
+                        <IconArrowR
+                          size={12}
+                          className="transition-transform group-hover:translate-x-1"
+                        />
+                      </span>
+                    </div>
+                  </Link>
+                );
               })}
             </div>
           )}


### PR DESCRIPTION
## Mejora
- Reconexión siempre visible para GitHub y Vercel, incluso en estado conectado.
- Cierre de sesión explícito en el encabezado.
- Resumen de preparación 0/2–2/2.
- Constructor bloqueado hasta validar ambas conexiones.
- Acciones de reparación específicas para GitHub o Vercel.
- Hero más compacto para priorizar controles y trabajo.

## Verificación
- TypeScript OK
- ESLint OK
- Next.js build OK
- Auditoría de contraste sin regresión: main 163 / rama 163

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cambios solo de UI y gating en el cliente; no alteran APIs de ship ni lógica de auth en servidor.
> 
> **Overview**
> Mejora el flujo del workspace para que **GitHub y Vercel sean requisitos visibles** antes de construir, con reconexión y reparación más claras.
> 
> En **`ScopedWorkspaceHome`**: hero más compacto y mensaje orientado a “tus propias cuentas”; bloque **Preparación** con contador **0/2–2/2** y enlace a conexiones; **Cerrar sesión** explícito en el header; en tarjetas ya conectadas aparece **Reconectar** además del estado “Listo”. Se pasan `githubConnected` y `vercelConnected` al constructor.
> 
> En **`ScopedCreateApp`**: el botón **Construir y publicar** queda deshabilitado hasta que ambas conexiones estén listas, con aviso lateral y CTAs de OAuth para lo que falte. El plan de construcción refleja el estado real de conexión (no solo éxito tras un ship). Los errores de ship llevan `service` (`github` | `vercel`) y un único CTA **Reparar conexión** vía `/api/auth/.../start?return_to=/workspace`, sustituyendo el enlace genérico a instalaciones de GitHub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f944cbeb6492a19a8633974c163ff935f3d5f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->