### PR TITLE
Repair existing GitHub App installations

### DIFF
--- a/app/api/auth/github/start/route.ts
+++ b/app/api/auth/github/start/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@clerk/nextjs/server";
 import { randomBytes } from "node:crypto";
 import { cookies } from "next/headers";
 import { normalizarOAuthReturnPath } from "@/lib/connect/oauth-state";
+import { getUserSecret, saveUserSecret } from "@/lib/connect/user-vault";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,6 +22,68 @@ function returnToPermitido(url: string | null): string | null {
     return ok ? url : null;
   } catch {
     return null;
+  }
+}
+
+type GitHubInstallation = {
+  id: number;
+  app_id: number;
+  app_slug?: string;
+  account?: { login?: string } | null;
+  permissions?: Record<string, string>;
+};
+
+async function repairExistingInstallation(userId: string): Promise<boolean> {
+  const token = await getUserSecret(userId, "GITHUB_USER_TOKEN");
+  if (!token) return false;
+
+  try {
+    const response = await fetch(
+      "https://api.github.com/user/installations?per_page=100",
+      {
+        headers: {
+          Authorization: `Bearer `,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "vforge",
+        },
+        cache: "no-store",
+      },
+    );
+    if (!response.ok) return false;
+
+    const data = (await response.json()) as {
+      installations?: GitHubInstallation[];
+    };
+    const appId = Number(process.env.GITHUB_APP_ID || "3696759");
+    const appSlug = process.env.GITHUB_APP_SLUG || "v-forge-momentum";
+    const installation = data.installations?.find(
+      (item) => item.app_id === appId || item.app_slug === appSlug,
+    );
+    if (!installation || installation.permissions?.administration !== "write") {
+      return false;
+    }
+
+    await saveUserSecret(
+      userId,
+      "GITHUB_INSTALLATION_ID",
+      String(installation.id),
+      "github",
+    );
+    if (installation.account?.login) {
+      await saveUserSecret(
+        userId,
+        "GITHUB_INSTALLATION_ACCOUNT",
+        installation.account.login,
+        "github",
+      );
+    }
+    return true;
+  } catch (error) {
+    console.error("[gh install repair] lookup failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return false;
   }
 }
 
@@ -51,6 +114,15 @@ export async function GET(req: Request) {
     reqUrl.searchParams.get("return_to"),
   );
   const tenant = reqUrl.searchParams.get("tenant");
+
+  // Migración transparente para instalaciones creadas antes del flujo actual.
+  // Si el token existente ya ve la App con el permiso correcto, registramos su
+  // installation_id y regresamos sin mandar al usuario a GitHub otra vez.
+  if (!returnTo && (await repairExistingInstallation(userId))) {
+    const destination = new URL(internalReturnTo, siteUrl());
+    destination.searchParams.set("github", "connected");
+    return Response.redirect(destination.toString(), 302);
+  }
 
   const state = randomBytes(16).toString("hex");
   const jar = await cookies();

--- a/app/api/auth/github/start/route.ts
+++ b/app/api/auth/github/start/route.ts
@@ -42,7 +42,7 @@ async function repairExistingInstallation(userId: string): Promise<boolean> {
       "https://api.github.com/user/installations?per_page=100",
       {
         headers: {
-          Authorization: `Bearer `,
+          Authorization: `Bearer ${token}`,
           Accept: "application/vnd.github+json",
           "X-GitHub-Api-Version": "2022-11-28",
           "User-Agent": "vforge",

--- a/app/app/integrations/page.tsx
+++ b/app/app/integrations/page.tsx
@@ -44,7 +44,7 @@ const SERVICES: Service[] = [
     description: "Repositorios y aplicación instalada.",
     Icon: IconGithub,
     mode: "oauth",
-    endpoint: "/api/auth/github/start",
+    endpoint: "/api/auth/github/start?return_to=%2Fapp%2Fintegrations",
   },
   {
     id: "vercel",
@@ -52,7 +52,7 @@ const SERVICES: Service[] = [
     description: "Previews, dominios y producción.",
     Icon: IconGlobe,
     mode: "oauth",
-    endpoint: "/api/auth/vercel/start",
+    endpoint: "/api/auth/vercel/start?return_to=%2Fapp%2Fintegrations",
   },
   {
     id: "stripe",
@@ -60,7 +60,7 @@ const SERVICES: Service[] = [
     description: "Cuenta conectada para pagos.",
     Icon: IconCreditCard,
     mode: "oauth",
-    endpoint: "/api/auth/stripe/start",
+    endpoint: "/api/auth/stripe/start?return_to=%2Fapp%2Fintegrations",
   },
   {
     id: "neon",
@@ -133,9 +133,9 @@ export default function IntegrationsPage() {
         setConnected([]);
       }
 
-      const healthPayload = (await healthResponse.json().catch(() => null)) as
-        | PlatformHealth
-        | null;
+      const healthPayload = (await healthResponse
+        .json()
+        .catch(() => null)) as PlatformHealth | null;
       setHealth(healthPayload);
     } finally {
       setLoading(false);
@@ -166,7 +166,9 @@ export default function IntegrationsPage() {
         error?: string;
       };
       if (!response.ok || !payload.ok) {
-        throw new Error(payload.error || `La conexión respondió HTTP ${response.status}.`);
+        throw new Error(
+          payload.error || `La conexión respondió HTTP ${response.status}.`,
+        );
       }
       setConnected((current) =>
         current.includes(service.id) ? current : [...current, service.id],
@@ -179,7 +181,9 @@ export default function IntegrationsPage() {
       setErrors((current) => ({
         ...current,
         [service.id]:
-          caught instanceof Error ? caught.message : "No se pudo guardar la conexión.",
+          caught instanceof Error
+            ? caught.message
+            : "No se pudo guardar la conexión.",
       }));
     }
   }
@@ -197,7 +201,10 @@ export default function IntegrationsPage() {
             disabled={refreshing}
             className="btn-ghost"
           >
-            <IconRefresh size={12} className={refreshing ? "animate-spin" : ""} />
+            <IconRefresh
+              size={12}
+              className={refreshing ? "animate-spin" : ""}
+            />
             Actualizar
           </button>
         }
@@ -260,7 +267,9 @@ export default function IntegrationsPage() {
                       <service.Icon size={17} />
                     </span>
                     <div className="min-w-0">
-                      <h2 className="text-[14px] font-medium">{service.name}</h2>
+                      <h2 className="text-[14px] font-medium">
+                        {service.name}
+                      </h2>
                       <p className="mt-1 text-[11px] leading-5 text-[var(--fg-muted)]">
                         {service.description}
                       </p>
@@ -276,10 +285,14 @@ export default function IntegrationsPage() {
                   {service.mode === "oauth" ? (
                     <a
                       href={service.endpoint}
-                      className={isConnected ? "btn-ghost w-full" : "btn-primary w-full"}
+                      className={
+                        isConnected ? "btn-ghost w-full" : "btn-primary w-full"
+                      }
                     >
                       <IconLink size={12} />
-                      {isConnected ? `Reconectar ${service.name}` : `Conectar ${service.name}`}
+                      {isConnected
+                        ? `Reconectar ${service.name}`
+                        : `Conectar ${service.name}`}
                     </a>
                   ) : isEditing ? (
                     <div>
@@ -379,7 +392,9 @@ function HealthCell({
           {state ?? "Sin lectura"}
         </span>
         {detail ? (
-          <span className="font-mono text-[9px] text-[var(--fg-muted)]">{detail}</span>
+          <span className="font-mono text-[9px] text-[var(--fg-muted)]">
+            {detail}
+          </span>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Causa raíz
El flujo nuevo enviaba siempre a `/installations/new`. Para cuentas donde V-Forge ya estaba instalada, GitHub mostraba `Configure` y no iniciaba callback; además el owner no llevaba `return_to`, por lo que podía terminar fuera de Integraciones.

## Corrección
- Detecta token e instalación existentes antes de abrir GitHub.
- Valida App ID/slug y `Administration: write`.
- Migra y guarda `GITHUB_INSTALLATION_ID` y cuenta de instalación.
- Regresa directamente a la pantalla original cuando la conexión ya es válida.
- GitHub, Vercel y Stripe del owner conservan `return_to=/app/integrations`.

## Verificación
- TypeScript OK
- ESLint OK
- Build Next.js OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth/connect flow and writes GitHub installation secrets from API lookup; mistakes could skip re-auth when permissions are wrong or mis-route users after connect.
> 
> **Overview**
> **GitHub connect** now short-circuits the install/OAuth redirect when the user already has a stored token and GitHub reports an existing V-Forge app installation with **Administration: write**. In that case the route persists `GITHUB_INSTALLATION_ID` (and account login when present) via the user vault and redirects to the normal post-connect URL with `github=connected`, avoiding another trip through GitHub’s “Configure” screen for legacy installs.
> 
> This repair path runs only when there is no cross-app bridge `return_to` (whitelisted external URL). On **Integrations**, GitHub, Vercel, and Stripe OAuth links now include `return_to=/app/integrations` so successful flows return to that page instead of a default elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f3b303ba27934054a06a0f68eefc6d6a6380fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->