### PR TITLE
fix(live): compactar invitaciones en un drawer

### DIFF
--- a/components/live/InvitePanel.tsx
+++ b/components/live/InvitePanel.tsx
@@ -40,7 +40,13 @@ function invitationState(invitation: Invitation) {
   return "Pendiente";
 }
 
-export function InvitePanel({ projectId }: { projectId: string }) {
+export function InvitePanel({
+  projectId,
+  compact = false,
+}: {
+  projectId: string;
+  compact?: boolean;
+}) {
   const encodedProjectId = encodeURIComponent(projectId);
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [email, setEmail] = useState("");
@@ -125,8 +131,8 @@ export function InvitePanel({ projectId }: { projectId: string }) {
   const selectedRole = ROLES.find((item) => item.value === role);
 
   return (
-    <section className="rounded-[8px] border border-black bg-white">
-      <header className="flex flex-col gap-3 border-b border-[var(--border-1)] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+    <section className={compact ? "bg-white" : "rounded-[8px] border border-black bg-white"}>
+      <header className="flex items-center justify-between gap-3 border-b border-[var(--border-1)] px-4 py-3">
         <div className="flex items-center gap-2">
           <IconUsers size={14} />
           <div>
@@ -141,7 +147,7 @@ export function InvitePanel({ projectId }: { projectId: string }) {
         </span>
       </header>
 
-      <div className="grid gap-3 px-4 py-4 lg:grid-cols-[minmax(0,1fr)_190px_auto] lg:items-start">
+      <div className={compact ? "grid gap-3 px-4 py-4" : "grid gap-3 px-4 py-4 lg:grid-cols-[minmax(0,1fr)_190px_auto] lg:items-start"}>
         <label>
           <span className="mono-label">Correo del invitado</span>
           <input
@@ -175,7 +181,7 @@ export function InvitePanel({ projectId }: { projectId: string }) {
           type="button"
           onClick={() => void createInvitation()}
           disabled={busy || !email.trim()}
-          className="btn-primary mt-[26px] disabled:opacity-40"
+          className={compact ? "btn-primary w-full disabled:opacity-40" : "btn-primary mt-[26px] disabled:opacity-40"}
         >
           {busy ? <IconLoader size={13} className="animate-spin" /> : <IconPlus size={13} />}
           Crear invitación
@@ -183,7 +189,7 @@ export function InvitePanel({ projectId }: { projectId: string }) {
       </div>
 
       {lastLink ? (
-        <div className="mx-4 mb-4 flex flex-col gap-2 border border-black bg-[#f7f7f5] p-3 sm:flex-row sm:items-center">
+        <div className="mx-4 mb-4 flex flex-col gap-2 border border-black bg-[#f7f7f5] p-3">
           <code className="min-w-0 flex-1 break-all font-mono text-[9px]">
             {lastLink}
           </code>
@@ -201,7 +207,7 @@ export function InvitePanel({ projectId }: { projectId: string }) {
       ) : null}
 
       <div className="border-t border-[var(--border-1)]">
-        <div className="grid grid-cols-[minmax(0,1fr)_90px_90px] px-4 py-3 font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
+        <div className={compact ? "grid grid-cols-[minmax(0,1fr)_70px_72px] px-4 py-3 font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]" : "grid grid-cols-[minmax(0,1fr)_90px_90px] px-4 py-3 font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]"}>
           <span>Invitado</span>
           <span>Rol</span>
           <span className="text-right">Estado</span>
@@ -219,7 +225,7 @@ export function InvitePanel({ projectId }: { projectId: string }) {
             {invitations.map((invitation) => (
               <div
                 key={invitation.id}
-                className="grid grid-cols-[minmax(0,1fr)_90px_90px] items-center px-4 py-3 text-[10px]"
+                className={compact ? "grid grid-cols-[minmax(0,1fr)_70px_72px] items-center px-4 py-3 text-[10px]" : "grid grid-cols-[minmax(0,1fr)_90px_90px] items-center px-4 py-3 text-[10px]"}
               >
                 <span className="truncate">{invitation.email}</span>
                 <span className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -186,18 +186,22 @@ export function LivePortal({
   me: LivePortalMe;
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const canSeeAdmin = me.role === "owner" || me.role === "reviewer";
   const canInvite = me.role === "owner";
 
   useEffect(() => {
-    if (!drawerOpen) return;
+    if (!drawerOpen && !inviteOpen) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setDrawerOpen(false);
+      if (event.key === "Escape") {
+        setDrawerOpen(false);
+        setInviteOpen(false);
+      }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [drawerOpen]);
+  }, [drawerOpen, inviteOpen]);
 
   return (
     <div className="vf-mobile-stable flex h-svh overflow-hidden overscroll-none bg-[var(--color-surface)] text-[var(--color-ink)] lg:h-dvh">
@@ -230,6 +234,28 @@ export function LivePortal({
               <IconX size={14} />
             </button>
             <LiveSidebar project={project} me={me} />
+          </aside>
+        </div>
+      ) : null}
+
+      {inviteOpen ? (
+        <div className="fixed inset-0 z-[60]" role="dialog" aria-modal="true" aria-label="Invitar al proyecto">
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/30"
+            onClick={() => setInviteOpen(false)}
+            aria-label="Cerrar invitaciones"
+          />
+          <aside className="absolute inset-y-0 right-0 w-[min(92vw,420px)] overflow-y-auto border-l border-black bg-white shadow-2xl">
+            <button
+              type="button"
+              onClick={() => setInviteOpen(false)}
+              className="absolute right-3 top-2 z-10 grid h-8 w-8 place-items-center rounded-md border border-[var(--border-1)] bg-white hover:border-black"
+              aria-label="Cerrar invitaciones"
+            >
+              <IconX size={12} />
+            </button>
+            <InvitePanel projectId={project.id} compact />
           </aside>
         </div>
       ) : null}
@@ -270,22 +296,15 @@ export function LivePortal({
               {ROLE_LABEL[me.role]}
             </span>
             {canInvite ? (
-              <a href="#live-invitations" className="btn-primary !min-h-9 !px-3">
+              <button type="button" onClick={() => setInviteOpen(true)} className="btn-primary !min-h-9 !px-3">
                 <IconUsers size={12} /> <span className="hidden sm:inline">Invitar</span>
-              </a>
+              </button>
             ) : null}
           </div>
         </header>
 
         <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain bg-[var(--color-background)]">
           <LiveWorkspace project={project} me={me} canSeeAdmin={canSeeAdmin} />
-          <div className="px-3 pb-3 md:px-4 md:pb-4">
-            {canInvite ? (
-              <div id="live-invitations" className="scroll-mt-4">
-                <InvitePanel projectId={project.id} />
-              </div>
-            ) : null}
-          </div>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Resultado
- elimina el bloque grande de invitaciones debajo del workspace
- abre invitaciones en un drawer lateral de 420 px
- cierra con Escape o clic fuera
- conserva creación, alcance, copia de enlace e historial

## Verificación
- `npm run typecheck`
- ESLint focalizado
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only relocation and layout tweaks; no API or permission logic changes beyond replacing an in-page anchor with a modal drawer.
> 
> **Overview**
> **Moves project invitations out of the main scroll area** into a right-side drawer opened from the header **Invitar** control (owners only), instead of anchoring to a large panel below the workspace.
> 
> `LivePortal` adds `inviteOpen` state, a fixed overlay dialog (~420px wide) with backdrop and close controls, and extends the existing Escape handler to dismiss both the mobile nav drawer and the invite drawer. `InvitePanel` gains an optional **`compact`** prop that strips the card chrome, uses a stacked form layout (full-width create button), and tightens invitation table columns for the narrow drawer—invite creation, roles, one-time link copy, and history behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505bd1d78e9a3083d5e1d8a3d6b8089840759116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->