### PR TITLE
feat: agrupar repositorios por proyecto

### DIFF
--- a/app/api/projects/[id]/repositories/route.ts
+++ b/app/api/projects/[id]/repositories/route.ts
@@ -1,0 +1,221 @@
+import { queryAll, queryOne, sql } from "@/lib/db/client";
+import { resolveRequestOwner } from "@/lib/auth/request-owner";
+import { getRepo } from "@/lib/github/client";
+import {
+  isProjectRepositoryRole,
+  type ProjectRepository,
+} from "@/lib/projects/repository-groups";
+import { ensureProjectRepositoriesSchema } from "@/lib/projects/repository-schema";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function requireOwner(): Promise<{ userId: string } | Response> {
+  const access = await resolveRequestOwner();
+  if (!access.userId) return jsonError("unauthorized", 401);
+  if (!access.isOwner) return jsonError("forbidden", 403);
+  return { userId: access.userId };
+}
+
+async function projectExists(projectId: string): Promise<boolean> {
+  return Boolean(
+    await queryOne<{ id: string }>("SELECT id FROM projects WHERE id = $1", [
+      projectId,
+    ]),
+  );
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const access = await requireOwner();
+  if (access instanceof Response) return access;
+  const { id } = await params;
+
+  await ensureProjectRepositoriesSchema();
+  if (!(await projectExists(id))) return jsonError("project not found", 404);
+
+  const repositories = await queryAll<ProjectRepository>(
+    `SELECT repo_full_name, role, is_primary, default_branch,
+            private, language, html_url, pushed_at::text
+       FROM project_repositories
+      WHERE project_id = $1
+      ORDER BY is_primary DESC, role, repo_full_name`,
+    [id],
+  );
+  return json({ repositories });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const access = await requireOwner();
+  if (access instanceof Response) return access;
+  const { id } = await params;
+  await ensureProjectRepositoriesSchema();
+  if (!(await projectExists(id))) return jsonError("project not found", 404);
+
+  let body: { repo_full_name?: string; role?: string; is_primary?: boolean };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonError("invalid JSON body", 400);
+  }
+
+  const repoFullName = (body.repo_full_name ?? "").trim();
+  const role = body.role ?? "app";
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repoFullName)) {
+    return jsonError("repo_full_name must be owner/repository", 400);
+  }
+  if (!isProjectRepositoryRole(role)) {
+    return jsonError("invalid repository role", 400);
+  }
+
+  const [owner, repoName] = repoFullName.split("/", 2);
+  let repo;
+  try {
+    repo = await getRepo(owner, repoName, { auditUserId: access.userId });
+  } catch (caught) {
+    return jsonError(
+      caught instanceof Error
+        ? `GitHub no permitió leer ${repoFullName}: ${caught.message}`
+        : `GitHub no permitió leer ${repoFullName}`,
+      422,
+    );
+  }
+
+  const current = await queryOne<{ count: number }>(
+    "SELECT count(*)::int AS count FROM project_repositories WHERE project_id = $1",
+    [id],
+  );
+  const makePrimary = body.is_primary === true || (current?.count ?? 0) === 0;
+
+  if (makePrimary) {
+    await sql`
+      UPDATE project_repositories SET is_primary = false, updated_at = now()
+      WHERE project_id = ${id}
+    `;
+  }
+
+  await sql`
+    INSERT INTO project_repositories (
+      project_id, repo_full_name, role, is_primary,
+      default_branch, private, language, html_url, pushed_at
+    ) VALUES (
+      ${id}, ${repo.full_name}, ${role}, ${makePrimary},
+      ${repo.default_branch}, ${repo.private}, ${repo.language},
+      ${repo.html_url}, ${repo.pushed_at}
+    )
+    ON CONFLICT (project_id, repo_full_name) DO UPDATE SET
+      role = EXCLUDED.role,
+      is_primary = CASE WHEN ${makePrimary} THEN true ELSE project_repositories.is_primary END,
+      default_branch = EXCLUDED.default_branch,
+      private = EXCLUDED.private,
+      language = EXCLUDED.language,
+      html_url = EXCLUDED.html_url,
+      pushed_at = EXCLUDED.pushed_at,
+      updated_at = now()
+  `;
+
+  if (makePrimary) {
+    await sql`
+      UPDATE projects SET
+        github_repo = ${repo.full_name},
+        github_url = ${repo.html_url},
+        github_private = ${repo.private},
+        github_language = ${repo.language},
+        github_default_branch = ${repo.default_branch},
+        updated_at = now()
+      WHERE id = ${id}
+    `;
+  }
+
+  await sql`
+    INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+    VALUES (
+      ${access.userId}, 'project.repository.upsert', 'project', ${id}, 1,
+      ${JSON.stringify({ repo_full_name: repo.full_name, role, is_primary: makePrimary })}::jsonb
+    )
+  `;
+
+  return GET(req, { params: Promise.resolve({ id }) });
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const access = await requireOwner();
+  if (access instanceof Response) return access;
+  const { id } = await params;
+  const repoFullName = new URL(req.url).searchParams.get("repo")?.trim() ?? "";
+  if (!repoFullName) return jsonError("repo query parameter required", 400);
+
+  await ensureProjectRepositoriesSchema();
+  const removed = await queryOne<{ repo_full_name: string; is_primary: boolean }>(
+    `DELETE FROM project_repositories
+      WHERE project_id = $1 AND lower(repo_full_name) = lower($2)
+      RETURNING repo_full_name, is_primary`,
+    [id, repoFullName],
+  );
+  if (!removed) return jsonError("repository is not part of this project", 404);
+
+  if (removed.is_primary) {
+    const replacement = await queryOne<ProjectRepository>(
+      `SELECT repo_full_name, role, is_primary, default_branch,
+              private, language, html_url, pushed_at::text
+         FROM project_repositories
+        WHERE project_id = $1
+        ORDER BY created_at, repo_full_name
+        LIMIT 1`,
+      [id],
+    );
+    if (replacement) {
+      await sql`
+        UPDATE project_repositories SET is_primary = true, updated_at = now()
+        WHERE project_id = ${id} AND repo_full_name = ${replacement.repo_full_name}
+      `;
+      await sql`
+        UPDATE projects SET
+          github_repo = ${replacement.repo_full_name},
+          github_url = ${replacement.html_url},
+          github_private = ${replacement.private},
+          github_language = ${replacement.language},
+          github_default_branch = COALESCE(${replacement.default_branch}, 'main'),
+          updated_at = now()
+        WHERE id = ${id}
+      `;
+    } else {
+      await sql`
+        UPDATE projects SET
+          github_repo = NULL, github_url = NULL, github_language = NULL,
+          updated_at = now()
+        WHERE id = ${id}
+      `;
+    }
+  }
+
+  await sql`
+    INSERT INTO audit_events (user_id, action, resource_type, resource_id, ring, payload)
+    VALUES (
+      ${access.userId}, 'project.repository.remove', 'project', ${id}, 1,
+      ${JSON.stringify({ repo_full_name: removed.repo_full_name })}::jsonb
+    )
+  `;
+
+  return GET(req, { params: Promise.resolve({ id }) });
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+  });
+}
+
+function jsonError(message: string, status: number): Response {
+  return json({ error: message }, status);
+}
+

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -3,6 +3,8 @@ import { resolveRequestOwner } from "@/lib/auth/request-owner";
 import { createRepo } from "@/lib/github/client";
 import { neon } from "@neondatabase/serverless";
 import { ensureDeliveryColumns } from "@/lib/projects/delivery-meta";
