### PR TITLE
fix: evitar pantallas antiguas en la PWA

### DIFF
--- a/components/pwa/RegisterSW.tsx
+++ b/components/pwa/RegisterSW.tsx
@@ -35,9 +35,10 @@ export function RegisterSW() {
     };
 
     navigator.serviceWorker
-      .register("/sw.js")
+      .register("/sw.js", { updateViaCache: "none" })
       .then((registration) => {
         reg = registration;
+        void registration.update().catch(() => {});
 
         // Ya hay uno esperando de una visita anterior.
         if (registration.waiting) promote(registration.waiting);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,9 @@
 // VForge minimal service worker — offline shell + network-first for documents
 // Bump VERSION on every deploy where you want forced cache invalidation
-const VERSION = "vforge-scoped-workspace-2026-08-30-1";
-const SHELL = ["/", "/app/chat", "/offline"];
+const VERSION = "vforge-project-repos-2026-08-30-2";
+// Nunca precachear pantallas autenticadas: su HTML debe corresponder siempre
+// al deployment actual y a la sesión activa.
+const SHELL = ["/", "/offline"];
 
 self.addEventListener("install", (event) => {
   event.waitUntil(caches.open(VERSION).then((c) => c.addAll(SHELL)).catch(() => {}));
@@ -34,10 +36,26 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  const isAuthenticatedApp =
+    url.pathname.startsWith("/app") ||
+    url.pathname.startsWith("/workspace") ||
+    url.pathname.startsWith("/onboarding") ||
+    url.pathname.startsWith("/sign-in") ||
+    url.pathname.startsWith("/sign-up");
+
+  // Las consolas privadas no usan fallback cacheado. Un catálogo viejo es más
+  // peligroso que mostrar la pantalla offline correcta.
+  if (isAuthenticatedApp) {
+    event.respondWith(
+      fetch(new Request(req, { cache: "no-store" })).catch(() => caches.match("/offline"))
+    );
+    return;
+  }
+
   // Network-first para HTML/navigation — siempre intenta versión nueva.
   if (req.mode === "navigate") {
     event.respondWith(
-      fetch(req)
+      fetch(new Request(req, { cache: "no-store" }))
         .then((res) => {
           const copy = res.clone();
           caches.open(VERSION).then((c) => c.put(req, copy));


### PR DESCRIPTION
- invalida el caché viejo del service worker
- elimina pantallas autenticadas del precache
- fuerza red sin caché para /app, /workspace y autenticación
- obliga al navegador a revisar sw.js sin caché HTTP

Verificado: node --check, ESLint dirigido, typecheck, 38 pruebas y build de producción.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline/PWA fetch behavior for all authenticated routes; misconfiguration could break offline UX or delay update prompts, but it reduces risk of serving stale private UI.
> 
> **Overview**
> **Fixes PWA users seeing outdated authenticated UI** by tightening how the service worker caches and how updates are detected.
> 
> `RegisterSW` now registers `/sw.js` with **`updateViaCache: "none"`** and triggers an immediate **`registration.update()`** so deploys are picked up without the browser serving a cached worker script.
> 
> In **`public/sw.js`**, the cache version is bumped and **`/app/chat` is removed from the install precache** so only public shell routes (`/` and `/offline`) are warmed. Authenticated areas (`/app`, `/workspace`, `/onboarding`, sign-in/up) are handled with **network-only navigation** (`cache: "no-store"`), falling back to **`/offline`** instead of any cached HTML. Other navigations also use **`no-store`** fetches before optionally caching the response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe991a76e84691fc2143d2ce048f3bbd56d63d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->