### PR TITLE
feat(live): agregar panel de referencias visuales

### DIFF
--- a/app/api/live/[projectId]/references/[referenceId]/route.ts
+++ b/app/api/live/[projectId]/references/[referenceId]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { queryOne } from "@/lib/db/client";
+import {
+  authorizeReferenceAccess,
+  ensureProjectReferencesTable,
+} from "@/lib/live/project-references";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string; referenceId: string }> },
+) {
+  const { projectId, referenceId } = await params;
+  if (!uuidPattern.test(referenceId))
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  try {
+    const access = await authorizeReferenceAccess(projectId, req.signal);
+    if (!access)
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    if (!access.canWrite)
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    await ensureProjectReferencesTable();
+    const deleted = await queryOne<{ id: string; label: string }>(
+      `DELETE FROM project_references WHERE id = $1 AND project_id = $2 RETURNING id, label`,
+      [referenceId, projectId],
+    );
+    if (!deleted)
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    await queryOne(
+      `INSERT INTO project_events (project_id, event_type, details, severity)
+       VALUES ($1, 'reference.deleted', $2::jsonb, 'low')`,
+      [
+        projectId,
+        JSON.stringify({
+          message: `Referencia eliminada: ${deleted.label}`,
+          reference_id: deleted.id,
+        }),
+      ],
+    ).catch(() => null);
+    return NextResponse.json(
+      { deleted: true },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch {
+    return NextResponse.json({ error: "service_unavailable" }, { status: 503 });
+  }
+}

--- a/app/api/live/[projectId]/references/route.ts
+++ b/app/api/live/[projectId]/references/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { queryAll, queryOne } from "@/lib/db/client";
+import {
+  authorizeReferenceAccess,
+  ensureProjectReferencesTable,
+  normalizeReferenceUrl,
+} from "@/lib/live/project-references";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+type ReferenceKind = "page" | "component" | "inspiration";
+
+interface ReferenceRow {
+  id: string;
+  label: string;
+  url: string;
+  kind: ReferenceKind;
+  notes: string;
+  created_by: string;
+  created_at: string;
+}
+
+function json(value: unknown, status = 200) {
+  return NextResponse.json(value, { status, headers: noStore });
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  try {
+    const access = await authorizeReferenceAccess(projectId, req.signal);
+    if (!access) return json({ error: "not_found" }, 404);
+    await ensureProjectReferencesTable();
+    const references = await queryAll<ReferenceRow>(
+      `SELECT id, label, url, kind, notes, created_by, created_at
+         FROM project_references
+        WHERE project_id = $1
+        ORDER BY created_at DESC`,
+      [projectId],
+    );
+    return json({ references, canWrite: access.canWrite });
+  } catch {
+    return json({ error: "service_unavailable" }, 503);
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  try {
+    const access = await authorizeReferenceAccess(projectId, req.signal);
+    if (!access) return json({ error: "not_found" }, 404);
+    if (!access.canWrite) return json({ error: "forbidden" }, 403);
+    const payload = (await req.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    const url = normalizeReferenceUrl(payload?.url);
+    const label =
+      typeof payload?.label === "string"
+        ? payload.label.trim().slice(0, 120)
+        : "";
+    const notes =
+      typeof payload?.notes === "string"
+        ? payload.notes.trim().slice(0, 1000)
+        : "";
+    const kind: ReferenceKind | null =
+      payload?.kind === "page" ||
+      payload?.kind === "component" ||
+      payload?.kind === "inspiration"
+        ? payload.kind
+        : null;
+    if (!url || !label || !kind)
+      return json({ error: "invalid_reference" }, 400);
+
+    await ensureProjectReferencesTable();
+    const reference = await queryOne<ReferenceRow>(
+      `INSERT INTO project_references (project_id, label, url, kind, notes, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, label, url, kind, notes, created_by, created_at`,
+      [projectId, label, url, kind, notes, access.identity.email],
+    );
+    await queryOne(
+      `INSERT INTO project_events (project_id, event_type, details, severity)
+       VALUES ($1, 'reference.created', $2::jsonb, 'low')`,
+      [
+        projectId,
+        JSON.stringify({
+          message: `Referencia agregada: ${label}`,
+          reference_id: reference?.id,
+        }),
+      ],
+    ).catch(() => null);
+    return json({ reference }, 201);
+  } catch {
+    return json({ error: "service_unavailable" }, 503);
+  }
+}

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -47,6 +47,11 @@ const CodeEditorPanel = dynamic(
   { ssr: false },
 );
 
+const ReferencesPanel = dynamic(
+  () => import("@/components/live/ReferencesPanel").then((module) => module.ReferencesPanel),
+  { ssr: false },
+);
+
 export interface LivePortalProject {
   id: string;
   name: string;
@@ -55,7 +60,6 @@ export interface LivePortalProject {
   mobile_url: string | null;
   admin_url: string | null;
 }
-
 export interface LivePortalMe {
   name: string;
   role: LiveRole;
@@ -83,7 +87,8 @@ type WorkspacePanelId =
   | "activity"
   | "comments"
   | "context"
-  | "code";
+  | "code"
+  | "references";
 type WorkspacePreset = "balanced" | "previews" | "review";
 type PreviewKind = "desktop" | "mobile" | "admin";
 
@@ -127,6 +132,7 @@ const PANEL_LABELS: Record<WorkspacePanelId, string> = {
   comments: "Comentarios",
   context: "Contexto",
   code: "Código",
+  references: "Referencias",
 };
 
 
@@ -305,6 +311,7 @@ function LiveWorkspace({
       "comments",
       "context",
       "code",
+      "references",
     ],
     [canSeeAdmin],
   );
@@ -327,6 +334,7 @@ function LiveWorkspace({
     comments: false,
     context: false,
     code: false,
+    references: false,
   });
   const savedLayoutsRef = useRef(DOCK_LAYOUTS.balanced);
 
@@ -392,7 +400,7 @@ function LiveWorkspace({
       feedback: source.feedback,
     };
     setFocusedPanel(null);
-    setCollapsed({ desktop: false, mobile: false, admin: false, activity: false, comments: false, context: false, code: false });
+    setCollapsed({ desktop: false, mobile: false, admin: false, activity: false, comments: false, context: false, code: false, references: false });
     desktopRef.current?.expand();
     mobileRef.current?.expand();
     adminRef.current?.expand();
@@ -423,6 +431,7 @@ function LiveWorkspace({
     comments: commentsRef.current,
     context: contextRef.current,
     code: null,
+    references: null,
   };
 
   const updateCollapsed = (panel: WorkspacePanelId, pixels: number) => {
@@ -444,6 +453,8 @@ function LiveWorkspace({
     <ProjectContextPanel projectId={project.id} workspace onFocus={() => setFocusedPanel(null)} focused />
   ) : focusedPanel === "code" ? (
     <CodeEditorPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
+  ) : focusedPanel === "references" ? (
+    <ReferencesPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
   ) : null;
 
   return (
@@ -464,12 +475,13 @@ function LiveWorkspace({
         </div>
         <div className="flex shrink-0 items-center gap-1" aria-label="Paneles visibles">
           {availablePanels.map((panel) => {
-            const visible = panel === "code" ? focusedPanel === "code" : !collapsed[panel];
+            const standalone = panel === "code" || panel === "references";
+            const visible = standalone ? focusedPanel === panel : !collapsed[panel];
             return (
               <button
                 key={panel}
                 type="button"
-                onClick={() => panel === "code" ? focusAction("code") : togglePanel(panel, panelHandles[panel])}
+                onClick={() => standalone ? focusAction(panel) : togglePanel(panel, panelHandles[panel])}
                 aria-pressed={visible}
                 className={cn(
                   "rounded-md border px-2.5 py-2 font-mono text-[8px] uppercase tracking-[0.1em]",

--- a/components/live/ReferencesPanel.tsx
+++ b/components/live/ReferencesPanel.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  IconExtLink,
+  IconLayout,
+  IconLoader,
+  IconPlus,
+  IconRefresh,
+  IconTrash,
+  IconX,
+} from "@/components/brand/VFIcons";
+
+type ReferenceKind = "page" | "component" | "inspiration";
+type ViewportKind = "desktop" | "mobile";
+
+interface ProjectReference {
+  id: string;
+  label: string;
+  url: string;
+  kind: ReferenceKind;
+  notes: string;
+  created_by: string;
+  created_at: string;
+}
+
+const KIND_LABELS: Record<ReferenceKind, string> = {
+  page: "Página",
+  component: "Componente",
+  inspiration: "Inspiración",
+};
+
+const VIEWPORTS = {
+  desktop: { width: 1440, height: 900, label: "1440 × 900" },
+  mobile: { width: 390, height: 844, label: "390 × 844" },
+} satisfies Record<
+  ViewportKind,
+  { width: number; height: number; label: string }
+>;
+
+function referenceHostname(value: string) {
+  try {
+    return new URL(value).hostname;
+  } catch {
+    return value;
+  }
+}
+
+export function ReferencesPanel({
+  projectId,
+  onClose,
+}: {
+  projectId: string;
+  onClose: () => void;
+}) {
+  const [references, setReferences] = useState<ProjectReference[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [viewport, setViewport] = useState<ViewportKind>("desktop");
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [canWrite, setCanWrite] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [label, setLabel] = useState("");
+  const [url, setUrl] = useState("");
+  const [notes, setNotes] = useState("");
+  const [kind, setKind] = useState<ReferenceKind>("page");
+
+  const selected = useMemo(
+    () =>
+      references.find((reference) => reference.id === selectedId) ??
+      references[0] ??
+      null,
+    [references, selectedId],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(
+          `/api/live/${encodeURIComponent(projectId)}/references`,
+          {
+            cache: "no-store",
+            signal: controller.signal,
+          },
+        );
+        const payload = (await response.json().catch(() => null)) as {
+          references?: ProjectReference[];
+          canWrite?: boolean;
+        } | null;
+        if (!response.ok)
+          throw new Error("No fue posible cargar las referencias.");
+        const next = Array.isArray(payload?.references)
+          ? payload.references
+          : [];
+        setReferences(next);
+        setSelectedId((current) =>
+          current && next.some((item) => item.id === current)
+            ? current
+            : (next[0]?.id ?? null),
+        );
+        setCanWrite(Boolean(payload?.canWrite));
+      } catch (caught) {
+        if (!controller.signal.aborted)
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : "No fue posible cargar las referencias.",
+          );
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }
+    void load();
+    return () => controller.abort();
+  }, [projectId]);
+
+  async function createReference(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!label.trim() || !url.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/references`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label, url, kind, notes }),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        reference?: ProjectReference;
+      } | null;
+      if (!response.ok || !payload?.reference) {
+        throw new Error(
+          response.status === 400
+            ? "Usa una URL pública válida con https://"
+            : "No fue posible guardar la referencia.",
+        );
+      }
+      setReferences((current) => [payload.reference!, ...current]);
+      setSelectedId(payload.reference.id);
+      setLabel("");
+      setUrl("");
+      setNotes("");
+      setKind("page");
+      setShowForm(false);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "No fue posible guardar la referencia.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function removeReference(reference: ProjectReference) {
+    if (!window.confirm(`¿Eliminar la referencia “${reference.label}”?`))
+      return;
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/references/${encodeURIComponent(reference.id)}`,
+        { method: "DELETE" },
+      );
+      if (!response.ok)
+        throw new Error("No fue posible eliminar la referencia.");
+      setReferences((current) =>
+        current.filter((item) => item.id !== reference.id),
+      );
+      setSelectedId((current) => (current === reference.id ? null : current));
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "No fue posible eliminar la referencia.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-white">
+      <header className="flex min-h-12 shrink-0 items-center justify-between gap-3 border-b border-[var(--border-1)] px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <IconLayout size={12} />
+          <span className="font-mono text-[9px] uppercase tracking-[0.14em]">
+            Referencias
+          </span>
+          <span className="hidden truncate text-[10px] text-[var(--fg-muted)] sm:block">
+            Páginas, componentes y look &amp; feel del proyecto
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {canWrite ? (
+            <button
+              type="button"
+              onClick={() => setShowForm((current) => !current)}
+              className={cn(
+                "inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 font-mono text-[8px] uppercase tracking-[0.08em]",
+                showForm
+                  ? "border-black bg-black text-white"
+                  : "border-[var(--border-1)] hover:border-black",
+              )}
+            >
+              {showForm ? <IconX size={10} /> : <IconPlus size={10} />}
+              {showForm ? "Cancelar" : "Agregar"}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={onClose}
+            className="grid h-8 w-8 place-items-center rounded-md hover:bg-[var(--color-background)]"
+            aria-label="Cerrar referencias"
+          >
+            <IconX size={11} />
+          </button>
+        </div>
+      </header>
+
+      {showForm ? (
+        <form
+          onSubmit={createReference}
+          className="grid shrink-0 gap-2 border-b border-[var(--border-1)] bg-[var(--color-background)] p-3 md:grid-cols-[1fr_1.5fr_auto]"
+        >
+          <label className="grid gap-1">
+            <span className="mono-label">Nombre</span>
+            <input
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              maxLength={120}
+              placeholder="Checkout que nos gusta"
+              className="min-h-10 rounded-md border border-[var(--border-1)] bg-white px-3 text-[12px] outline-none focus:border-black"
+              required
+            />
+          </label>
+          <label className="grid gap-1">
+            <span className="mono-label">URL pública</span>
+            <input
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              type="url"
+              maxLength={2048}
+              placeholder="https://ejemplo.com/componente"
+              className="min-h-10 rounded-md border border-[var(--border-1)] bg-white px-3 text-[12px] outline-none focus:border-black"
+              required
+            />
+          </label>
+          <label className="grid gap-1">
+            <span className="mono-label">Tipo</span>
+            <select
+              value={kind}
+              onChange={(event) => setKind(event.target.value as ReferenceKind)}
+              className="min-h-10 rounded-md border border-[var(--border-1)] bg-white px-3 text-[12px] outline-none focus:border-black"
+            >
+              {Object.entries(KIND_LABELS).map(([value, text]) => (
+                <option key={value} value={value}>
+                  {text}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="grid gap-1 md:col-span-2">
+            <span className="mono-label">Nota opcional</span>
+            <input
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              maxLength={1000}
+              placeholder="Qué tomar de esta referencia"
+              className="min-h-10 rounded-md border border-[var(--border-1)] bg-white px-3 text-[12px] outline-none focus:border-black"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={saving || !label.trim() || !url.trim()}
+            className="btn-primary min-h-10 self-end disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? (
+              <IconLoader size={11} className="animate-spin" />
+            ) : (
+              <IconPlus size={11} />
+            )}{" "}
+            Guardar
+          </button>
+        </form>
+      ) : null}
+
+      {error ? (
+        <div className="shrink-0 border-b border-[var(--border-1)] px-3 py-2 text-[11px] text-[var(--color-danger)]">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid min-h-0 flex-1 md:grid-cols-[280px_minmax(0,1fr)]">
+        <aside className="min-h-0 overflow-y-auto border-b border-[var(--border-1)] bg-white md:border-b-0 md:border-r">
+          {loading ? (
+            <div className="flex items-center gap-2 p-4 text-[11px] text-[var(--fg-muted)]">
+              <IconLoader size={12} className="animate-spin" /> Cargando
+              referencias…
+            </div>
+          ) : references.length ? (
+            <div className="divide-y divide-[var(--border-1)]">
+              {references.map((reference) => (
+                <button
+                  key={reference.id}
+                  type="button"
+                  onClick={() => setSelectedId(reference.id)}
+                  className={cn(
+                    "w-full px-3 py-3 text-left hover:bg-[var(--color-background)]",
+                    selected?.id === reference.id &&
+                      "bg-black text-white hover:bg-black",
+                  )}
+                >
+                  <span className="flex items-center justify-between gap-2">
+                    <strong className="truncate text-[12px] font-medium">
+                      {reference.label}
+                    </strong>
+                    <span
+                      className={cn(
+                        "shrink-0 font-mono text-[8px] uppercase tracking-[0.08em]",
+                        selected?.id === reference.id
+                          ? "text-white/60"
+                          : "text-[var(--fg-muted)]",
+                      )}
+                    >
+                      {KIND_LABELS[reference.kind]}
+                    </span>
+                  </span>
+                  <span
+                    className={cn(
+                      "mt-1 block truncate text-[9px]",
+                      selected?.id === reference.id
+                        ? "text-white/65"
+                        : "text-[var(--fg-muted)]",
+                    )}
+                  >
+                    {referenceHostname(reference.url)}
+                  </span>
+                  {reference.notes ? (
+                    <span
+                      className={cn(
+                        "mt-2 line-clamp-2 block text-[10px] leading-4",
+                        selected?.id === reference.id
+                          ? "text-white/75"
+                          : "text-[var(--fg-muted)]",
+                      )}
+                    >
+                      {reference.notes}
+                    </span>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="p-5 text-[11px] leading-5 text-[var(--fg-muted)]">
+              Aún no hay referencias. Guarda una URL de inspiración, una página
+              o un componente para verla aquí.
+            </div>
+          )}
+        </aside>
+
+        <div className="flex min-h-[420px] min-w-0 flex-col bg-[var(--color-background)]">
+          {selected ? (
+            <>
+              <div className="flex min-h-11 shrink-0 flex-wrap items-center justify-between gap-2 border-b border-[var(--border-1)] bg-white px-3">
+                <div className="min-w-0">
+                  <p className="truncate text-[11px] font-medium">
+                    {selected.label}
+                  </p>
+                  <p className="truncate font-mono text-[8px] text-[var(--fg-muted)]">
+                    {selected.url}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  {(["desktop", "mobile"] as ViewportKind[]).map((item) => (
+                    <button
+                      key={item}
+                      type="button"
+                      onClick={() => setViewport(item)}
+                      className={cn(
+                        "h-7 rounded-md border px-2 font-mono text-[8px] uppercase",
+                        viewport === item
+                          ? "border-black bg-black text-white"
+                          : "border-[var(--border-1)] bg-white",
+                      )}
+                    >
+                      {item === "desktop" ? "Escritorio" : "Móvil"}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() => setRefreshKey((current) => current + 1)}
+                    className="grid h-7 w-7 place-items-center rounded-md hover:bg-[var(--color-background)]"
+                    aria-label="Actualizar referencia"
+                  >
+                    <IconRefresh size={10} />
+                  </button>
+                  <a
+                    href={selected.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="grid h-7 w-7 place-items-center rounded-md hover:bg-[var(--color-background)]"
+                    aria-label="Abrir referencia en otra pestaña"
+                  >
+                    <IconExtLink size={10} />
+                  </a>
+                  {canWrite ? (
+                    <button
+                      type="button"
+                      disabled={saving}
+                      onClick={() => void removeReference(selected)}
+                      className="grid h-7 w-7 place-items-center rounded-md hover:bg-[var(--color-background)] disabled:opacity-40"
+                      aria-label="Eliminar referencia"
+                    >
+                      <IconTrash size={10} />
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+              <ReferenceStage
+                key={`${selected.id}:${refreshKey}`}
+                reference={selected}
+                viewport={viewport}
+              />
+              <p className="shrink-0 border-t border-[var(--border-1)] bg-white px-3 py-2 text-[9px] text-[var(--fg-muted)]">
+                {VIEWPORTS[viewport].label} · Si el sitio bloquea iframes,
+                ábrelo con el botón externo.
+              </p>
+            </>
+          ) : (
+            <div className="grid h-full place-items-center p-8 text-center">
+              <div>
+                <IconLayout size={22} className="mx-auto" />
+                <p className="mt-3 text-[12px] font-medium">
+                  Selecciona o agrega una referencia
+                </p>
+                <p className="mt-2 text-[10px] text-[var(--fg-muted)]">
+                  Aquí podrás compararla en escritorio y móvil sin salir de la
+                  sala.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ReferenceStage({
+  reference,
+  viewport,
+}: {
+  reference: ProjectReference;
+  viewport: ViewportKind;
+}) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const spec = VIEWPORTS[viewport];
+
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry)
+        setSize({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        });
+    });
+    observer.observe(stage);
+    setSize({ width: stage.clientWidth, height: stage.clientHeight });
+    return () => observer.disconnect();
+  }, []);
+
+  const padding = viewport === "mobile" ? 24 : 12;
+  const scale =
+    size.width && size.height
+      ? Math.min(
+          (size.width - padding * 2) / spec.width,
+          (size.height - padding * 2) / spec.height,
+          1,
+        )
+      : 0;
+
+  return (
+    <div ref={stageRef} className="relative min-h-0 flex-1 overflow-hidden">
+      <div
+        className={cn(
+          "absolute left-1/2 top-1/2 overflow-hidden bg-white shadow-lg",
+          viewport === "mobile"
+            ? "rounded-[28px] border-[6px] border-black"
+            : "border border-[var(--border-1)]",
+        )}
+        style={{
+          width: spec.width,
+          height: spec.height,
+          transform: `translate(-50%, -50%) scale(${Math.max(scale, 0.01)})`,
+        }}
+      >
+        <iframe
+          src={reference.url}
+          title={`Referencia ${reference.label}`}
+          className="h-full w-full border-0 bg-white"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          referrerPolicy="no-referrer"
+        />
+      </div>
+    </div>
+  );
+}

--- a/lib/live/project-references.ts
+++ b/lib/live/project-references.ts
@@ -1,0 +1,90 @@
+import "server-only";
+
+import { queryOne } from "@/lib/db/client";
+import {
+  fetchVForgeApi,
+  getCurrentVForgeIdentity,
+  projectApiPath,
+  type VForgeIdentity,
+} from "@/lib/api/vforge-owned";
+import type { LiveRole } from "@/lib/projects/roles";
+
+export interface ReferenceAccess {
+  identity: VForgeIdentity;
+  role: LiveRole;
+  canWrite: boolean;
+}
+
+export async function ensureProjectReferencesTable(): Promise<void> {
+  await queryOne(
+    `CREATE TABLE IF NOT EXISTS project_references (
+      id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      project_id  text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      label       text NOT NULL CHECK (char_length(label) BETWEEN 1 AND 120),
+      url         text NOT NULL CHECK (char_length(url) BETWEEN 1 AND 2048),
+      kind        text NOT NULL DEFAULT 'page'
+                    CHECK (kind IN ('page', 'component', 'inspiration')),
+      notes       text NOT NULL DEFAULT '' CHECK (char_length(notes) <= 1000),
+      created_by  text NOT NULL,
+      created_at  timestamptz NOT NULL DEFAULT now()
+    )`,
+  );
+  await queryOne(
+    `CREATE INDEX IF NOT EXISTS idx_project_references_project
+       ON project_references (project_id, created_at DESC)`,
+  );
+}
+
+export async function authorizeReferenceAccess(
+  projectId: string,
+  signal: AbortSignal,
+): Promise<ReferenceAccess | null> {
+  const identity = await getCurrentVForgeIdentity();
+  if (!identity) return null;
+
+  const upstream = await fetchVForgeApi(
+    projectApiPath(projectId, "context"),
+    identity,
+    { signal },
+  );
+  if (!upstream.ok) return null;
+  const payload = (await upstream.json().catch(() => null)) as {
+    me?: { role?: LiveRole };
+  } | null;
+  const role = payload?.me?.role;
+  if (role !== "owner" && role !== "reviewer" && role !== "observer")
+    return null;
+  return { identity, role, canWrite: role === "owner" };
+}
+
+export function normalizeReferenceUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 2048) return null;
+  try {
+    const url = new URL(trimmed);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password
+    )
+      return null;
+    const hostname = url.hostname.toLowerCase();
+    if (
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      hostname === "0.0.0.0" ||
+      hostname === "::1" ||
+      /^127\./.test(hostname) ||
+      /^10\./.test(hostname) ||
+      /^192\.168\./.test(hostname) ||
+      /^169\.254\./.test(hostname) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(hostname)
+    )
+      return null;
+    url.hash = "";
+    return url.href;
+  } catch {
+    return null;
+  }
+}

--- a/migrations/044_project_references.sql
+++ b/migrations/044_project_references.sql
@@ -1,0 +1,18 @@
+-- Referencias visuales guardadas dentro de una sala live.
+
+CREATE TABLE IF NOT EXISTS project_references (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id  text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  label       text NOT NULL CHECK (char_length(label) BETWEEN 1 AND 120),
+  url         text NOT NULL CHECK (char_length(url) BETWEEN 1 AND 2048),
+  kind        text NOT NULL DEFAULT 'page'
+                CHECK (kind IN ('page', 'component', 'inspiration')),
+  notes       text NOT NULL DEFAULT '' CHECK (char_length(notes) <= 1000),
+  created_by  text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_references_project
+  ON project_references (project_id, created_at DESC);
+
+SELECT 'migracion 044 (project references) OK' AS resultado;


### PR DESCRIPTION
## Resultado
- agrega panel Referencias en cada sala live
- permite guardar múltiples URLs con tipo y notas por proyecto
- compara cada referencia en viewport escritorio o móvil
- restringe altas y bajas al owner; revisores y observadores tienen lectura
- registra creación y eliminación en actividad

## Seguridad
- autorización por membresía real de la sala
- sólo URLs HTTP(S) públicas, sin credenciales ni direcciones privadas
- iframe aislado con sandbox y sin referrer

## Verificación
- `npm run typecheck`
- ESLint en archivos tocados
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated APIs persist user-supplied URLs and render them in sandboxed iframes; SSRF-style abuse is partially mitigated by host filtering, but embedding third-party scripts in the live UI still warrants careful review.
> 
> **Overview**
> Adds a **Referencias** workspace panel in live rooms so teams can save external inspiration URLs (label, kind, notes) per project and preview them in desktop or mobile frames without leaving the portal.
> 
> Backend introduces `project_references` (migration `044` plus lazy `ensureProjectReferencesTable`), live routes for list/create/delete under `/api/live/[projectId]/references`, membership checks via upstream project context (read for owner/reviewer/observer, **write/delete only for owner**), public HTTP(S) URL normalization that blocks credentials and private hosts, and `reference.created` / `reference.deleted` activity events.
> 
> **LivePortal** wires the panel like **Código**: toolbar toggle opens a focused overlay via dynamically loaded `ReferencesPanel`, which lists references, optional owner-only create/delete, and sandboxed iframes with external-link fallback when embedding is blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce6ec2d2c45abd61ff6ac7790d81e38aa6914cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->