### PR TITLE
fix: mantener comentarios anclados durante el scroll

### DIFF
--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -33,6 +33,13 @@ import { CommentsPanel } from "@/components/live/CommentsPanel";
 import { ProjectContextPanel } from "@/components/live/ProjectContextPanel";
 import { ReviewContextProvider, useReviewContext } from "@/components/live/ReviewContext";
 import { ReviewNotesTray } from "@/components/live/ReviewNotesTray";
+import {
+  anchorViewportPosition,
+  documentPointForAnchor,
+  parseReviewBridgeViewport,
+  type ReviewAnchor,
+  type ReviewBridgeViewport,
+} from "@/lib/live/review-context";
 
 export interface LivePortalProject {
   id: string;
@@ -680,7 +687,9 @@ function Viewport({
   const url = useMemo(() => normalizeUrl(rawUrl), [rawUrl]);
   const spec = PREVIEW_SPECS[kind];
   const stageRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
   const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
+  const [bridgeViewport, setBridgeViewport] = useState<ReviewBridgeViewport | null>(null);
   const frameClass =
     fill
       ? "min-h-0 flex-1"
@@ -709,6 +718,24 @@ function Viewport({
     updateSize(stage.clientWidth, stage.clientHeight);
     return () => observer.disconnect();
   }, [kind]);
+
+  useEffect(() => {
+    setBridgeViewport(null);
+    if (!url) return;
+    let iframeOrigin: string;
+    try {
+      iframeOrigin = new URL(url).origin;
+    } catch {
+      return;
+    }
+    const receive = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow || event.origin !== iframeOrigin) return;
+      const next = parseReviewBridgeViewport(event.data);
+      if (next) setBridgeViewport(next);
+    };
+    window.addEventListener("message", receive);
+    return () => window.removeEventListener("message", receive);
+  }, [refreshKey, url]);
 
   const stagePadding = kind === "mobile" ? 20 : 12;
   const previewScale =
@@ -743,6 +770,7 @@ function Viewport({
       y: Math.round(y * 10_000) / 10_000,
       url,
       label: `${title} · ${Math.round(x * 100)}%, ${Math.round(y * 100)}%`,
+      ...documentPointForAnchor(x, y, bridgeViewport),
     });
     setPinMode(false);
   }
@@ -781,7 +809,7 @@ function Viewport({
               )}
               aria-pressed={pinMode}
               aria-label={`Anclar comentario en ${title}`}
-              title="Marca varios puntos y escribe sus notas en la bandeja"
+              title={bridgeViewport ? "Anclaje preciso activo: la marca seguirá al contenido" : "Marca varios puntos y escribe sus notas en la bandeja"}
             >
               <IconMap size={10} /> <span className="hidden xl:inline">Anclar</span>
             </button>
