### PR TITLE
fix: permitir múltiples notas ancladas

### DIFF
--- a/components/live/CommentsPanel.tsx
+++ b/components/live/CommentsPanel.tsx
@@ -75,11 +75,7 @@ export function CommentsPanel({
   onMinimize?: () => void;
 }) {
   const router = useRouter();
-  const {
-    draftAnchor,
-    setDraftAnchor,
-    setAnchoredComments,
-  } = useReviewContext();
+  const { setAnchoredComments, commentsVersion } = useReviewContext();
   const encodedProjectId = encodeURIComponent(projectId);
   const [comments, setComments] = useState<CommentRow[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -159,7 +155,7 @@ export function CommentsPanel({
     void load();
     const timer = window.setInterval(() => void load(), 10_000);
     return () => window.clearInterval(timer);
-  }, [load]);
+  }, [commentsVersion, load]);
 
   async function send() {
     const text = body.trim();
@@ -170,14 +166,13 @@ export function CommentsPanel({
       const response = await fetch("/api/live/" + encodedProjectId + "/comments", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ body: text, anchor: draftAnchor }),
+        body: JSON.stringify({ body: text }),
       });
       if (!response.ok) {
         setError("No se pudo publicar el comentario.");
         return;
       }
       setBody("");
-      setDraftAnchor(null);
       await load();
     } catch {
       setError("No se pudo publicar el comentario.");
@@ -311,16 +306,6 @@ export function CommentsPanel({
       </div>
 
       <div className="mt-3">
-        {draftAnchor ? (
-          <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-black bg-[var(--color-background)] px-2.5 py-2">
-            <p className="truncate font-mono text-[8px] uppercase tracking-[0.08em]">
-              Anclado · {draftAnchor.label}
-            </p>
-            <button type="button" onClick={() => setDraftAnchor(null)} className="grid h-6 w-6 shrink-0 place-items-center rounded-md border border-[var(--border-1)]" aria-label="Quitar ancla">
-              <IconX size={10} />
-            </button>
-          </div>
-        ) : null}
         <textarea
           value={body}
           onChange={(e) => setBody(e.target.value)}

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -32,6 +32,7 @@ import { InvitePanel } from "@/components/live/InvitePanel";
 import { CommentsPanel } from "@/components/live/CommentsPanel";
 import { ProjectContextPanel } from "@/components/live/ProjectContextPanel";
 import { ReviewContextProvider, useReviewContext } from "@/components/live/ReviewContext";
+import { ReviewNotesTray } from "@/components/live/ReviewNotesTray";
 
 export interface LivePortalProject {
   id: string;
@@ -531,6 +532,7 @@ function LiveWorkspace({
         </div>
       )}
     </div>
+    <ReviewNotesTray projectId={project.id} />
     </ReviewContextProvider>
   );
 }
@@ -674,7 +676,7 @@ function Viewport({
 }) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [pinMode, setPinMode] = useState(false);
-  const { anchoredComments, draftAnchor, setDraftAnchor } = useReviewContext();
+  const { anchoredComments, draftNotes, addDraftAnchor } = useReviewContext();
   const url = useMemo(() => normalizeUrl(rawUrl), [rawUrl]);
   const spec = PREVIEW_SPECS[kind];
   const stageRef = useRef<HTMLDivElement>(null);
@@ -726,13 +728,16 @@ function Viewport({
   const markers = anchoredComments.filter(
     (comment) => comment.anchor.viewport === kind && comment.anchor.url === url,
   );
+  const pendingMarkers = draftNotes.filter(
+    (note) => note.anchor.viewport === kind && note.anchor.url === url,
+  );
 
   function placeAnchor(event: React.MouseEvent<HTMLDivElement>) {
     if (!url) return;
     const rect = event.currentTarget.getBoundingClientRect();
     const x = Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
     const y = Math.min(1, Math.max(0, (event.clientY - rect.top) / rect.height));
-    setDraftAnchor({
+    addDraftAnchor({
       viewport: kind,
       x: Math.round(x * 10_000) / 10_000,
       y: Math.round(y * 10_000) / 10_000,
@@ -776,7 +781,7 @@ function Viewport({
               )}
               aria-pressed={pinMode}
               aria-label={`Anclar comentario en ${title}`}
-              title="Selecciona un punto y escribe el comentario abajo"
+              title="Marca varios puntos y escribe sus notas en la bandeja"
             >
               <IconMap size={10} /> <span className="hidden xl:inline">Anclar</span>
             </button>
@@ -876,15 +881,16 @@ function Viewport({
                   {index + 1}
                 </a>
               ))}
-              {draftAnchor?.viewport === kind && draftAnchor.url === url ? (
+              {pendingMarkers.map((note) => (
                 <span
+                  key={note.id}
                   className="absolute grid h-8 w-8 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full border-2 border-black bg-white font-mono text-[10px] text-black shadow-lg"
-                  style={{ left: `${draftAnchor.x * 100}%`, top: `${draftAnchor.y * 100}%` }}
-                  aria-label="Ancla pendiente"
+                  style={{ left: `${note.anchor.x * 100}%`, top: `${note.anchor.y * 100}%` }}
+                  aria-label={`Ancla pendiente ${draftNotes.indexOf(note) + 1}`}
                 >
-                  +
+                  {draftNotes.indexOf(note) + 1}
                 </span>
-              ) : null}
+              ))}
             </div>
           </div>
         </div>

--- a/components/live/ReviewContext.tsx
+++ b/components/live/ReviewContext.tsx
@@ -2,6 +2,7 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -12,26 +13,77 @@ import type {
   ReviewAnchor,
 } from "@/lib/live/review-context";
 
+export interface ReviewDraftNote {
+  id: string;
+  anchor: ReviewAnchor;
+  body: string;
+}
+
 interface ReviewContextValue {
-  draftAnchor: ReviewAnchor | null;
-  setDraftAnchor: (anchor: ReviewAnchor | null) => void;
+  draftNotes: ReviewDraftNote[];
+  addDraftAnchor: (anchor: ReviewAnchor) => string;
+  updateDraftBody: (id: string, body: string) => void;
+  removeDraftNote: (id: string) => void;
   anchoredComments: AnchoredComment[];
   setAnchoredComments: (comments: AnchoredComment[]) => void;
+  commentsVersion: number;
+  notifyCommentsChanged: () => void;
 }
 
 const ReviewContext = createContext<ReviewContextValue | null>(null);
 
+function draftId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `draft-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 export function ReviewContextProvider({ children }: { children: ReactNode }) {
-  const [draftAnchor, setDraftAnchor] = useState<ReviewAnchor | null>(null);
+  const [draftNotes, setDraftNotes] = useState<ReviewDraftNote[]>([]);
   const [anchoredComments, setAnchoredComments] = useState<AnchoredComment[]>([]);
+  const [commentsVersion, setCommentsVersion] = useState(0);
+
+  const addDraftAnchor = useCallback((anchor: ReviewAnchor) => {
+    const id = draftId();
+    setDraftNotes((current) => [...current, { id, anchor, body: "" }]);
+    return id;
+  }, []);
+
+  const updateDraftBody = useCallback((id: string, body: string) => {
+    setDraftNotes((current) =>
+      current.map((note) => (note.id === id ? { ...note, body } : note)),
+    );
+  }, []);
+
+  const removeDraftNote = useCallback((id: string) => {
+    setDraftNotes((current) => current.filter((note) => note.id !== id));
+  }, []);
+
+  const notifyCommentsChanged = useCallback(() => {
+    setCommentsVersion((version) => version + 1);
+  }, []);
+
   const value = useMemo(
     () => ({
-      draftAnchor,
-      setDraftAnchor,
+      draftNotes,
+      addDraftAnchor,
+      updateDraftBody,
+      removeDraftNote,
       anchoredComments,
       setAnchoredComments,
+      commentsVersion,
+      notifyCommentsChanged,
     }),
-    [anchoredComments, draftAnchor],
+    [
+      addDraftAnchor,
+      anchoredComments,
+      commentsVersion,
+      draftNotes,
+      notifyCommentsChanged,
+      removeDraftNote,
+      updateDraftBody,
+    ],
   );
 
   return <ReviewContext.Provider value={value}>{children}</ReviewContext.Provider>;

--- a/components/live/ReviewNotesTray.tsx
+++ b/components/live/ReviewNotesTray.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import {
+  IconCheck,
+  IconLoader,
+  IconMap,
+  IconSend,
+  IconX,
+} from "@/components/brand/VFIcons";
+import { useReviewContext, type ReviewDraftNote } from "@/components/live/ReviewContext";
+
+export function ReviewNotesTray({ projectId }: { projectId: string }) {
+  const {
+    draftNotes,
+    updateDraftBody,
+    removeDraftNote,
+    notifyCommentsChanged,
+  } = useReviewContext();
+  const [collapsed, setCollapsed] = useState(false);
+  const [publishing, setPublishing] = useState<string | "all" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const encodedProjectId = encodeURIComponent(projectId);
+
+  if (draftNotes.length === 0) return null;
+
+  async function publish(note: ReviewDraftNote) {
+    const body = note.body.trim();
+    if (!body) return false;
+    const response = await fetch(`/api/live/${encodedProjectId}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body, anchor: note.anchor }),
+    });
+    if (!response.ok) throw new Error("publish_failed");
+    removeDraftNote(note.id);
+    notifyCommentsChanged();
+    return true;
+  }
+
+  async function publishOne(note: ReviewDraftNote) {
+    if (publishing || !note.body.trim()) return;
+    setPublishing(note.id);
+    setError(null);
+    try {
+      await publish(note);
+    } catch {
+      setError("No se pudo publicar esta nota. El borrador sigue aquí.");
+    } finally {
+      setPublishing(null);
+    }
+  }
+
+  async function publishAll() {
+    if (publishing || draftNotes.some((note) => !note.body.trim())) return;
+    setPublishing("all");
+    setError(null);
+    try {
+      for (const note of draftNotes) await publish(note);
+    } catch {
+      setError("Una nota no pudo publicarse. Las pendientes se conservaron.");
+    } finally {
+      setPublishing(null);
+    }
+  }
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={() => setCollapsed(false)}
+        className="fixed bottom-4 right-4 z-[80] inline-flex h-11 items-center gap-2 rounded-[8px] border border-black bg-white px-4 text-[11px] font-medium text-black shadow-[0_12px_35px_rgba(0,0,0,0.18)]"
+      >
+        <IconMap size={13} /> {draftNotes.length} {draftNotes.length === 1 ? "nota pendiente" : "notas pendientes"}
+      </button>
+    );
+  }
+
+  const allReady = draftNotes.every((note) => note.body.trim());
+
+  return (
+    <aside className="fixed bottom-4 right-4 z-[80] flex max-h-[min(680px,calc(100dvh-32px))] w-[min(400px,calc(100vw-24px))] flex-col overflow-hidden rounded-[8px] border border-black bg-white text-black shadow-[0_18px_50px_rgba(0,0,0,0.2)]" aria-label="Bandeja de notas ancladas">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-black px-4">
+        <div className="flex items-center gap-2">
+          <IconMap size={13} />
+          <p className="text-[12px] font-medium">Notas ancladas</p>
+          <span className="rounded-full bg-black px-2 py-0.5 font-mono text-[8px] text-white">{draftNotes.length}</span>
+        </div>
+        <button type="button" onClick={() => setCollapsed(true)} className="grid h-7 w-7 place-items-center rounded-md hover:bg-[#f2f2f0]" aria-label="Minimizar notas" title="Minimizar">
+          <span className="h-px w-3 bg-current" />
+        </button>
+      </header>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-[#f7f7f5] p-3">
+        {draftNotes.map((note, index) => (
+          <section key={note.id} className="rounded-[6px] border border-[var(--border-1)] bg-white p-3">
+            <div className="flex items-start gap-2">
+              <span className="grid h-6 w-6 shrink-0 place-items-center rounded-full border border-black font-mono text-[9px]">{index + 1}</span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-mono text-[8px] uppercase tracking-[0.08em]">{note.anchor.label}</p>
+                <p className="mt-1 truncate text-[9px] text-[var(--fg-muted)]">{note.anchor.viewport}</p>
+              </div>
+              <button type="button" onClick={() => removeDraftNote(note.id)} className="grid h-6 w-6 shrink-0 place-items-center rounded-md border border-[var(--border-1)] hover:border-black" aria-label={`Eliminar nota ${index + 1}`}>
+                <IconX size={10} />
+              </button>
+            </div>
+            <textarea
+              value={note.body}
+              onChange={(event) => updateDraftBody(note.id, event.target.value)}
+              rows={3}
+              maxLength={4000}
+              autoFocus={index === draftNotes.length - 1}
+              placeholder="Escribe la observación para este punto…"
+              className="mt-3 w-full resize-y rounded-md border border-[var(--border-1)] bg-white px-3 py-2.5 text-[11px] placeholder:text-[var(--fg-muted)] focus:border-black"
+            />
+            <button type="button" onClick={() => void publishOne(note)} disabled={!!publishing || !note.body.trim()} className="mt-2 inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md border border-black bg-white px-3 font-mono text-[8px] uppercase tracking-[0.08em] hover:bg-black hover:text-white disabled:opacity-35">
+              {publishing === note.id ? <IconLoader size={11} className="animate-spin" /> : <IconCheck size={11} />}
+              Publicar esta nota
+            </button>
+          </section>
+        ))}
+      </div>
+
+      <footer className="shrink-0 border-t border-black bg-white p-3">
+        {error ? <p className="mb-2 text-[10px] leading-4">{error}</p> : null}
+        <button type="button" onClick={() => void publishAll()} disabled={!!publishing || !allReady} className="btn-primary w-full disabled:opacity-35">
+          {publishing === "all" ? <IconLoader size={13} className="animate-spin" /> : <IconSend size={13} />}
+          Publicar todas
+        </button>
+        {!allReady ? <p className="mt-2 text-center font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">Escribe una nota en cada ancla</p> : null}
+      </footer>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Cambio
- permite crear varias anclas sin reemplazar las anteriores
- añade una bandeja persistente con una nota independiente por marca
- permite publicar una nota o todas en lote
- conserva borradores si falla una publicación
- mantiene la bandeja disponible con cualquier panel ampliado

## Validación
- `npm run typecheck`
- ESLint en archivos modificados
- `npm test` (37/37)
- `npm run build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cambia el flujo de feedback anclado y quién publica anchors (bandeja vs panel), pero reutiliza el mismo endpoint de comentarios; conviene validar permisos y que el listado se actualice al publicar en lote.
> 
> **Overview**
> La revisión en vivo deja de usar **una sola ancla pendiente** ligada al cuadro de comentarios y pasa a **varias notas borrador**, cada una con su propio punto en el preview.
> 
> `ReviewContext` sustituye `draftAnchor` por `draftNotes` (añadir ancla, editar texto, eliminar) y expone `commentsVersion` / `notifyCommentsChanged` para que `CommentsPanel` vuelva a cargar el hilo tras publicar desde la bandeja. En los viewports, cada clic en modo anclar **añade** un marcador numerado en lugar de reemplazar el anterior.
> 
> Nuevo **`ReviewNotesTray`**: panel fijo (minimizable) con un textarea por ancla, publicación individual o **Publicar todas** vía `POST` con `body` + `anchor`. Los comentarios generales del panel ya no envían `anchor`. Si falla una publicación, los borradores restantes se conservan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbb30d822988604e8edcd2df81fced0ac23d2967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->