+import { ensureProjectRepositoriesSchema } from "@/lib/projects/repository-schema";
+import type { ProjectRepository } from "@/lib/projects/repository-groups";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -20,6 +22,8 @@ interface ProjectRow {
   delivery_priority?: boolean;
   progress_pct?: number;
   family_code?: string | null;
+  repositories: ProjectRepository[];
+  repository_count: number;
 }
 
 const VALID_CATEGORIES = new Set([
@@ -46,18 +50,37 @@ export async function GET() {
   }
 
   await ensureDeliveryColumns();
+  await ensureProjectRepositoriesSchema();
 
   const rows = await queryAll<ProjectRow>(
-    `SELECT id, name, category, status,
-            github_repo, github_private, github_language,
-            vercel_url, domain,
-            COALESCE(delivery_priority, false) AS delivery_priority,
-            COALESCE(progress_pct, 0) AS progress_pct,
-            family_code
-       FROM projects
+    `SELECT p.id, p.name, p.category, p.status,
+            p.github_repo, p.github_private, p.github_language,
+            p.vercel_url, p.domain,
+            COALESCE(p.delivery_priority, false) AS delivery_priority,
+            COALESCE(p.progress_pct, 0) AS progress_pct,
+            p.family_code,
+            COALESCE((
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'repo_full_name', pr.repo_full_name,
+                  'role', pr.role,
+                  'is_primary', pr.is_primary,
+                  'default_branch', pr.default_branch,
+                  'private', pr.private,
+                  'language', pr.language,
+                  'html_url', pr.html_url,
+                  'pushed_at', pr.pushed_at
+                ) ORDER BY pr.is_primary DESC, pr.role, pr.repo_full_name
+              )
+              FROM project_repositories pr
+              WHERE pr.project_id = p.id
+            ), '[]'::jsonb) AS repositories,
+            (SELECT count(*)::int FROM project_repositories pr WHERE pr.project_id = p.id)
+              AS repository_count
+       FROM projects p
        ORDER BY
-         COALESCE(delivery_priority, false) DESC,
-         CASE category
+         COALESCE(p.delivery_priority, false) DESC,
+         CASE p.category
            WHEN 'produccion' THEN 1
            WHEN 'activo' THEN 2
            WHEN 'en_revision' THEN 3
@@ -66,8 +89,8 @@ export async function GET() {
            WHEN 'pendiente_borrado' THEN 6
            ELSE 99
          END,
-         COALESCE(progress_pct, 0) DESC,
-         name`,
+         COALESCE(p.progress_pct, 0) DESC,
+         p.name`,
   );
   return new Response(JSON.stringify({ projects: rows }), {
     status: 200,
@@ -128,6 +151,7 @@ export async function POST(req: Request) {
 
   try {
     await ensureDeliveryColumns();
+    await ensureProjectRepositoriesSchema();
     await txClient.transaction([
       txClient`
         INSERT INTO projects (
@@ -164,13 +188,43 @@ export async function POST(req: Request) {
         createdRepo = { full_name: repo.full_name, url: repo.url };
         await sql`
           UPDATE projects
-          SET github_repo = ${repo.full_name}, github_url = ${repo.url}
+          SET github_repo = ${repo.full_name}, github_url = ${repo.url},
+              github_private = ${repo.private},
+              github_default_branch = ${repo.default_branch}
           WHERE id = ${id}
+        `;
+        await sql`
+          INSERT INTO project_repositories (
+            project_id, repo_full_name, role, is_primary,
+            default_branch, private, language, html_url, pushed_at
+          ) VALUES (
+            ${id}, ${repo.full_name}, 'app', true,
+            ${repo.default_branch}, ${repo.private}, NULL,
+            ${repo.url}, NULL
+          )
+          ON CONFLICT (project_id, repo_full_name) DO UPDATE SET
+            is_primary = true,
+            default_branch = EXCLUDED.default_branch,
+            private = EXCLUDED.private,
+            language = EXCLUDED.language,
+            html_url = EXCLUDED.html_url,
+            pushed_at = EXCLUDED.pushed_at,
+            updated_at = now()
         `;
       } catch (e) {
         repoError = e instanceof Error ? e.message : String(e);
         console.error("[projects] createRepo failed:", repoError);
       }
+    }
+
+    if (github_repo && !createdRepo) {
+      await sql`
+        INSERT INTO project_repositories (
+          project_id, repo_full_name, role, is_primary, html_url
+        ) VALUES (${id}, ${github_repo}, 'app', true, ${github_url})
+        ON CONFLICT (project_id, repo_full_name) DO UPDATE SET
+          is_primary = true, html_url = EXCLUDED.html_url, updated_at = now()
+      `;
     }
 
     fetch("http://178.105.135.26:3003/notify", {

--- a/app/api/projects/sync/route.ts
+++ b/app/api/projects/sync/route.ts
@@ -1,167 +1,159 @@
-import { sql } from "@/lib/db/client";
-import { listAllUserRepos } from "@/lib/github/client";
+import { queryAll, queryOne, sql } from "@/lib/db/client";
+import { listAllUserRepos, type RepoSummary } from "@/lib/github/client";
 import {
   listProjects as vercelListProjects,
   listProjectDomains,
   pickCustomDomain,
 } from "@/lib/vercel/client";
-import {
-  requireOperatorAuth,
-  authFailureResponse,
-} from "@/lib/auth/operator-token";
+import { requireOperatorAuth } from "@/lib/auth/operator-token";
+import { resolveRequestOwner } from "@/lib/auth/request-owner";
+import { ensureProjectRepositoriesSchema } from "@/lib/projects/repository-schema";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/**
- * POST /api/projects/sync
- *
- * Cross-references the Vercel project list and the GitHub repo list
- * to upsert rows in `projects`. Each row gets:
- *   - id: slug derived from the project's name (or repo when no project)
- *   - name, description
- *   - github_* fields when a matching repo exists
- *   - vercel_project_id, vercel_url when a matching deploy exists
- *
- * Idempotent: existing rows get updated; nothing is deleted.
- *
- * Bearer-token protected, audit-logged.
- */
-export async function POST(req: Request) {
-  const auth = requireOperatorAuth(req);
-  if (!auth.ok) return authFailureResponse(auth);
+interface Membership {
+  project_id: string;
+  repo_full_name: string;
+  is_primary: boolean;
+}
 
-  const [vercelProjects, ghRepos] = await Promise.all([
-    vercelListProjects({ auditUserId: auth.userId, max: 200 }).catch(
-      (err) => {
-        return { error: err instanceof Error ? err.message : String(err), data: [] as const };
-      },
-    ),
-    listAllUserRepos({ auditUserId: auth.userId, max: 200 }).catch(
-      (err) => {
-        return { error: err instanceof Error ? err.message : String(err), data: [] as const };
-      },
-    ),
+/** Synchronize inventory without flattening multi-repository projects. */
+export async function POST(req: Request) {
+  const auth = await resolveSyncOwner(req);
+  if (auth instanceof Response) return auth;
+  await ensureProjectRepositoriesSchema();
+
+  const [vercelResult, githubResult] = await Promise.all([
+    vercelListProjects({ auditUserId: auth.userId, max: 500 }).catch((error) => ({
+      error: error instanceof Error ? error.message : String(error),
+      data: [] as const,
+    })),
+    listAllUserRepos({ auditUserId: auth.userId, max: 500 }).catch((error) => ({
+      error: error instanceof Error ? error.message : String(error),
+      data: [] as const,
+    })),
   ]);
 
-  const vp = Array.isArray(vercelProjects) ? vercelProjects : [];
-  const gr = Array.isArray(ghRepos) ? ghRepos : [];
-
-  // Build a unified set keyed on the GitHub repo full_name when known,
-  // or the Vercel project name otherwise.
-  type Aggregated = {
-    id: string;
-    name: string;
-    description: string | null;
-    github_repo: string | null;
-    github_private: boolean | null;
-    github_default_branch: string | null;
-    github_language: string | null;
-    github_url: string | null;
-    vercel_project_id: string | null;
-    vercel_url: string | null;
-    domain: string | null;
-  };
-  const byKey = new Map<string, Aggregated>();
-
-  for (const repo of gr) {
-    const id = slugify(repo.name);
-    byKey.set(repo.full_name.toLowerCase(), {
-      id,
-      name: repo.name,
-      description: repo.description,
-      github_repo: repo.full_name,
-      github_private: repo.private,
-      github_default_branch: repo.default_branch,
-      github_language: repo.language,
-      github_url: repo.html_url,
-      vercel_project_id: null,
-      vercel_url: null,
-      domain: null,
-    });
+  const vercelProjects = Array.isArray(vercelResult) ? vercelResult : [];
+  const githubRepos = Array.isArray(githubResult) ? githubResult : [];
+  const errors: Array<{ resource: string; message: string }> = [];
+  if (!Array.isArray(vercelResult)) {
+    errors.push({ resource: "vercel", message: vercelResult.error });
+  }
+  if (!Array.isArray(githubResult)) {
+    errors.push({ resource: "github", message: githubResult.error });
   }
 
-  for (const project of vp) {
-    const repoFullName = (project.link as { repo?: string; org?: string } | null | undefined)
-      ?.repo
-      ? `${(project.link as { repo: string; org: string }).org ?? ""}/${(project.link as { repo: string; org: string }).repo}`
-      : null;
-    const key = repoFullName ? repoFullName.toLowerCase() : `vercel:${project.name}`;
-    // Dominio CUSTOM real de Vercel (no *.vercel.app) — fiel a producción.
-    let customDomain: string | null = null;
-    try {
-      const domains = await listProjectDomains(project.id, { auditUserId: auth.userId });
-      customDomain = pickCustomDomain(domains);
-    } catch {
-      /* sin permiso o sin dominios: se deja null */
-    }
-    const prevAgg = byKey.get(key);
-    const merged: Aggregated = prevAgg
-      ? {
-          ...prevAgg,
-          vercel_project_id: project.id,
-          vercel_url: prevAgg.vercel_url ?? guessVercelUrl(project.name),
-          domain: customDomain ?? prevAgg.domain,
-        }
-      : {
-          id: slugify(project.name),
-          name: project.name,
-          description: null,
-          github_repo: null,
-          github_private: null,
-          github_default_branch: null,
-          github_language: null,
-          github_url: null,
-          vercel_project_id: project.id,
-          vercel_url: guessVercelUrl(project.name),
-          domain: customDomain,
-        };
-    byKey.set(key, merged);
+  const memberships = await queryAll<Membership>(
+    "SELECT project_id, repo_full_name, is_primary FROM project_repositories",
+  );
+  const membershipsByRepo = new Map<string, Membership[]>();
+  for (const membership of memberships) {
+    const key = membership.repo_full_name.toLowerCase();
+    membershipsByRepo.set(key, [
+      ...(membershipsByRepo.get(key) ?? []),
+      membership,
+    ]);
   }
 
+  const projectIds = new Set(
+    (await queryAll<{ id: string }>("SELECT id FROM projects")).map((row) => row.id),
+  );
   let inserted = 0;
   let updated = 0;
-  let errors: Array<{ id: string; message: string }> = [];
+  let membershipsUpdated = 0;
 
-  for (const agg of byKey.values()) {
+  for (const repo of githubRepos) {
     try {
-      const existing = (await sql`SELECT id FROM projects WHERE id = ${agg.id}`) as Array<{ id: string }>;
-      if (existing.length > 0) {
+      let linked = membershipsByRepo.get(repo.full_name.toLowerCase()) ?? [];
+      if (linked.length === 0) {
+        const existing = await queryOne<{ id: string }>(
+          "SELECT id FROM projects WHERE github_repo = $1 LIMIT 1",
+          [repo.full_name],
+        );
+        const id = existing?.id ?? nextProjectId(repo, projectIds);
+
+        if (!existing) {
+          await insertProjectFromRepo(id, repo);
+          projectIds.add(id);
+          inserted += 1;
+        }
+        await upsertMembership(id, repo, true);
+        linked = [{ project_id: id, repo_full_name: repo.full_name, is_primary: true }];
+        membershipsByRepo.set(repo.full_name.toLowerCase(), linked);
+      } else {
+        for (const membership of linked) {
+          await upsertMembership(membership.project_id, repo, membership.is_primary);
+          if (membership.is_primary) {
+            await updatePrimaryProject(membership.project_id, repo);
+          }
+        }
+        updated += linked.length;
+      }
+      membershipsUpdated += linked.length;
+    } catch (error) {
+      errors.push({
+        resource: repo.full_name,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  for (const project of vercelProjects) {
+    try {
+      const linkedRepo = vercelRepoFullName(project.link);
+      const linkedMemberships = linkedRepo
+        ? membershipsByRepo.get(linkedRepo.toLowerCase()) ?? []
+        : [];
+      let targetIds = [...new Set(linkedMemberships.map((row) => row.project_id))];
+
+      if (targetIds.length === 0) {
+        const nameMatch = await queryOne<{ id: string }>(
+          `SELECT id FROM projects
+            WHERE lower(id) = lower($1) OR lower(name) = lower($2)
+            ORDER BY CASE WHEN lower(id) = lower($1) THEN 0 ELSE 1 END
+            LIMIT 1`,
+          [slugify(project.name), project.name],
+        );
+        if (nameMatch) {
+          targetIds = [nameMatch.id];
+        } else {
+          const id = uniqueId(slugify(project.name), projectIds);
+          await sql`
+            INSERT INTO projects (id, name, vercel_project_id, vercel_url)
+            VALUES (${id}, ${project.name}, ${project.id}, ${guessVercelUrl(project.name)})
+          `;
+          projectIds.add(id);
+          targetIds = [id];
+          inserted += 1;
+        }
+      }
+
+      let customDomain: string | null = null;
+      try {
+        customDomain = pickCustomDomain(
+          await listProjectDomains(project.id, { auditUserId: auth.userId }),
+        );
+      } catch {
+        // A Vercel project without domain access still stays synchronized.
+      }
+
+      for (const id of targetIds) {
         await sql`
           UPDATE projects SET
-            name = COALESCE(${agg.name}, name),
-            description = COALESCE(${agg.description}, description),
-            github_repo = COALESCE(${agg.github_repo}, github_repo),
-            github_private = COALESCE(${agg.github_private}, github_private),
-            github_default_branch = COALESCE(${agg.github_default_branch}, github_default_branch),
-            github_language = COALESCE(${agg.github_language}, github_language),
-            github_url = COALESCE(${agg.github_url}, github_url),
-            vercel_project_id = COALESCE(${agg.vercel_project_id}, vercel_project_id),
-            vercel_url = COALESCE(${agg.vercel_url}, vercel_url),
-            domain = COALESCE(${agg.domain}, domain)
-          WHERE id = ${agg.id}
+            vercel_project_id = ${project.id},
+            vercel_url = COALESCE(vercel_url, ${guessVercelUrl(project.name)}),
+            domain = COALESCE(${customDomain}, domain),
+            updated_at = now()
+          WHERE id = ${id}
         `;
         updated += 1;
-      } else {
-        await sql`
-          INSERT INTO projects (
-            id, name, description,
-            github_repo, github_private, github_default_branch,
-            github_language, github_url,
-            vercel_project_id, vercel_url, domain
-          ) VALUES (
-            ${agg.id}, ${agg.name}, ${agg.description},
-            ${agg.github_repo}, ${agg.github_private}, ${agg.github_default_branch},
-            ${agg.github_language}, ${agg.github_url},
-            ${agg.vercel_project_id}, ${agg.vercel_url}, ${agg.domain}
-          )
-        `;
-        inserted += 1;
       }
-    } catch (err) {
+    } catch (error) {
       errors.push({
-        id: agg.id,
-        message: err instanceof Error ? err.message : String(err),
+        resource: `vercel:${project.name}`,
+        message: error instanceof Error ? error.message : String(error),
       });
     }
   }
@@ -173,29 +165,105 @@ export async function POST(req: Request) {
       ${JSON.stringify({
         inserted,
         updated,
-        total_aggregated: byKey.size,
-        vercel_count: vp.length,
-        github_count: gr.length,
+        memberships_updated: membershipsUpdated,
+        vercel_count: vercelProjects.length,
+        github_count: githubRepos.length,
         errors,
       })}::jsonb
     )
   `;
 
-  return new Response(
-    JSON.stringify({
-      ok: errors.length === 0,
-      inserted,
-      updated,
-      total: byKey.size,
-      vercel_count: vp.length,
-      github_count: gr.length,
-      errors,
-    }),
-    {
-      status: 200,
-      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
-    },
-  );
+  return json({
+    ok: errors.length === 0,
+    inserted,
+    updated,
+    memberships_updated: membershipsUpdated,
+    vercel_count: vercelProjects.length,
+    github_count: githubRepos.length,
+    errors,
+  });
+}
+
+async function resolveSyncOwner(
+  req: Request,
+): Promise<{ userId: string } | Response> {
+  const tokenAuth = requireOperatorAuth(req);
+  if (tokenAuth.ok) return { userId: tokenAuth.userId };
+
+  const access = await resolveRequestOwner();
+  if (!access.userId) return json({ error: "unauthorized" }, 401);
+  if (!access.isOwner) return json({ error: "forbidden" }, 403);
+  return { userId: access.userId };
+}
+
+async function insertProjectFromRepo(id: string, repo: RepoSummary) {
+  await sql`
+    INSERT INTO projects (
+      id, name, description, github_repo, github_private,
+      github_default_branch, github_language, github_url
+    ) VALUES (
+      ${id}, ${repo.name}, ${repo.description}, ${repo.full_name}, ${repo.private},
+      ${repo.default_branch}, ${repo.language}, ${repo.html_url}
+    )
+  `;
+}
+
+async function upsertMembership(
+  projectId: string,
+  repo: RepoSummary,
+  primary: boolean,
+) {
+  await sql`
+    INSERT INTO project_repositories (
+      project_id, repo_full_name, role, is_primary, default_branch,
+      private, language, html_url, pushed_at
+    ) VALUES (
+      ${projectId}, ${repo.full_name}, 'app', ${primary}, ${repo.default_branch},
+      ${repo.private}, ${repo.language}, ${repo.html_url}, ${repo.pushed_at}
+    )
+    ON CONFLICT (project_id, repo_full_name) DO UPDATE SET
+      default_branch = EXCLUDED.default_branch,
+      private = EXCLUDED.private,
+      language = EXCLUDED.language,
+      html_url = EXCLUDED.html_url,
+      pushed_at = EXCLUDED.pushed_at,
+      updated_at = now()
+  `;
+}
+
+async function updatePrimaryProject(projectId: string, repo: RepoSummary) {
+  await sql`
+    UPDATE projects SET
+      github_repo = ${repo.full_name},
+      github_private = ${repo.private},
+      github_default_branch = ${repo.default_branch},
+      github_language = ${repo.language},
+      github_url = ${repo.html_url},
+      updated_at = now()
+    WHERE id = ${projectId}
+  `;
+}
+
+function vercelRepoFullName(link: unknown): string | null {
+  if (!link || typeof link !== "object") return null;
+  const value = link as { repo?: unknown; org?: unknown };
+  if (typeof value.repo !== "string" || !value.repo.trim()) return null;
+  if (typeof value.org !== "string" || !value.org.trim()) return null;
+  return `${value.org}/${value.repo}`;
+}
+
+function nextProjectId(repo: RepoSummary, existing: Set<string>): string {
+  const simple = slugify(repo.name);
+  if (!existing.has(simple)) return simple;
+  return uniqueId(slugify(`${repo.owner}-${repo.name}`), existing);
+}
+
+function uniqueId(base: string, existing: Set<string>): string {
+  const safeBase = base || "project";
+  if (!existing.has(safeBase)) return safeBase;
+  let suffix = 2;
+  while (existing.has(`${safeBase}-${suffix}`)) suffix += 1;
+  return `${safeBase}-${suffix}`;
 }
 
 function slugify(input: string): string {
@@ -208,4 +276,11 @@ function slugify(input: string): string {
 
 function guessVercelUrl(projectName: string): string {
   return `https://${projectName}.vercel.app`;
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+  });
 }

--- a/app/app/projects/page.tsx
+++ b/app/app/projects/page.tsx
@@ -11,6 +11,8 @@ import {
   IconUsers,
 } from "@/components/brand/VFIcons";
 import { InviteShare } from "@/components/live/InviteShare";
+import { RepositoryGroupManager } from "@/components/projects/RepositoryGroupManager";
+import type { ProjectRepository } from "@/lib/projects/repository-groups";
 
 interface Project {
   id: string;
@@ -25,6 +27,8 @@ interface Project {
   delivery_priority?: boolean;
   progress_pct?: number;
   family_code?: string | null;
+  repositories: ProjectRepository[];
+  repository_count: number;
 }
 
 type CategoryFilter = "all" | "produccion" | "revision" | "pausa";
@@ -85,6 +89,8 @@ export default function ProjectsPage() {
   const [familyFilter, setFamilyFilter] = useState<FamilyFilter>("all");
   const [inviteProject, setInviteProject] = useState<Project | null>(null);
   const [savingId, setSavingId] = useState<string | null>(null);
+  const [repositoryProject, setRepositoryProject] = useState<Project | null>(null);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
 
   const loadProjects = useCallback(async (manual = false) => {
     manual ? setRefreshing(true) : setLoading(true);
@@ -109,6 +115,41 @@ export default function ProjectsPage() {
       setRefreshing(false);
     }
   }, []);
+
+  const syncProjects = useCallback(async () => {
+    setRefreshing(true);
+    setError(null);
+    setSyncMessage("Sincronizando GitHub y Vercel…");
+    try {
+      const response = await fetch("/api/projects/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const payload = (await response.json()) as {
+        github_count?: number;
+        vercel_count?: number;
+        inserted?: number;
+        errors?: Array<unknown>;
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(payload.error ?? `HTTP ${response.status}`);
+      }
+      setSyncMessage(
+        `${payload.github_count ?? 0} repos · ${payload.vercel_count ?? 0} proyectos Vercel · ${payload.inserted ?? 0} nuevos`,
+      );
+      await loadProjects();
+    } catch (caught) {
+      setSyncMessage(null);
+      setError(
+        caught instanceof Error
+          ? `No se pudo sincronizar: ${caught.message}`
+          : "No se pudo sincronizar GitHub y Vercel.",
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  }, [loadProjects]);
 
   useEffect(() => {
     void loadProjects();
@@ -147,6 +188,9 @@ export default function ProjectsPage() {
         project.id.toLowerCase().includes(needle) ||
         (project.domain ?? "").toLowerCase().includes(needle) ||
         (project.github_repo ?? "").toLowerCase().includes(needle) ||
+        (project.repositories ?? []).some((repo) =>
+          repo.repo_full_name.toLowerCase().includes(needle),
+        ) ||
         (project.family_code ?? "").toLowerCase().includes(needle);
       return matchesSearch;
     });
@@ -237,15 +281,31 @@ export default function ProjectsPage() {
           </div>
           <button
             type="button"
-            onClick={() => void loadProjects(true)}
+            onClick={() => void syncProjects()}
             disabled={refreshing}
             className="btn-ghost self-start md:self-auto"
           >
             <IconRefresh size={13} className={refreshing ? "animate-spin" : ""} />
-            Actualizar
+            Sincronizar
           </button>
         </div>
       </header>
+
+      {syncMessage ? (
+        <div className="border-b border-[var(--border-1)] bg-white px-5 py-3 font-mono text-[9px] uppercase tracking-[0.11em] text-[var(--fg-secondary)] md:px-8">
+          {syncMessage}
+        </div>
+      ) : null}
+
+      {repositoryProject ? (
+        <RepositoryGroupManager
+          projectId={repositoryProject.id}
+          projectName={repositoryProject.name}
+          initialRepositories={repositoryProject.repositories ?? []}
+          onClose={() => setRepositoryProject(null)}
+          onChanged={() => void loadProjects()}
+        />
+      ) : null}
 
       {inviteProject ? (
         <div className="border-b border-[var(--border-1)] bg-[#f7f7f5] px-5 py-6 md:px-8">
@@ -370,6 +430,7 @@ export default function ProjectsPage() {
                   })()
                 }
                 onInvite={() => setInviteProject(project)}
+                onRepositories={() => setRepositoryProject(project)}
                 onTogglePriority={() =>
                   void patchMeta(project.id, {
                     delivery_priority: !project.delivery_priority,
@@ -419,6 +480,7 @@ function ProjectRow({
   saving,
   relatedHint,
   onInvite,
+  onRepositories,
   onTogglePriority,
   onProgress,
   onFamily,
@@ -427,6 +489,7 @@ function ProjectRow({
   saving: boolean;
   relatedHint: string | null;
   onInvite: () => void;
+  onRepositories: () => void;
   onTogglePriority: () => void;
   onProgress: (pct: number) => void;
   onFamily: (code: string | null) => void;
@@ -502,6 +565,11 @@ function ProjectRow({
         <p className="mt-1 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
           {CATEGORY_LABELS[project.category] ?? project.category}
         </p>
+        {(project.repository_count ?? project.repositories?.length ?? 0) > 1 ? (
+          <p className="mt-1 font-mono text-[8px] uppercase tracking-[0.1em]">
+            {project.repository_count ?? project.repositories.length} repositorios en el grupo
+          </p>
+        ) : null}
       </div>
 
       <div className="min-w-0">
@@ -540,6 +608,17 @@ function ProjectRow({
       </div>
 
       <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+        <button
+          type="button"
+          onClick={onRepositories}
+          className="btn-ghost !min-h-9 !px-3"
+          title="Agrupar repositorios"
+        >
+          <IconGithub size={12} />
+          <span className="hidden xl:inline">
+            Repos · {project.repository_count ?? project.repositories?.length ?? 0}
+          </span>
+        </button>
         {externalUrl ? (
           <a
             href={externalUrl}

--- a/components/live/ProjectContextPanel.tsx
+++ b/components/live/ProjectContextPanel.tsx
@@ -30,6 +30,14 @@ interface ContextPayload {
     last_audit_at: string | null;
   };
   integrations: Array<{ kind: string; label: string; status: string }>;
+  repositories: Array<{
+    repo_full_name: string;
+    role: string;
+    is_primary: boolean;
+    default_branch: string | null;
+    language: string | null;
+    html_url: string | null;
+  }>;
   document: { content: string; updated_by: string | null; updated_at: string | null };
   assets: Array<{
     id: string;
@@ -246,11 +254,28 @@ export function ProjectContextPanel({
               <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">Código y publicación</p>
               <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[10px]">
                 <dt className="text-[var(--fg-muted)]">Estado</dt><dd className="truncate text-right">{data.project.status}</dd>
-                <dt className="text-[var(--fg-muted)]">Repositorio</dt><dd className="truncate text-right">{data.project.github_repo || "Sin enlazar"}</dd>
+                <dt className="text-[var(--fg-muted)]">Repositorio principal</dt><dd className="truncate text-right">{data.project.github_repo || "Sin enlazar"}</dd>
                 <dt className="text-[var(--fg-muted)]">Rama</dt><dd className="truncate text-right">{data.project.github_default_branch || "—"}</dd>
                 <dt className="text-[var(--fg-muted)]">Vercel</dt><dd className="truncate text-right">{data.project.domain || data.project.vercel_url || "Sin publicar"}</dd>
                 <dt className="text-[var(--fg-muted)]">Auditoría</dt><dd className="truncate text-right">{data.project.last_audit_score ?? "—"}</dd>
               </dl>
+              {data.repositories?.length ? (
+                <div className="mt-3 border-t border-[var(--border-1)] pt-2">
+                  <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
+                    Grupo · {data.repositories.length} repositorios
+                  </p>
+                  <div className="mt-2 space-y-1.5">
+                    {data.repositories.map((repository) => (
+                      <div key={repository.repo_full_name} className="flex items-center justify-between gap-3 text-[9px]">
+                        <span className="truncate">{repository.repo_full_name}</span>
+                        <span className="shrink-0 font-mono text-[7px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">
+                          {repository.role}{repository.is_primary ? " · principal" : ""}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
             </div>
             <div className="rounded-md border border-[var(--border-1)] p-3">
               <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">Integraciones reales</p>

--- a/components/projects/RepositoryGroupManager.tsx
+++ b/components/projects/RepositoryGroupManager.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  IconCheck,
+  IconGithub,
+  IconPlus,
+  IconTrash,
+  IconX,
+} from "@/components/brand/VFIcons";
+import {
+  PROJECT_REPOSITORY_ROLES,
+  type ProjectRepository,
+  type ProjectRepositoryRole,
+} from "@/lib/projects/repository-groups";
+
+interface AvailableRepo {
+  full_name: string;
+  private: boolean;
+  language: string | null;
+  updated_at: string | null;
+}
+
+const ROLE_LABEL: Record<ProjectRepositoryRole, string> = {
+  app: "App",
+  frontend: "Frontend",
+  backend: "Backend",
+  api: "API",
+  admin: "Administración",
+  mobile: "Móvil",
+  infra: "Infraestructura",
+  docs: "Documentación",
+  shared: "Compartido",
+  other: "Otro",
+};
+
+export function RepositoryGroupManager({
+  projectId,
+  projectName,
+  initialRepositories,
+  onClose,
+  onChanged,
+}: {
+  projectId: string;
+  projectName: string;
+  initialRepositories: ProjectRepository[];
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [repositories, setRepositories] = useState(initialRepositories);
+  const [available, setAvailable] = useState<AvailableRepo[]>([]);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/github/repos?max=500", { cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return (await response.json()) as {
+          repos?: AvailableRepo[];
+          needsConnect?: string;
+        };
+      })
+      .then((payload) => {
+        if (!active) return;
+        if (payload.needsConnect) {
+          setError("Conecta GitHub antes de administrar repositorios.");
+        }
+        setAvailable(Array.isArray(payload.repos) ? payload.repos : []);
+      })
+      .catch(() => {
+        if (active) setError("No se pudo leer el inventario de GitHub.");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const currentNames = useMemo(
+    () => new Set(repositories.map((repo) => repo.repo_full_name.toLowerCase())),
+    [repositories],
+  );
+  const candidates = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return available
+      .filter((repo) => !currentNames.has(repo.full_name.toLowerCase()))
+      .filter((repo) => !needle || repo.full_name.toLowerCase().includes(needle))
+      .slice(0, 80);
+  }, [available, currentNames, search]);
+
+  async function upsert(
+    repoFullName: string,
+    role: ProjectRepositoryRole,
+    isPrimary = false,
+  ) {
+    setSaving(repoFullName);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/projects/${encodeURIComponent(projectId)}/repositories`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            repo_full_name: repoFullName,
+            role,
+            is_primary: isPrimary,
+          }),
+        },
+      );
+      const payload = (await response.json()) as {
+        repositories?: ProjectRepository[];
+        error?: string;
+      };
+      if (!response.ok) throw new Error(payload.error ?? "save_failed");
+      setRepositories(payload.repositories ?? []);
+      onChanged();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "No se pudo guardar el repositorio.",
+      );
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function remove(repoFullName: string) {
+    setSaving(repoFullName);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/projects/${encodeURIComponent(projectId)}/repositories?repo=${encodeURIComponent(repoFullName)}`,
+        { method: "DELETE" },
+      );
+      const payload = (await response.json()) as {
+        repositories?: ProjectRepository[];
+        error?: string;
+      };
+      if (!response.ok) throw new Error(payload.error ?? "delete_failed");
+      setRepositories(payload.repositories ?? []);
+      onChanged();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "No se pudo quitar el repositorio.",
+      );
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-end justify-center bg-black/50 p-0 md:items-center md:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="repository-group-title"
+    >
+      <div className="flex max-h-[92vh] w-full max-w-3xl flex-col border border-black bg-white shadow-2xl">
+        <header className="flex items-start justify-between gap-4 border-b border-[var(--border-1)] px-5 py-5 md:px-7">
+          <div>
+            <p className="mono-label">Grupo de repositorios</p>
+            <h2 id="repository-group-title" className="mt-2 text-2xl font-semibold tracking-[-0.04em]">
+              {projectName}
+            </h2>
+            <p className="mt-2 max-w-xl text-[12px] leading-5 text-[var(--fg-secondary)]">
+              Un proyecto puede reunir frontend, API, administración, móvil e
+              infraestructura. El principal conserva compatibilidad con deploys y herramientas existentes.
+            </p>
+          </div>
+          <button type="button" onClick={onClose} className="btn-ghost !min-h-9 !px-3" aria-label="Cerrar">
+            <IconX size={14} />
+          </button>
+        </header>
+
+        <div className="overflow-y-auto">
+          <section className="border-b border-[var(--border-1)] px-5 py-5 md:px-7">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h3 className="text-[13px] font-medium">Repositorios del proyecto</h3>
+              <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
+                {repositories.length} enlazados
+              </span>
+            </div>
+            {repositories.length === 0 ? (
+              <p className="border border-dashed border-[var(--border-1)] px-4 py-6 text-[12px] text-[var(--fg-muted)]">
+                Agrega el primer repositorio; quedará como principal.
+              </p>
+            ) : (
+              <div className="divide-y divide-[var(--border-1)] border border-[var(--border-1)]">
+                {repositories.map((repo) => (
+                  <div key={repo.repo_full_name} className="grid gap-3 px-3 py-3 md:grid-cols-[minmax(0,1fr)_150px_auto] md:items-center">
+                    <div className="min-w-0">
+                      <p className="flex items-center gap-2 truncate font-mono text-[11px]">
+                        <IconGithub size={12} className="shrink-0" />
+                        <span className="truncate">{repo.repo_full_name}</span>
+                      </p>
+                      <p className="mt-1 font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
+                        {repo.is_primary ? "Principal" : "Relacionado"}
+                        {repo.language ? ` · ${repo.language}` : ""}
+                      </p>
+                    </div>
+                    <select
+                      value={repo.role}
+                      disabled={saving === repo.repo_full_name}
+                      onChange={(event) =>
+                        void upsert(
+                          repo.repo_full_name,
+                          event.target.value as ProjectRepositoryRole,
+                        )
+                      }
+                      className="min-h-9 rounded border border-[var(--border-1)] bg-white px-2 font-mono text-[9px] uppercase"
+                      aria-label={`Rol de ${repo.repo_full_name}`}
+                    >
+                      {PROJECT_REPOSITORY_ROLES.map((role) => (
+                        <option key={role} value={role}>{ROLE_LABEL[role]}</option>
+                      ))}
+                    </select>
+                    <div className="flex items-center gap-1 md:justify-end">
+                      {!repo.is_primary ? (
+                        <button
+                          type="button"
+                          disabled={saving === repo.repo_full_name}
+                          onClick={() => void upsert(repo.repo_full_name, repo.role, true)}
+                          className="btn-ghost !min-h-9 !px-3"
+                        >
+                          <IconCheck size={11} /> Principal
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        disabled={saving === repo.repo_full_name}
+                        onClick={() => void remove(repo.repo_full_name)}
+                        className="btn-ghost !min-h-9 !px-3"
+                        aria-label={`Quitar ${repo.repo_full_name}`}
+                      >
+                        <IconTrash size={11} />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="px-5 py-5 md:px-7">
+            <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h3 className="text-[13px] font-medium">Agregar desde GitHub</h3>
+                <p className="mt-1 text-[11px] text-[var(--fg-muted)]">
+                  Inventario real de la cuenta conectada.
+                </p>
+              </div>
+              <input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Buscar owner/repositorio"
+                className="min-h-10 w-full rounded border border-[var(--border-1)] bg-white px-3 font-mono text-[10px] md:max-w-xs"
+              />
+            </div>
+
+            {error ? (
+              <p className="mt-3 border border-black px-3 py-3 text-[11px]">{error}</p>
+            ) : null}
+
+            <div className="mt-4 max-h-64 divide-y divide-[var(--border-1)] overflow-y-auto border border-[var(--border-1)]">
+              {loading ? (
+                <p className="px-4 py-6 text-[11px] text-[var(--fg-muted)]">Leyendo GitHub…</p>
+              ) : candidates.length === 0 ? (
+                <p className="px-4 py-6 text-[11px] text-[var(--fg-muted)]">
+                  No hay repositorios disponibles con ese filtro.
+                </p>
+              ) : (
+                candidates.map((repo) => (
+                  <div key={repo.full_name} className="flex items-center justify-between gap-3 px-3 py-3">
+                    <div className="min-w-0">
+                      <p className="truncate font-mono text-[10px]">{repo.full_name}</p>
+                      <p className="mt-1 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
+                        {repo.private ? "Privado" : "Público"}{repo.language ? ` · ${repo.language}` : ""}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      disabled={saving === repo.full_name}
+                      onClick={() => void upsert(repo.full_name, "app")}
+                      className="btn-ghost !min-h-9 shrink-0 !px-3"
+                    >
+                      <IconPlus size={11} /> Agregar
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -901,7 +901,7 @@ export async function runMcpTool(
       const allowed = await authorizeMcpProject(projectId, principal);
       if (!allowed) return err("Proyecto no encontrado o sin acceso para este token MCP.");
 
-      const [project, integrations, document, assets] = await Promise.all([
+      const [project, integrations, repositories, document, assets] = await Promise.all([
         queryOne<{
           id: string; name: string; description: string | null; github_repo: string | null;
           github_default_branch: string | null; github_url: string | null; vercel_url: string | null;
@@ -914,6 +914,13 @@ export async function runMcpTool(
         ),
         queryAll<{ kind: string; label: string; status: string }>(
           "SELECT kind, label, status FROM project_integrations WHERE project_id = $1 ORDER BY kind",
+          [projectId],
+        ).catch(() => []),
+        queryAll<{ repo_full_name: string; role: string; is_primary: boolean; default_branch: string | null }>(
+          `SELECT repo_full_name, role, is_primary, default_branch
+             FROM project_repositories
+            WHERE project_id = $1
+            ORDER BY is_primary DESC, role, repo_full_name`,
           [projectId],
         ).catch(() => []),
         queryOne<{ content: string; updated_by: string; updated_at: string }>(
@@ -930,12 +937,18 @@ export async function runMcpTool(
       const integrationsText = integrations.length
         ? integrations.map((item) => `• ${item.label} (${item.kind}): ${item.status}`).join("\n")
         : "• Sin integraciones registradas.";
+      const repositoriesText = repositories.length
+        ? repositories
+            .map((item) => `• ${item.repo_full_name} · ${item.role}${item.is_primary ? " · principal" : ""} · rama ${item.default_branch ?? "sin definir"}`)
+            .join("\n")
+        : `• ${project.github_repo ?? "Sin repositorios enlazados."}`;
       const assetsText = assets.length
         ? assets.map((item) => `• ${item.filename} · id ${item.id} · ${item.size_bytes} bytes · texto extraído ${item.extracted_text_bytes} bytes`).join("\n")
         : "• Sin archivos de contexto.";
       return text(
         `# Contexto — ${project.name} (${project.id})\n\n` +
-        `## Código y publicación\nEstado: ${project.status}\nRepo: ${project.github_repo ?? "sin repo"}\nRama: ${project.github_default_branch ?? "sin rama"}\nGitHub: ${project.github_url ?? "sin URL"}\nVercel: ${project.vercel_url ?? "sin URL"}\nDominio: ${project.domain ?? "sin dominio"}\nAuditoría: ${project.last_audit_score ?? "sin score"} · ${project.last_audit_at ?? "sin fecha"}\n\n` +
+        `## Código y publicación\nEstado: ${project.status}\nRepo principal: ${project.github_repo ?? "sin repo"}\nRama principal: ${project.github_default_branch ?? "sin rama"}\nGitHub: ${project.github_url ?? "sin URL"}\nVercel: ${project.vercel_url ?? "sin URL"}\nDominio: ${project.domain ?? "sin dominio"}\nAuditoría: ${project.last_audit_score ?? "sin score"} · ${project.last_audit_at ?? "sin fecha"}\n\n` +
+        `## Grupo de repositorios\n${repositoriesText}\n\n` +
         `## Integraciones\n${integrationsText}\n\n` +
         `## CONTENIDO.md\n${document?.content?.trim() || project.description || "Sin contenido documentado todavía."}\n\n` +
         `## Archivos privados\n${assetsText}\n\n` +

--- a/lib/projects/repository-groups.ts
+++ b/lib/projects/repository-groups.ts
@@ -1,0 +1,35 @@
+export const PROJECT_REPOSITORY_ROLES = [
+  "app",
+  "frontend",
+  "backend",
+  "api",
+  "admin",
+  "mobile",
+  "infra",
+  "docs",
+  "shared",
+  "other",
+] as const;
+
+export type ProjectRepositoryRole = (typeof PROJECT_REPOSITORY_ROLES)[number];
+
+export interface ProjectRepository {
+  repo_full_name: string;
+  role: ProjectRepositoryRole;
+  is_primary: boolean;
+  default_branch: string | null;
+  private: boolean | null;
+  language: string | null;
+  html_url: string | null;
+  pushed_at: string | null;
+}
+
+export function isProjectRepositoryRole(
+  value: unknown,
+): value is ProjectRepositoryRole {
+  return (
+    typeof value === "string" &&
+    PROJECT_REPOSITORY_ROLES.includes(value as ProjectRepositoryRole)
+  );
+}
+

--- a/lib/projects/repository-schema.ts
+++ b/lib/projects/repository-schema.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+import { sql } from "@/lib/db/client";
+
+let schemaReady = false;
+
+/** Idempotent fallback for production environments where migrations lag deploys. */
+export async function ensureProjectRepositoriesSchema(): Promise<void> {
+  if (schemaReady) return;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS project_repositories (
+      project_id text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      repo_full_name text NOT NULL,
+      role text NOT NULL DEFAULT 'app',
+      is_primary boolean NOT NULL DEFAULT false,
+      default_branch text,
+      private boolean,
+      language text,
+      html_url text,
+      pushed_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (project_id, repo_full_name)
+    )
+  `;
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_project_repositories_one_primary
+    ON project_repositories (project_id) WHERE is_primary
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_project_repositories_repo
+    ON project_repositories (lower(repo_full_name))
+  `;
+  await sql`
+    INSERT INTO project_repositories (
+      project_id, repo_full_name, role, is_primary,
+      default_branch, private, language, html_url
+    )
+    SELECT id, github_repo, 'app', true,
+           github_default_branch, github_private, github_language, github_url
+      FROM projects
+     WHERE github_repo IS NOT NULL AND btrim(github_repo) <> ''
+    ON CONFLICT (project_id, repo_full_name) DO UPDATE SET
+      default_branch = COALESCE(EXCLUDED.default_branch, project_repositories.default_branch),
+      private = COALESCE(EXCLUDED.private, project_repositories.private),
+      language = COALESCE(EXCLUDED.language, project_repositories.language),
+      html_url = COALESCE(EXCLUDED.html_url, project_repositories.html_url),
+      updated_at = now()
+  `;
+
+  schemaReady = true;
+}
+

--- a/migrations/043_project_repositories.sql
+++ b/migrations/043_project_repositories.sql
@@ -1,0 +1,49 @@
+-- A project is a product/workstream and can be backed by more than one repo.
+-- projects.github_repo stays as the compatible primary-repo pointer.
+
+CREATE TABLE IF NOT EXISTS project_repositories (
+  project_id       text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  repo_full_name   text NOT NULL,
+  role             text NOT NULL DEFAULT 'app'
+                   CHECK (role IN (
+                     'app', 'frontend', 'backend', 'api', 'admin',
+                     'mobile', 'infra', 'docs', 'shared', 'other'
+                   )),
+  is_primary       boolean NOT NULL DEFAULT false,
+  default_branch   text,
+  private          boolean,
+  language         text,
+  html_url         text,
+  pushed_at        timestamptz,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, repo_full_name)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_project_repositories_one_primary
+  ON project_repositories (project_id)
+  WHERE is_primary;
+
+CREATE INDEX IF NOT EXISTS idx_project_repositories_repo
+  ON project_repositories (lower(repo_full_name));
+
+INSERT INTO project_repositories (
+  project_id, repo_full_name, role, is_primary,
+  default_branch, private, language, html_url
+)
+SELECT
+  id, github_repo, 'app', true,
+  github_default_branch, github_private, github_language, github_url
+FROM projects
+WHERE github_repo IS NOT NULL AND btrim(github_repo) <> ''
+ON CONFLICT (project_id, repo_full_name) DO UPDATE SET
+  is_primary = true,
+  default_branch = COALESCE(EXCLUDED.default_branch, project_repositories.default_branch),
+  private = COALESCE(EXCLUDED.private, project_repositories.private),
+  language = COALESCE(EXCLUDED.language, project_repositories.language),
+  html_url = COALESCE(EXCLUDED.html_url, project_repositories.html_url),
+  updated_at = now();
+
+INSERT INTO schema_migrations (version) VALUES ('043_project_repositories')
+ON CONFLICT (version) DO NOTHING;
+

--- a/services/vforge-api/server.mjs
+++ b/services/vforge-api/server.mjs
@@ -495,7 +495,7 @@ async function liveContext(req, res, projectId) {
     return;
   }
 
-  const [projects, integrations, documents, assets] = await Promise.all([
+  const [projects, integrations, repositories, documents, assets] = await Promise.all([
     sql.query(
       `SELECT id, name, description, github_repo, github_default_branch,
               github_url, vercel_url, domain, status, last_audit_score, last_audit_at
@@ -509,6 +509,14 @@ async function liveContext(req, res, projectId) {
         ORDER BY kind`,
       [projectId],
     ),
+    sql.query(
+      `SELECT repo_full_name, role, is_primary, default_branch, private,
+              language, html_url, pushed_at
+         FROM project_repositories
+        WHERE project_id = $1
+        ORDER BY is_primary DESC, role, repo_full_name`,
+      [projectId],
+    ).catch(() => []),
     sql.query(
       `SELECT content, updated_by, updated_at
          FROM project_context_documents
@@ -532,6 +540,7 @@ async function liveContext(req, res, projectId) {
   json(res, 200, {
     project: projects[0],
     integrations,
+    repositories,
     document: documents[0] || { content: "", updated_by: null, updated_at: null },
     assets,
     me: { role: access.role, canWrite: canWriteContext(access.role) },


### PR DESCRIPTION
## Qué cambia
- un proyecto puede reunir varios repositorios con rol y repo principal
- el catálogo ejecuta sincronización real de GitHub y Vercel
- la sala y el MCP exponen el grupo completo de repositorios
- mantiene `projects.github_repo` como compatibilidad

## Verificación
- `npm run typecheck`
- `npm test` (38/38)
- `npm run build`
- `node --check services/vforge-api/server.mjs`

## Migración
- `043_project_repositories.sql`
- fallback idempotente desde la app para despliegues donde la migración llegue después