@@ -837,6 +865,7 @@ function Viewport({
               <>
                 <div className="absolute left-1/2 top-[9px] z-10 h-[6px] w-[72px] -translate-x-1/2 rounded-full bg-black" aria-hidden="true" />
                 <iframe
+                  ref={iframeRef}
                   key={refreshKey}
                   src={url}
                   title={"Vista móvil real de " + title}
@@ -849,6 +878,7 @@ function Viewport({
               </>
             ) : (
               <iframe
+                ref={iframeRef}
                 key={refreshKey}
                 src={url}
                 title={`Vista ${kind === "admin" ? "administrativa" : "de escritorio"} de ${title}`}
@@ -870,26 +900,24 @@ function Viewport({
               aria-label={pinMode ? `Selecciona un punto en ${title}` : undefined}
             >
               {markers.map((comment, index) => (
-                <a
+                <ReviewMarker
                   key={comment.id}
+                  anchor={comment.anchor}
+                  bridge={bridgeViewport}
                   href={`#comment-${comment.id}`}
-                  className="pointer-events-auto absolute grid h-8 w-8 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full border-2 border-white bg-black font-mono text-[10px] text-white shadow-lg"
-                  style={{ left: `${comment.anchor.x * 100}%`, top: `${comment.anchor.y * 100}%` }}
-                  aria-label={`Ver comentario ${index + 1}: ${comment.anchor.label}`}
-                  title={comment.anchor.label}
-                >
-                  {index + 1}
-                </a>
+                  label={`${index + 1}`}
+                  ariaLabel={`Ver comentario ${index + 1}: ${comment.anchor.label}`}
+                  saved
+                />
               ))}
               {pendingMarkers.map((note) => (
-                <span
+                <ReviewMarker
                   key={note.id}
-                  className="absolute grid h-8 w-8 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full border-2 border-black bg-white font-mono text-[10px] text-black shadow-lg"
-                  style={{ left: `${note.anchor.x * 100}%`, top: `${note.anchor.y * 100}%` }}
-                  aria-label={`Ancla pendiente ${draftNotes.indexOf(note) + 1}`}
-                >
-                  {draftNotes.indexOf(note) + 1}
-                </span>
+                  anchor={note.anchor}
+                  bridge={bridgeViewport}
+                  label={`${draftNotes.indexOf(note) + 1}`}
+                  ariaLabel={`Ancla pendiente ${draftNotes.indexOf(note) + 1}`}
+                />
               ))}
             </div>
           </div>
@@ -909,6 +937,41 @@ function Viewport({
         </div>
       )}
     </section>
+  );
+}
+
+function ReviewMarker({
+  anchor,
+  bridge,
+  label,
+  ariaLabel,
+  href,
+  saved = false,
+}: {
+  anchor: ReviewAnchor;
+  bridge: ReviewBridgeViewport | null;
+  label: string;
+  ariaLabel: string;
+  href?: string;
+  saved?: boolean;
+}) {
+  const position = anchorViewportPosition(anchor, bridge);
+  if (!position.visible) return null;
+  const className = cn(
+    "absolute grid h-8 w-8 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full border-2 font-mono text-[10px] shadow-lg",
+    saved
+      ? "pointer-events-auto border-white bg-black text-white"
+      : "border-black bg-white text-black",
+  );
+  const style = { left: `${position.x * 100}%`, top: `${position.y * 100}%` };
+  return href ? (
+    <a href={href} className={className} style={style} aria-label={ariaLabel} title={anchor.label}>
+      {label}
+    </a>
+  ) : (
+    <span className={className} style={style} aria-label={ariaLabel} title={anchor.label}>
+      {label}
+    </span>
   );
 }
 

--- a/lib/live/review-context.ts
+++ b/lib/live/review-context.ts
@@ -6,6 +6,17 @@ export interface ReviewAnchor {
   y: number;
   url: string;
   label: string;
+  documentX?: number;
+  documentY?: number;
+}
+
+export interface ReviewBridgeViewport {
+  scrollX: number;
+  scrollY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  documentWidth: number;
+  documentHeight: number;
 }
 
 export interface AnchoredComment {
@@ -53,13 +64,84 @@ export function parseReviewAnchor(value: unknown): ReviewAnchor | null {
   const url = cleanUrl(raw.url);
   if (!url) return null;
   const label = typeof raw.label === "string" ? raw.label.trim().slice(0, 120) : "";
+  const documentX = finiteDocumentCoordinate(raw.documentX);
+  const documentY = finiteDocumentCoordinate(raw.documentY);
   return {
     viewport: raw.viewport as ReviewViewport,
     x: Math.round(raw.x * 10_000) / 10_000,
     y: Math.round(raw.y * 10_000) / 10_000,
     url,
     label: label || `${raw.viewport} · ${Math.round(raw.x * 100)}%, ${Math.round(raw.y * 100)}%`,
+    ...(documentX != null && documentY != null ? { documentX, documentY } : {}),
   };
+}
+
+function finiteDocumentCoordinate(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 10_000_000
+    ? Math.round(value * 100) / 100
+    : null;
+}
+
+function finitePositive(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 && value <= 10_000_000
+    ? value
+    : null;
+}
+
+export function parseReviewBridgeViewport(value: unknown): ReviewBridgeViewport | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.source !== "vforge-review-bridge" || raw.type !== "viewport" || raw.version !== 1) {
+    return null;
+  }
+  const scrollX = finiteDocumentCoordinate(raw.scrollX);
+  const scrollY = finiteDocumentCoordinate(raw.scrollY);
+  const viewportWidth = finitePositive(raw.viewportWidth);
+  const viewportHeight = finitePositive(raw.viewportHeight);
+  const documentWidth = finitePositive(raw.documentWidth);
+  const documentHeight = finitePositive(raw.documentHeight);
+  if (
+    scrollX == null ||
+    scrollY == null ||
+    viewportWidth == null ||
+    viewportHeight == null ||
+    documentWidth == null ||
+    documentHeight == null
+  ) {
+    return null;
+  }
+  return {
+    scrollX,
+    scrollY,
+    viewportWidth,
+    viewportHeight,
+    documentWidth,
+    documentHeight,
+  };
+}
+
+export function documentPointForAnchor(
+  x: number,
+  y: number,
+  bridge: ReviewBridgeViewport | null,
+): Pick<ReviewAnchor, "documentX" | "documentY"> | Record<string, never> {
+  if (!bridge) return {};
+  return {
+    documentX: Math.round((bridge.scrollX + x * bridge.viewportWidth) * 100) / 100,
+    documentY: Math.round((bridge.scrollY + y * bridge.viewportHeight) * 100) / 100,
+  };
+}
+
+export function anchorViewportPosition(
+  anchor: ReviewAnchor,
+  bridge: ReviewBridgeViewport | null,
+): { x: number; y: number; visible: boolean } {
+  if (bridge && anchor.documentX != null && anchor.documentY != null) {
+    const x = (anchor.documentX - bridge.scrollX) / bridge.viewportWidth;
+    const y = (anchor.documentY - bridge.scrollY) / bridge.viewportHeight;
+    return { x, y, visible: x >= 0 && x <= 1 && y >= 0 && y <= 1 };
+  }
+  return { x: anchor.x, y: anchor.y, visible: true };
 }
 
 export function isAcceptedZip(filename: string, contentType: string, size: number): boolean {

--- a/public/vforge-review-bridge.js
+++ b/public/vforge-review-bridge.js
@@ -1,0 +1,53 @@
+(function () {
+  "use strict";
+  if (window === window.parent) return;
+
+  var queued = false;
+  function emitViewport() {
+    queued = false;
+    var root = document.documentElement;
+    var body = document.body;
+    var documentWidth = Math.max(
+      root ? root.scrollWidth : 0,
+      body ? body.scrollWidth : 0,
+      window.innerWidth
+    );
+    var documentHeight = Math.max(
+      root ? root.scrollHeight : 0,
+      body ? body.scrollHeight : 0,
+      window.innerHeight
+    );
+    window.parent.postMessage(
+      {
+        source: "vforge-review-bridge",
+        type: "viewport",
+        version: 1,
+        scrollX: Math.max(0, window.scrollX || 0),
+        scrollY: Math.max(0, window.scrollY || 0),
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        documentWidth: documentWidth,
+        documentHeight: documentHeight,
+      },
+      "*"
+    );
+  }
+
+  function schedule() {
+    if (queued) return;
+    queued = true;
+    window.requestAnimationFrame(emitViewport);
+  }
+
+  window.addEventListener("scroll", schedule, { passive: true });
+  window.addEventListener("resize", schedule, { passive: true });
+  window.addEventListener("load", schedule, { once: true });
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("scroll", schedule, { passive: true });
+    window.visualViewport.addEventListener("resize", schedule, { passive: true });
+  }
+  if (typeof ResizeObserver !== "undefined" && document.documentElement) {
+    new ResizeObserver(schedule).observe(document.documentElement);
+  }
+  schedule();
+})();

--- a/tests/review-context.test.ts
+++ b/tests/review-context.test.ts
@@ -1,9 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  anchorViewportPosition,
+  documentPointForAnchor,
   isAcceptedZip,
   isSafeProjectBlobPath,
   parseReviewAnchor,
+  parseReviewBridgeViewport,
   safeArchiveName,
 } from "../lib/live/review-context";
 
@@ -30,6 +33,48 @@ test("parseReviewAnchor fails closed", () => {
   assert.equal(parseReviewAnchor({ viewport: "desktop", x: -1, y: 0.2, url: "https://a.test" }), null);
   assert.equal(parseReviewAnchor({ viewport: "tablet", x: 0.2, y: 0.2, url: "https://a.test" }), null);
   assert.equal(parseReviewAnchor({ viewport: "admin", x: 0.2, y: 0.2, url: "javascript:alert(1)" }), null);
+});
+
+test("scroll-aware anchors keep their document position", () => {
+  const bridge = parseReviewBridgeViewport({
+    source: "vforge-review-bridge",
+    type: "viewport",
+    version: 1,
+    scrollX: 0,
+    scrollY: 600,
+    viewportWidth: 1440,
+    viewportHeight: 900,
+    documentWidth: 1440,
+    documentHeight: 2400,
+  });
+  assert.ok(bridge);
+  assert.deepEqual(documentPointForAnchor(0.25, 0.5, bridge), {
+    documentX: 360,
+    documentY: 1050,
+  });
+
+  const anchor = parseReviewAnchor({
+    viewport: "desktop",
+    x: 0.25,
+    y: 0.5,
+    url: "https://example.com",
+    documentX: 360,
+    documentY: 1050,
+  });
+  assert.ok(anchor);
+  assert.deepEqual(anchorViewportPosition(anchor, bridge), {
+    x: 0.25,
+    y: 0.5,
+    visible: true,
+  });
+  assert.deepEqual(
+    anchorViewportPosition(anchor, { ...bridge, scrollY: 1050 }),
+    { x: 0.25, y: 0, visible: true },
+  );
+  assert.equal(
+    anchorViewportPosition(anchor, { ...bridge, scrollY: 1200 }).visible,
+    false,
+  );
 });
 
 test("ZIP validation rejects renamed or oversized files", () => {


### PR DESCRIPTION
## Cambio
- agrega puente de geometría seguro para previews cross-origin
- guarda coordenadas reales del documento en anclas nuevas
- mueve/oculta/reaparece cada marcador conforme se desplaza la app
- conserva compatibilidad con comentarios anteriores

## Validación
- TypeScript
- ESLint
- 38/38 pruebas
- build de producción
- diff check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cross-origin postMessage handling in the Live portal; origin and source checks limit exposure, but marker accuracy depends on previews loading the bridge script.
> 
> **Overview**
> **Anchored comments in Live preview iframes now track scroll** instead of staying fixed to viewport percentages. When the preview exposes geometry via the new review bridge, new pins store **document coordinates** (`documentX` / `documentY`) and markers **move, hide, or reappear** as the embedded page scrolls; older anchors without those fields still use the previous percentage behavior.
> 
> The portal **listens for validated `postMessage` viewport updates** from each preview iframe (matching iframe origin and message source), resets bridge state on refresh/URL change, and routes placement and rendering through shared helpers in `review-context` plus a **`ReviewMarker`** component. A new **`public/vforge-review-bridge.js`** script (for pages loaded inside the iframe) emits scroll/resize/document size on a throttled schedule. Unit tests cover bridge parsing and scroll-aware position math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf92633662f2c3726f55cb6c4dc132d0a79c0d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->