### PR TITLE
fix: sala live con viewports reales y feedback MCP

### DIFF
--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -16,18 +16,13 @@ import { VWordmark } from "@/components/brand/VMark";
 import {
   IconActivity,
   IconArrowL,
-  IconChat,
-  IconCheck,
-  IconCopy,
   IconExtLink,
   IconLayout,
   IconLoader,
   IconMaximize,
   IconMenu,
   IconRefresh,
-  IconSend,
   IconShield,
-  IconSparkles,
   IconUsers,
   IconX,
 } from "@/components/brand/VFIcons";
@@ -58,14 +53,6 @@ interface EventRow {
   ts: string;
 }
 
-interface CommentRow {
-  id: string;
-  author_email: string;
-  author_name: string | null;
-  body: string;
-  created_at: string;
-}
-
 const ROLE_LABEL: Record<LiveRole, string> = {
   owner: "Owner",
   reviewer: "Revisor",
@@ -79,6 +66,39 @@ type WorkspacePanelId =
   | "activity"
   | "comments";
 type WorkspacePreset = "balanced" | "previews" | "review";
+type PreviewKind = "desktop" | "mobile" | "admin";
+
+interface PreviewSpec {
+  width: number;
+  height: number;
+  frameWidth: number;
+  frameHeight: number;
+  label: string;
+}
+
+const PREVIEW_SPECS: Record<PreviewKind, PreviewSpec> = {
+  desktop: {
+    width: 1440,
+    height: 900,
+    frameWidth: 1440,
+    frameHeight: 900,
+    label: "1440 × 900",
+  },
+  mobile: {
+    width: 390,
+    height: 844,
+    frameWidth: 414,
+    frameHeight: 884,
+    label: "390 × 844",
+  },
+  admin: {
+    width: 1280,
+    height: 800,
+    frameWidth: 1280,
+    frameHeight: 800,
+    label: "1280 × 800",
+  },
+};
 
 const PANEL_LABELS: Record<WorkspacePanelId, string> = {
   desktop: "Escritorio",
@@ -293,6 +313,15 @@ function LiveWorkspace({
   }, []);
 
   useEffect(() => {
+    if (!focusedPanel) return;
+    const restoreWorkspace = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setFocusedPanel(null);
+    };
+    window.addEventListener("keydown", restoreWorkspace);
+    return () => window.removeEventListener("keydown", restoreWorkspace);
+  }, [focusedPanel]);
+
+  useEffect(() => {
     try {
       const saved = window.localStorage.getItem(storageKey);
       if (!saved) return;
@@ -424,7 +453,7 @@ function LiveWorkspace({
       </div>
 
       {focusedContent ? (
-        <div className="h-[calc(100dvh-160px)] min-h-[520px] overflow-hidden rounded-[8px] bg-white">
+        <div className="h-[calc(100dvh-160px)] min-h-[520px] overflow-hidden rounded-[8px] bg-white" aria-label="Panel ampliado">
           {focusedContent}
         </div>
       ) : (
@@ -627,12 +656,53 @@ function Viewport({
 }) {
   const [refreshKey, setRefreshKey] = useState(0);
   const url = useMemo(() => normalizeUrl(rawUrl), [rawUrl]);
+  const spec = PREVIEW_SPECS[kind];
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
   const frameClass =
     fill
       ? "min-h-0 flex-1"
       : kind === "mobile"
       ? "min-h-[520px] aspect-[9/16] xl:min-h-[380px] 2xl:min-h-[520px]"
       : "min-h-[380px] aspect-[16/10]";
+
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage || typeof ResizeObserver === "undefined") return;
+
+    const updateSize = (width: number, height: number) => {
+      setStageSize((current) =>
+        Math.abs(current.width - width) < 0.5 &&
+        Math.abs(current.height - height) < 0.5
+          ? current
+          : { width, height },
+      );
+    };
+
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return;
+      updateSize(entry.contentRect.width, entry.contentRect.height);
+    });
+    observer.observe(stage);
+    updateSize(stage.clientWidth, stage.clientHeight);
+    return () => observer.disconnect();
+  }, [kind]);
+
+  const stagePadding = kind === "mobile" ? 20 : 12;
+  const previewScale =
+    stageSize.width > 0 && stageSize.height > 0
+      ? Math.min(
+          Math.max(1, stageSize.width - stagePadding * 2) / spec.frameWidth,
+          Math.max(1, stageSize.height - stagePadding * 2) / spec.frameHeight,
+          1,
+        )
+      : 1;
+  const scaledHeight = spec.frameHeight * previewScale;
+  const previewTop = Math.max(
+    stagePadding,
+    (stageSize.height - scaledHeight) / 2,
+  );
+  const scaleLabel = stageSize.width > 0 ? `${Math.round(previewScale * 100)}%` : "…";
 
   return (
     <section
@@ -642,11 +712,18 @@ function Viewport({
         className,
       )}
     >
-      <header className="flex h-10 shrink-0 items-center justify-between border-b border-[var(--border-1)] px-3">
+      <header
+        className="flex h-10 shrink-0 items-center justify-between border-b border-[var(--border-1)] px-3"
+        onDoubleClick={onFocus}
+        title={onFocus ? (focused ? "Doble clic para restaurar" : "Doble clic para ampliar") : undefined}
+      >
         <div className="flex items-center gap-2">
           {kind === "admin" ? <IconShield size={12} /> : <IconLayout size={12} />}
           <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--fg-muted)]">
             {title}
+          </span>
+          <span className="hidden font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)] sm:inline">
+            {spec.label} · {scaleLabel}
           </span>
         </div>
         <div className="flex items-center gap-1">
@@ -677,19 +754,56 @@ function Viewport({
       </header>
 
       {url ? (
-        <div className={cn("relative w-full overflow-hidden bg-white", frameClass)}>
-          <iframe
-            key={refreshKey}
-            src={url}
-            title={"Vista " + title + " de " + rawUrl}
+        <div
+          ref={stageRef}
+          className={cn("relative w-full overflow-hidden bg-[var(--color-surface)]", frameClass)}
+          onDoubleClick={(event) => {
+            if (event.target === event.currentTarget) onFocus?.();
+          }}
+        >
+          <div
             className={cn(
-              "absolute inset-0 h-full w-full border-0 bg-white",
-              kind === "mobile" && fill && "left-1/2 max-w-[430px] -translate-x-1/2 border-x border-[var(--border-1)]",
+              "absolute left-1/2 overflow-hidden bg-white opacity-0 transition-opacity duration-150",
+              stageSize.width > 0 && "opacity-100",
+              kind === "mobile"
+                ? "rounded-[30px] border-[6px] border-black shadow-lg"
+                : "border border-[var(--border-1)] shadow-lg",
             )}
-            loading="lazy"
-            referrerPolicy="no-referrer"
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-          />
+            style={{
+              top: previewTop,
+              width: spec.frameWidth,
+              height: spec.frameHeight,
+              transform: `translateX(-50%) scale(${previewScale})`,
+              transformOrigin: "top center",
+            }}
+          >
+            {kind === "mobile" ? (
+              <>
+                <div className="absolute left-1/2 top-[9px] z-10 h-[6px] w-[72px] -translate-x-1/2 rounded-full bg-black" aria-hidden="true" />
+                <iframe
+                  key={refreshKey}
+                  src={url}
+                  title={"Vista móvil real de " + title}
+                  className="absolute left-[6px] top-[28px] border-0 bg-white"
+                  style={{ width: spec.width, height: spec.height }}
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                  sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+                />
+              </>
+            ) : (
+              <iframe
+                key={refreshKey}
+                src={url}
+                title={`Vista ${kind === "admin" ? "administrativa" : "de escritorio"} de ${title}`}
+                className="absolute inset-0 border-0 bg-white"
+                style={{ width: spec.width, height: spec.height }}
+                loading="lazy"
+                referrerPolicy="no-referrer"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+              />
+            )}
+          </div>
         </div>
       ) : (
         <div className={cn("grid w-full place-items-center bg-white p-6 text-center", frameClass)}>
@@ -698,7 +812,9 @@ function Viewport({
               Sin URL para {title.toLowerCase()}
             </p>
             <p className="mt-2 max-w-xs text-[10px] leading-4 text-[var(--fg-muted)]">
-              Esta vista aparecerá cuando el proyecto tenga una URL autorizada.
+              {kind === "admin"
+                ? "Configura la URL del panel administrativo del proyecto. La vista pública no se usará como sustituto."
+                : "Esta vista aparecerá cuando el proyecto tenga una URL autorizada."}
             </p>
           </div>
         </div>

--- a/docs/operations/admin-institucional.md
+++ b/docs/operations/admin-institucional.md
@@ -13,9 +13,12 @@ https://{dominio-o-vercel}/admin
 `resolveProjectViewportUrls`:
 
 1. Si `projects.admin_url` está definida → se usa tal cual.
-2. Si no → se deriva `{vercel_url|domain}/admin`.
+2. Si coincide con la landing pública → se rechaza como panel administrativo.
+3. Si no está definida → la sala muestra “Administración no configurada”.
 
-Así el viewport **Administración** deja de quedar vacío en proyectos que ya tienen deploy pero nunca guardaron `admin_url`.
+La ruta `/admin` debe existir y guardarse explícitamente después de verificarla.
+VForge no inventa la ruta porque una app puede responder 404 o reutilizar la
+landing, lo que hacía que la sala mostrara una administración falsa.
 
 ## Qué no es
 

--- a/lib/mcp/rbac.ts
+++ b/lib/mcp/rbac.ts
@@ -57,6 +57,7 @@ export const TOOL_KIND: Record<string, ToolKind> = {
 
   // ---- DATA (tenant / private, admin|client only) ----
   vforge_project_status: "data",
+  vforge_project_feedback: "data",
   vforge_payments: "data",
   vforge_apps_health: "data",
   vforge_brain_search: "data",

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -74,6 +74,25 @@ export const MCP_TOOLS: McpToolDef[] = [
     inputSchema: { type: "object", properties: {} },
   },
   {
+    name: "vforge_project_feedback",
+    description:
+      "DATOS (admin|client): lee las observaciones de una sala live y el estado de la tarea ligada a cada comentario. Exige project_id y valida que el token sea owner del tenant o miembro activo del proyecto.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: {
+          type: "string",
+          description: "ID exacto del proyecto cuya sala se quiere revisar (por ejemplo: apsus)",
+        },
+        limit: {
+          type: "number",
+          description: "Cantidad de observaciones recientes (1-100; default 40)",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
     name: "vforge_payments",
     description: "DATOS (admin|client): pagos y avance financiero (total/pagado/pendiente) de los proyectos. Admin ve todo; client ve SOLO su org_id. Aislado por tenant.",
     inputSchema: { type: "object", properties: {} },
@@ -519,6 +538,7 @@ function helpText(principal: McpPrincipal): string {
   lines.push("• help — esta ayuda.\n");
   lines.push("## De datos (requieren token admin|client; aisladas por tenant)");
   lines.push("• vforge_project_status — estado de tus proyectos.");
+  lines.push("• vforge_project_feedback — observaciones de una sala y estado de sus tareas.");
   lines.push("• vforge_payments — avance financiero (total/pagado/pendiente).");
   lines.push("• vforge_apps_health — salud de despliegue de tus apps.");
   lines.push("• vforge_brain_search — memoria y método de VForge.");
@@ -748,6 +768,93 @@ export async function runMcpTool(
         );
       }
       return text(rows.map((r) => `• ${r.name} [${r.category}] ${r.status} ${r.vercel_url ?? ""}`.trim()).join("\n"));
+    }
+
+    case "vforge_project_feedback": {
+      const projectId = String(args.project_id ?? "").trim().slice(0, 160);
+      if (!projectId) return err("Falta 'project_id'.");
+      const requestedLimit = Number(args.limit ?? 40);
+      const limit = Number.isFinite(requestedLimit)
+        ? Math.min(100, Math.max(1, Math.floor(requestedLimit)))
+        : 40;
+
+      // El proyecto se autoriza ANTES de leer comentarios. Un client puede
+      // entrar por ser dueño de su tenant o por una membresía live activa.
+      // Nunca se acepta email/org desde args: la identidad sale del token MCP.
+      const project = isAdminScope
+        ? await queryOne<{ id: string; name: string }>(
+            "SELECT id, name FROM projects WHERE id = $1 LIMIT 1",
+            [projectId],
+          ).catch(() => null)
+        : await queryOne<{ id: string; name: string }>(
+            `SELECT p.id, p.name
+               FROM projects p
+              WHERE p.id = $1
+                AND (
+                  p.org_id = $2
+                  OR EXISTS (
+                    SELECT 1
+                      FROM project_live_members m
+                     WHERE m.project_id = p.id
+                       AND m.clerk_user_id = $3
+                       AND m.status = 'active'
+                       AND (m.expires_at IS NULL OR m.expires_at > now())
+                  )
+                )
+              LIMIT 1`,
+            [projectId, orgId, userId],
+          ).catch(() => null);
+
+      if (!project) {
+        return err("Proyecto no encontrado o sin acceso para este token MCP.");
+      }
+
+      const { ensureCommentTasksTable } = await import("@/lib/live/comment-tasks");
+      await ensureCommentTasksTable();
+      const rows = await queryAll<{
+        id: string;
+        author_email: string;
+        author_name: string | null;
+        body: string;
+        created_at: string;
+        task_id: string | null;
+        task_status: string | null;
+        task_result: string | null;
+      }>(
+        `SELECT c.id, c.author_email, c.author_name, c.body, c.created_at,
+                task.id AS task_id, task.status AS task_status,
+                task.result_summary AS task_result
+           FROM project_comments c
+           LEFT JOIN LATERAL (
+             SELECT t.id, t.status, t.result_summary
+               FROM project_comment_tasks t
+              WHERE t.project_id = c.project_id AND t.comment_id = c.id
+              ORDER BY t.created_at DESC
+              LIMIT 1
+           ) task ON true
+          WHERE c.project_id = $1
+          ORDER BY c.created_at DESC
+          LIMIT $2`,
+        [project.id, limit],
+      ).catch(() => []);
+
+      if (rows.length === 0) {
+        return text(`# Feedback — ${project.name}\n\nAún no hay observaciones en esta sala.`);
+      }
+
+      const items = rows.map((row, index) => {
+        const author = row.author_name?.trim() || row.author_email;
+        const task = row.task_status
+          ? `tarea ${row.task_status}${row.task_id ? ` (${row.task_id})` : ""}`
+          : "observación abierta";
+        const result = row.task_result ? `\nResultado: ${row.task_result}` : "";
+        return `${index + 1}. [${row.created_at}] ${author}\nEstado: ${task}\nID: ${row.id}\n${row.body}${result}`;
+      });
+      return text(
+        `# Feedback — ${project.name} (${project.id})\n\n` +
+          `${rows.length} observación(es), más recientes primero.\n\n` +
+          items.join("\n\n"),
+      );
     }
 
     case "vforge_payments": {

--- a/lib/projects/viewport-url.ts
+++ b/lib/projects/viewport-url.ts
@@ -60,6 +60,25 @@ function withAdminEmbed(admin: string | null): string | null {
   }
 }
 
+function distinctAdminUrl(
+  admin: string | null,
+  publicUrl: string | null,
+): string | null {
+  if (!admin) return null;
+  if (!publicUrl) return admin;
+  try {
+    const candidate = new URL(admin);
+    const published = new URL(publicUrl);
+    const sameSurface =
+      candidate.origin === published.origin &&
+      candidate.pathname.replace(/\/+$/, "") ===
+        published.pathname.replace(/\/+$/, "");
+    return sameSurface ? null : admin;
+  } catch {
+    return null;
+  }
+}
+
 export function resolveProjectViewportUrls(
   project: ProjectViewportFields,
 ): ResolvedProjectViewports {
@@ -74,8 +93,8 @@ export function resolveProjectViewportUrls(
       normalizePublishedUrl(project.desktop_url) ?? publishedFallback,
     mobile_url:
       normalizePublishedUrl(project.mobile_url) ?? publishedFallback,
-    admin_url: withAdminEmbed(
-      explicitAdmin ?? resolveInstitutionalAdminUrl(publishedFallback),
-    ),
+    // Administración sólo existe cuando el proyecto declara una superficie
+    // distinta. Inventar /admin produce 404 y usar la landing pública engaña.
+    admin_url: withAdminEmbed(distinctAdminUrl(explicitAdmin, publishedFallback)),
   };
 }

--- a/services/vforge-api/viewport-url.mjs
+++ b/services/vforge-api/viewport-url.mjs
@@ -43,6 +43,21 @@ function withAdminEmbed(admin) {
   }
 }
 
+function distinctAdminUrl(admin, publicUrl) {
+  if (!admin) return null;
+  if (!publicUrl) return admin;
+  try {
+    const candidate = new URL(admin);
+    const published = new URL(publicUrl);
+    const sameSurface =
+      candidate.origin === published.origin &&
+      candidate.pathname.replace(/\/+$/, "") === published.pathname.replace(/\/+$/, "");
+    return sameSurface ? null : admin;
+  } catch {
+    return null;
+  }
+}
+
 export function resolveProjectViewportUrls(project) {
   const publishedFallback =
     normalizePublishedUrl(project.vercel_url) ??
@@ -55,8 +70,7 @@ export function resolveProjectViewportUrls(project) {
       normalizePublishedUrl(project.desktop_url) ?? publishedFallback,
     mobile_url:
       normalizePublishedUrl(project.mobile_url) ?? publishedFallback,
-    admin_url: withAdminEmbed(
-      explicitAdmin ?? resolveInstitutionalAdminUrl(publishedFallback),
-    ),
+    // La API no inventa paneles: /admin debe existir y quedar guardado.
+    admin_url: withAdminEmbed(distinctAdminUrl(explicitAdmin, publishedFallback)),
   };
 }

--- a/tests/viewport-url.test.ts
+++ b/tests/viewport-url.test.ts
@@ -27,20 +27,20 @@ describe("resolveInstitutionalAdminUrl", () => {
   it("añade /admin al origen del proyecto", () => {
     assert.equal(
       resolveInstitutionalAdminUrl("https://ssante.life"),
-      "https://ssante.life/admin",
+      "https://ssante.life/admin?embed=1",
     );
   });
 
   it("no duplica /admin", () => {
     assert.equal(
       resolveInstitutionalAdminUrl("https://ssante.life/admin"),
-      "https://ssante.life/admin",
+      "https://ssante.life/admin?embed=1",
     );
   });
 });
 
 describe("resolveProjectViewportUrls", () => {
-  it("infiere admin institucional cuando no hay admin_url", () => {
+  it("no inventa administración cuando no hay admin_url", () => {
     const resolved = resolveProjectViewportUrls({
       desktop_url: null,
       mobile_url: null,
@@ -50,7 +50,7 @@ describe("resolveProjectViewportUrls", () => {
     });
     assert.equal(resolved.desktop_url, "https://lu-spa.vercel.app/");
     assert.equal(resolved.mobile_url, "https://lu-spa.vercel.app/");
-    assert.equal(resolved.admin_url, "https://lu-spa.vercel.app/admin");
+    assert.equal(resolved.admin_url, null);
   });
 
   it("respeta admin_url explícita", () => {
@@ -61,18 +61,17 @@ describe("resolveProjectViewportUrls", () => {
       vercel_url: null,
       domain: null,
     });
-    assert.equal(resolved.admin_url, "https://app.example.com/dashboard");
+    assert.equal(resolved.admin_url, "https://app.example.com/dashboard?embed=1");
   });
 
-  it("prioriza domain para admin base", () => {
+  it("rechaza usar la misma landing como administración", () => {
     const resolved = resolveProjectViewportUrls({
       desktop_url: null,
       mobile_url: null,
-      admin_url: null,
+      admin_url: "https://x.vercel.app/",
       vercel_url: "https://x.vercel.app",
       domain: "ssante.life",
     });
-    // vercel_url gana como publishedFallback (mismo orden histórico)
-    assert.equal(resolved.admin_url, "https://x.vercel.app/admin");
+    assert.equal(resolved.admin_url, null);
   });
 });


### PR DESCRIPTION
## Resultado
- renderiza escritorio 1440×900, móvil 390×844 en marco de teléfono y administración 1280×800 sin deformar
- amplía/restaura por botón, doble clic y Escape
- evita usar la landing pública como falsa administración
- expone comentarios/tareas por `vforge_project_feedback` con aislamiento por tenant o membresía activa

## Validación
- 30/30 tests
- TypeScript estricto
- Next.js production build
- revisión alternativa Mesh: APROBADO

> El supervisor principal no pudo emitir veredicto por límite semanal del proveedor; no reportó defecto de código.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cambia resolución de URLs admin (comportamiento visible en live) y expone comentarios de proyecto vía MCP con controles de acceso que deben mantenerse correctos.
> 
> **Overview**
> **Mejora la sala live** para que escritorio, móvil y administración se vean a tamaño lógico fijo (1440×900, 390×844 con marco de teléfono, 1280×800) y se escalen con `ResizeObserver` sin estirar el iframe; el encabezado muestra resolución y porcentaje de escala, y **ampliar/restaurar** funciona por botón, doble clic en la barra o el fondo del stage, más **Escape** al salir del panel enfocado.
> 
> **Corrige la URL de administración**: deja de inferir `{deploy}/admin` y descarta `admin_url` que sea la misma superficie que la landing pública; sin URL distinta configurada, la vista admin queda vacía con copy explícito. Misma regla en `lib/projects/viewport-url.ts`, `services/vforge-api/viewport-url.mjs`, docs de operaciones y tests.
> 
> **Añade la tool MCP `vforge_project_feedback`**: lee comentarios recientes de una sala y el estado de la tarea ligada, con acceso admin global o client por `org_id` / membresía live activa (sin confiar en args de identidad).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe6d4854aacc4c6e27c7f43ef41eb18212ac92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->