### PR TITLE
feat(live): add V execution control circuit

### DIFF
--- a/app/api/live/[projectId]/runs/[runId]/route.ts
+++ b/app/api/live/[projectId]/runs/[runId]/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from "next/server";
+import { queryOne } from "@/lib/db/client";
+import {
+  authorizeAgentRunAccess,
+  ensureProjectAgentRunsTable,
+  type AgentRunRow,
+} from "@/lib/live/agent-runs";
+import { parseRepoFullName, withUserGithub } from "@/lib/live/github-user";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function json(value: unknown, status = 200) {
+  return NextResponse.json(value, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string; runId: string }> },
+) {
+  const { projectId, runId } = await params;
+  if (!uuidPattern.test(runId)) return json({ error: "not_found" }, 404);
+  const access = await authorizeAgentRunAccess(projectId, req.signal);
+  if (!access) return json({ error: "not_found" }, 404);
+  if (!access.canWrite) return json({ error: "forbidden" }, 403);
+  await ensureProjectAgentRunsTable();
+  const run = await queryOne<AgentRunRow>(
+    `SELECT * FROM project_agent_runs WHERE id = $1 AND project_id = $2 LIMIT 1`,
+    [runId, projectId],
+  );
+  if (!run) return json({ error: "not_found" }, 404);
+  const payload = (await req.json().catch(() => null)) as {
+    action?: string;
+  } | null;
+  const action = payload?.action;
+
+  if (action === "cancel") {
+    if (run.status === "published")
+      return json({ error: "already_published" }, 409);
+    const updated = await queryOne<AgentRunRow>(
+      `UPDATE project_agent_runs SET status = 'cancelled', phase = 'complete', updated_at = now()
+        WHERE id = $1 RETURNING *`,
+      [runId],
+    );
+    return json({ run: updated });
+  }
+
+  const parsed = parseRepoFullName(run.repo_full_name);
+  if (!parsed) return json({ error: "invalid_repository" }, 409);
+  const [owner, repo] = parsed;
+
+  if (action === "approve") {
+    if (
+      !run.preview_url ||
+      (run.status !== "preview_ready" && run.status !== "awaiting_approval")
+    ) {
+      return json({ error: "preview_required" }, 409);
+    }
+    try {
+      const pull = await withUserGithub(
+        access.identity.userId,
+        async (github) => {
+          const created = await github.request(
+            "POST /repos/{owner}/{repo}/pulls",
+            {
+              owner,
+              repo,
+              title: `VForge: ${run.instruction.replace(/\s+/g, " ").slice(0, 90)}`,
+              head: run.work_branch,
+              base: run.base_branch,
+              body: `Run VForge ${run.id}\n\n${run.instruction}\n\nPreview: ${run.preview_url}`,
+              draft: false,
+            },
+          );
+          return created.data;
+        },
+      );
+      if (!pull) return json({ error: "connect_github" }, 409);
+      const updated = await queryOne<AgentRunRow>(
+        `UPDATE project_agent_runs
+            SET status = 'approved', pr_number = $1, pr_url = $2, approved_at = now(), updated_at = now()
+          WHERE id = $3 RETURNING *`,
+        [pull.number, pull.html_url, runId],
+      );
+      return json({ run: updated });
+    } catch (caught) {
+      return json(
+        {
+          error:
+            caught instanceof Error
+              ? caught.message.slice(0, 300)
+              : "github_error",
+        },
+        502,
+      );
+    }
+  }
+
+  if (action === "publish") {
+    if (run.status !== "approved" || !run.pr_number)
+      return json({ error: "approval_required" }, 409);
+    try {
+      const merged = await withUserGithub(
+        access.identity.userId,
+        async (github) => {
+          const response = await github.request(
+            "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge",
+            {
+              owner,
+              repo,
+              pull_number: run.pr_number!,
+              merge_method: "squash",
+              commit_title: `VForge: publicar run ${run.id.slice(0, 8)}`,
+            },
+          );
+          return response.data;
+        },
+      );
+      if (!merged) return json({ error: "connect_github" }, 409);
+      if (!merged.merged)
+        return json({ error: merged.message || "merge_blocked" }, 409);
+      const updated = await queryOne<AgentRunRow>(
+        `UPDATE project_agent_runs
+            SET status = 'published', phase = 'complete', published_at = now(), updated_at = now()
+          WHERE id = $1 RETURNING *`,
+        [runId],
+      );
+      await queryOne(
+        `INSERT INTO project_events (project_id, event_type, details, severity)
+         VALUES ($1, 'agent.run.published', $2::jsonb, 'high')`,
+        [
+          projectId,
+          JSON.stringify({
+            message: `Run publicado: ${run.work_branch}`,
+            run_id: runId,
+            pr_url: run.pr_url,
+          }),
+        ],
+      ).catch(() => null);
+      return json({ run: updated, merged: true });
+    } catch (caught) {
+      return json(
+        {
+          error:
+            caught instanceof Error
+              ? caught.message.slice(0, 300)
+              : "github_error",
+        },
+        502,
+      );
+    }
+  }
+
+  return json({ error: "invalid_action" }, 400);
+}

--- a/app/api/live/[projectId]/runs/route.ts
+++ b/app/api/live/[projectId]/runs/route.ts
@@ -1,0 +1,366 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { queryOne } from "@/lib/db/client";
+import {
+  dispatchJob,
+  getDispatchJobs,
+  type DispatchJobSnapshot,
+} from "@/lib/vulcano/operator";
+import {
+  authorizeAgentRunAccess,
+  buildAgentPrompt,
+  ensureProjectAgentRunsTable,
+  listProjectAgentRuns,
+  resolveExecutor,
+  selectAgentRepository,
+  type AgentExecutor,
+  type AgentQueueJob,
+  type AgentRunRow,
+} from "@/lib/live/agent-runs";
+import { parseRepoFullName, withUserGithub } from "@/lib/live/github-user";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+const executors = new Set<AgentExecutor>([
+  "auto",
+  "codex",
+  "claude",
+  "grok",
+  "team",
+]);
+const terminalStatuses = new Set([
+  "approved",
+  "published",
+  "failed",
+  "cancelled",
+]);
+const doneJobStatuses = new Set(["done", "completed", "success", "succeeded"]);
+const failedJobStatuses = new Set(["failed", "error", "cancelled", "canceled"]);
+
+function json(value: unknown, status = 200) {
+  return NextResponse.json(value, { status, headers: noStore });
+}
+
+function queueJobs(value: unknown): AgentQueueJob[] {
+  return Array.isArray(value)
+    ? value.filter((job): job is AgentQueueJob =>
+        Boolean(
+          job &&
+          typeof job === "object" &&
+          Number.isInteger((job as AgentQueueJob).id),
+        ),
+      )
+    : [];
+}
+
+function safeSummary(job: DispatchJobSnapshot | undefined) {
+  return (job?.result || job?.logTail || "").trim().slice(0, 12000) || null;
+}
+
+async function appendJob(
+  run: AgentRunRow,
+  job: AgentQueueJob,
+  phase: "building" | "reviewing",
+) {
+  const nextJobs = [...queueJobs(run.queue_jobs), job];
+  await queryOne(
+    `UPDATE project_agent_runs
+        SET queue_jobs = $1::jsonb, phase = $2, status = 'queued', updated_at = now(), error = NULL
+      WHERE id = $3`,
+    [JSON.stringify(nextJobs), phase, run.id],
+  );
+}
+
+async function advanceRun(
+  run: AgentRunRow,
+  snapshots: Map<number, DispatchJobSnapshot>,
+) {
+  if (
+    terminalStatuses.has(run.status) ||
+    run.status === "awaiting_approval" ||
+    run.status === "preview_ready"
+  )
+    return;
+  const jobs = queueJobs(run.queue_jobs);
+  const current = jobs[jobs.length - 1];
+  if (!current) return;
+  const snapshot = snapshots.get(current.id);
+  if (!snapshot) return;
+  const normalized = snapshot.status.toLowerCase();
+
+  if (failedJobStatuses.has(normalized)) {
+    await queryOne(
+      `UPDATE project_agent_runs SET status = 'failed', error = $1, summary = $2, updated_at = now() WHERE id = $3`,
+      [
+        `${current.agent} terminó con estado ${snapshot.status}`,
+        safeSummary(snapshot),
+        run.id,
+      ],
+    );
+    return;
+  }
+  if (!doneJobStatuses.has(normalized)) {
+    const nextStatus =
+      normalized === "pending" || normalized === "queued"
+        ? "queued"
+        : "running";
+    await queryOne(
+      `UPDATE project_agent_runs SET status = $1, summary = COALESCE($2, summary), updated_at = now() WHERE id = $3`,
+      [nextStatus, safeSummary(snapshot), run.id],
+    );
+    return;
+  }
+
+  const result = safeSummary(snapshot);
+  if (run.requested_executor === "team" && run.phase === "planning") {
+    const claimed = await queryOne<{ id: string }>(
+      `UPDATE project_agent_runs SET phase = 'building', status = 'preparing', summary = $1, updated_at = now()
+        WHERE id = $2 AND phase = 'planning' RETURNING id`,
+      [result, run.id],
+    );
+    if (!claimed) return;
+    try {
+      const prompt = buildAgentPrompt({
+        runId: run.id,
+        projectId: run.project_id,
+        repo: run.repo_full_name,
+        baseBranch: run.base_branch,
+        workBranch: run.work_branch,
+        instruction: run.instruction,
+        role: "builder",
+        priorResult: result,
+      });
+      const dispatched = await dispatchJob({
+        agent: "codex",
+        prompt,
+        priority: 3,
+        source: `vforge:${run.project_id}:${run.id}`,
+      });
+      await appendJob(
+        run,
+        { id: dispatched.id, agent: "codex", role: "builder" },
+        "building",
+      );
+    } catch (caught) {
+      await queryOne(
+        `UPDATE project_agent_runs SET status = 'failed', error = $1, updated_at = now() WHERE id = $2`,
+        [
+          caught instanceof Error
+            ? caught.message
+            : "No se pudo despachar Codex",
+          run.id,
+        ],
+      );
+    }
+    return;
+  }
+
+  if (run.requested_executor === "team" && run.phase === "building") {
+    const claimed = await queryOne<{ id: string }>(
+      `UPDATE project_agent_runs SET phase = 'reviewing', status = 'preparing', summary = $1, updated_at = now()
+        WHERE id = $2 AND phase = 'building' RETURNING id`,
+      [result, run.id],
+    );
+    if (!claimed) return;
+    try {
+      const prompt = buildAgentPrompt({
+        runId: run.id,
+        projectId: run.project_id,
+        repo: run.repo_full_name,
+        baseBranch: run.base_branch,
+        workBranch: run.work_branch,
+        instruction: run.instruction,
+        role: "reviewer",
+        priorResult: result,
+      });
+      const dispatched = await dispatchJob({
+        agent: "grok",
+        prompt,
+        priority: 4,
+        source: `vforge:${run.project_id}:${run.id}`,
+      });
+      await appendJob(
+        run,
+        { id: dispatched.id, agent: "grok", role: "reviewer" },
+        "reviewing",
+      );
+    } catch (caught) {
+      await queryOne(
+        `UPDATE project_agent_runs SET status = 'failed', error = $1, updated_at = now() WHERE id = $2`,
+        [
+          caught instanceof Error
+            ? caught.message
+            : "No se pudo despachar Grok",
+          run.id,
+        ],
+      );
+    }
+    return;
+  }
+
+  await queryOne(
+    `UPDATE project_agent_runs
+        SET phase = 'validation', status = CASE WHEN preview_url IS NULL THEN 'awaiting_preview' ELSE 'preview_ready' END,
+            summary = $1, updated_at = now()
+      WHERE id = $2`,
+    [result, run.id],
+  );
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  try {
+    const access = await authorizeAgentRunAccess(projectId, req.signal);
+    if (!access) return json({ error: "not_found" }, 404);
+    let runs = await listProjectAgentRuns(projectId);
+    const ids = runs.flatMap((run) =>
+      queueJobs(run.queue_jobs).map((job) => job.id),
+    );
+    const snapshots = new Map(
+      (await getDispatchJobs(ids)).map((job) => [job.id, job]),
+    );
+    await Promise.all(runs.map((run) => advanceRun(run, snapshots)));
+    runs = await listProjectAgentRuns(projectId);
+    return json({
+      runs,
+      jobs: Array.from(snapshots.values()),
+      repositories: access.repositories,
+      canWrite: access.canWrite,
+    });
+  } catch (caught) {
+    console.error("[live runs] sync failed", caught);
+    return json({ error: "service_unavailable" }, 503);
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await authorizeAgentRunAccess(projectId, req.signal);
+  if (!access) return json({ error: "not_found" }, 404);
+  if (!access.canWrite) return json({ error: "forbidden" }, 403);
+  const payload = (await req.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const instruction =
+    typeof payload?.instruction === "string"
+      ? payload.instruction.trim().slice(0, 12000)
+      : "";
+  const requested =
+    typeof payload?.executor === "string" &&
+    executors.has(payload.executor as AgentExecutor)
+      ? (payload.executor as AgentExecutor)
+      : "auto";
+  const repository = selectAgentRepository(access, payload?.repository);
+  if (instruction.length < 3 || !repository)
+    return json({ error: "invalid_run" }, 400);
+  const parsed = parseRepoFullName(repository.repo_full_name);
+  if (!parsed) return json({ error: "invalid_repository" }, 400);
+
+  await ensureProjectAgentRunsTable();
+  const runId = randomUUID();
+  const baseBranch = repository.default_branch || "main";
+  const workBranch = `vforge/run-${runId.slice(0, 8)}`;
+  const resolved =
+    requested === "team" ? "team" : resolveExecutor(requested, instruction);
+  const phase = requested === "team" ? "planning" : "building";
+  await queryOne(
+    `INSERT INTO project_agent_runs
+      (id, project_id, instruction, requested_executor, resolved_executor, phase, status,
+       repo_full_name, base_branch, work_branch, created_by_user_id, created_by_email)
+     VALUES ($1,$2,$3,$4,$5,$6,'preparing',$7,$8,$9,$10,$11)`,
+    [
+      runId,
+      projectId,
+      instruction,
+      requested,
+      resolved,
+      phase,
+      repository.repo_full_name,
+      baseBranch,
+      workBranch,
+      access.identity.userId,
+      access.identity.email,
+    ],
+  );
+
+  try {
+    const [owner, repo] = parsed;
+    const branch = await withUserGithub(
+      access.identity.userId,
+      async (github) => {
+        const source = await github.request(
+          "GET /repos/{owner}/{repo}/git/ref/{ref}",
+          { owner, repo, ref: `heads/${baseBranch}` },
+        );
+        return github.request("POST /repos/{owner}/{repo}/git/refs", {
+          owner,
+          repo,
+          ref: `refs/heads/${workBranch}`,
+          sha: source.data.object.sha,
+        });
+      },
+    );
+    if (!branch) throw new Error("Conecta GitHub para crear la rama aislada.");
+    const firstAgent: "codex" | "claude" | "grok" =
+      requested === "team" ? "claude" : resolveExecutor(requested, instruction);
+    const role = requested === "team" ? "planner" : "builder";
+    const prompt = buildAgentPrompt({
+      runId,
+      projectId,
+      repo: repository.repo_full_name,
+      baseBranch,
+      workBranch,
+      instruction,
+      role,
+    });
+    const dispatched = await dispatchJob({
+      agent: firstAgent,
+      prompt,
+      priority: 3,
+      source: `vforge:${projectId}:${runId}:${access.identity.userId}`,
+    });
+    const jobs: AgentQueueJob[] = [
+      { id: dispatched.id, agent: firstAgent, role },
+    ];
+    const run = await queryOne<AgentRunRow>(
+      `UPDATE project_agent_runs SET queue_jobs = $1::jsonb, status = 'queued', updated_at = now()
+        WHERE id = $2 RETURNING *`,
+      [JSON.stringify(jobs), runId],
+    );
+    await queryOne(
+      `INSERT INTO project_events (project_id, event_type, details, severity)
+       VALUES ($1, 'agent.run.queued', $2::jsonb, 'medium')`,
+      [
+        projectId,
+        JSON.stringify({
+          message: `V inició ${requested} en ${workBranch}`,
+          run_id: runId,
+          repository: repository.repo_full_name,
+        }),
+      ],
+    ).catch(() => null);
+    return json({ run }, 201);
+  } catch (caught) {
+    const message =
+      caught instanceof Error
+        ? caught.message.slice(0, 500)
+        : "No se pudo iniciar el run";
+    await queryOne(
+      `UPDATE project_agent_runs SET status = 'failed', error = $1, updated_at = now() WHERE id = $2`,
+      [message, runId],
+    ).catch(() => null);
+    return json(
+      { error: message, runId },
+      message.includes("Conecta GitHub") ? 409 : 502,
+    );
+  }
+}

--- a/app/api/webhooks/vercel/route.ts
+++ b/app/api/webhooks/vercel/route.ts
@@ -50,6 +50,10 @@ export async function POST(req: Request) {
       (dep.meta?.githubCommitSha as string | undefined) ??
       (dep.meta?.gitCommitSha as string | undefined) ??
       null;
+    const branch =
+      (dep.meta?.githubCommitRef as string | undefined) ??
+      (dep.meta?.gitCommitRef as string | undefined) ??
+      null;
     const info: DeployInfo = {
       vercelProjectId: p.project?.id ?? null,
       name: dep.name ?? p.name ?? null,
@@ -57,6 +61,7 @@ export async function POST(req: Request) {
       state,
       deploymentId: dep.id ?? p.deploymentId ?? null,
       commitSha: sha,
+      branch,
     };
     matched = await recordVercelDeploy(info);
   } catch {

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -52,6 +52,11 @@ const ReferencesPanel = dynamic(
   { ssr: false },
 );
 
+const VControlPanel = dynamic(
+  () => import("@/components/live/VControlPanel").then((module) => module.VControlPanel),
+  { ssr: false },
+);
+
 export interface LivePortalProject {
   id: string;
   name: string;
@@ -88,7 +93,8 @@ type WorkspacePanelId =
   | "comments"
   | "context"
   | "code"
-  | "references";
+  | "references"
+  | "v";
 type WorkspacePreset = "balanced" | "previews" | "review";
 type PreviewKind = "desktop" | "mobile" | "admin";
 
@@ -133,6 +139,7 @@ const PANEL_LABELS: Record<WorkspacePanelId, string> = {
   context: "Contexto",
   code: "Código",
   references: "Referencias",
+  v: "V",
 };
 
 
@@ -323,6 +330,7 @@ function LiveWorkspace({
   const storageKey = `vforge:dock-layout:v1:${project.id}:${me.role}`;
   const availablePanels = useMemo<WorkspacePanelId[]>(
     () => [
+      "v",
       "desktop",
       "mobile",
       ...(canSeeAdmin ? (["admin"] as WorkspacePanelId[]) : []),
@@ -354,6 +362,7 @@ function LiveWorkspace({
     context: false,
     code: false,
     references: false,
+    v: false,
   });
   const savedLayoutsRef = useRef(DOCK_LAYOUTS.balanced);
 
@@ -419,7 +428,7 @@ function LiveWorkspace({
       feedback: source.feedback,
     };
     setFocusedPanel(null);
-    setCollapsed({ desktop: false, mobile: false, admin: false, activity: false, comments: false, context: false, code: false, references: false });
+    setCollapsed({ desktop: false, mobile: false, admin: false, activity: false, comments: false, context: false, code: false, references: false, v: false });
     desktopRef.current?.expand();
     mobileRef.current?.expand();
     adminRef.current?.expand();
@@ -451,6 +460,7 @@ function LiveWorkspace({
     context: contextRef.current,
     code: null,
     references: null,
+    v: null,
   };
 
   const updateCollapsed = (panel: WorkspacePanelId, pixels: number) => {
@@ -474,6 +484,8 @@ function LiveWorkspace({
     <CodeEditorPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
   ) : focusedPanel === "references" ? (
     <ReferencesPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
+  ) : focusedPanel === "v" ? (
+    <VControlPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
   ) : null;
 
   return (
@@ -494,7 +506,7 @@ function LiveWorkspace({
         </div>
         <div className="flex shrink-0 items-center gap-1" aria-label="Paneles visibles">
           {availablePanels.map((panel) => {
-            const standalone = panel === "code" || panel === "references";
+            const standalone = panel === "code" || panel === "references" || panel === "v";
             const visible = standalone ? focusedPanel === panel : !collapsed[panel];
             return (
               <button

--- a/components/live/VControlPanel.tsx
+++ b/components/live/VControlPanel.tsx
@@ -1,0 +1,625 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  IconBranch,
+  IconCheck,
+  IconExtLink,
+  IconLoader,
+  IconRocket,
+  IconSend,
+  IconSparkles,
+  IconStop,
+  IconX,
+} from "@/components/brand/VFIcons";
+
+type Executor = "auto" | "codex" | "claude" | "grok" | "team";
+type RunStatus =
+  | "preparing"
+  | "queued"
+  | "running"
+  | "awaiting_preview"
+  | "preview_ready"
+  | "awaiting_approval"
+  | "approved"
+  | "published"
+  | "failed"
+  | "cancelled";
+
+interface Repository {
+  repo_full_name: string;
+  is_primary: boolean;
+  default_branch: string | null;
+}
+
+interface QueueJobRef {
+  id: number;
+  agent: string;
+  role: string;
+}
+
+interface QueueJob {
+  id: number;
+  agent: string | null;
+  status: string;
+  progress: number | null;
+  result: string | null;
+  logTail: string | null;
+  verdict: string | null;
+}
+
+interface AgentRun {
+  id: string;
+  instruction: string;
+  requested_executor: Executor;
+  resolved_executor: string;
+  phase: string;
+  status: RunStatus;
+  repo_full_name: string;
+  base_branch: string;
+  work_branch: string;
+  queue_jobs: QueueJobRef[];
+  preview_url: string | null;
+  pr_url: string | null;
+  summary: string | null;
+  error: string | null;
+  created_at: string;
+}
+
+const EXECUTORS: Array<{ id: Executor; label: string; description: string }> = [
+  { id: "auto", label: "Auto", description: "V elige según la tarea" },
+  { id: "codex", label: "Codex", description: "Código y validación" },
+  {
+    id: "claude",
+    label: "Claude",
+    description: "Arquitectura y trabajo largo",
+  },
+  { id: "grok", label: "Grok", description: "Investigación y auditoría" },
+  { id: "team", label: "Equipo", description: "Claude → Codex → Grok" },
+];
+
+const STATUS_LABELS: Record<RunStatus, string> = {
+  preparing: "Preparando rama",
+  queued: "En cola",
+  running: "Trabajando",
+  awaiting_preview: "Esperando preview",
+  preview_ready: "Preview listo",
+  awaiting_approval: "Esperando aprobación",
+  approved: "Aprobado",
+  published: "Publicado",
+  failed: "Falló",
+  cancelled: "Cancelado",
+};
+
+const ACTIVE = new Set<RunStatus>([
+  "preparing",
+  "queued",
+  "running",
+  "awaiting_preview",
+]);
+
+export function VControlPanel({
+  projectId,
+  onClose,
+}: {
+  projectId: string;
+  onClose: () => void;
+}) {
+  const [runs, setRuns] = useState<AgentRun[]>([]);
+  const [jobs, setJobs] = useState<QueueJob[]>([]);
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const [canWrite, setCanWrite] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [instruction, setInstruction] = useState("");
+  const [executor, setExecutor] = useState<Executor>("auto");
+  const [repository, setRepository] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const pollingRef = useRef(false);
+
+  const load = useCallback(async () => {
+    if (pollingRef.current) return;
+    pollingRef.current = true;
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/runs`,
+        { cache: "no-store" },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        runs?: AgentRun[];
+        jobs?: QueueJob[];
+        repositories?: Repository[];
+        canWrite?: boolean;
+      } | null;
+      if (!response.ok) throw new Error("No se pudo leer la cabina V.");
+      const nextRuns = Array.isArray(payload?.runs) ? payload.runs : [];
+      const nextRepos = Array.isArray(payload?.repositories)
+        ? payload.repositories
+        : [];
+      setRuns(nextRuns);
+      setJobs(Array.isArray(payload?.jobs) ? payload.jobs : []);
+      setRepositories(nextRepos);
+      setCanWrite(Boolean(payload?.canWrite));
+      setSelectedId((current) =>
+        current && nextRuns.some((run) => run.id === current)
+          ? current
+          : (nextRuns[0]?.id ?? null),
+      );
+      setRepository(
+        (current) =>
+          current ||
+          nextRepos.find((repo) => repo.is_primary)?.repo_full_name ||
+          nextRepos[0]?.repo_full_name ||
+          "",
+      );
+      setError(null);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "No se pudo leer la cabina V.",
+      );
+    } finally {
+      pollingRef.current = false;
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void load();
+    const timer = window.setInterval(() => void load(), 3000);
+    return () => window.clearInterval(timer);
+  }, [load]);
+
+  const selected = useMemo(
+    () => runs.find((run) => run.id === selectedId) ?? runs[0] ?? null,
+    [runs, selectedId],
+  );
+  const jobMap = useMemo(
+    () => new Map(jobs.map((job) => [job.id, job])),
+    [jobs],
+  );
+
+  async function startRun(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!instruction.trim() || !repository || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/runs`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ instruction, executor, repository }),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        run?: AgentRun;
+        error?: string;
+      } | null;
+      if (!response.ok || !payload?.run)
+        throw new Error(payload?.error || "No se pudo iniciar el trabajo.");
+      setInstruction("");
+      setRuns((current) => [payload.run!, ...current]);
+      setSelectedId(payload.run.id);
+      await load();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "No se pudo iniciar el trabajo.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runAction(action: "approve" | "publish" | "cancel") {
+    if (!selected || busy) return;
+    const message =
+      action === "publish"
+        ? "Esto fusionará el PR y activará producción. ¿Publicar ahora?"
+        : action === "cancel"
+          ? "¿Cancelar este run? La rama se conservará para auditoría."
+          : null;
+    if (message && !window.confirm(message)) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(selected.id)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action }),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        run?: AgentRun;
+        error?: string;
+      } | null;
+      if (!response.ok)
+        throw new Error(payload?.error || "La acción no pudo completarse.");
+      await load();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "La acción no pudo completarse.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-white">
+      <header className="flex min-h-12 shrink-0 items-center justify-between gap-3 border-b border-[var(--border-1)] px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="grid h-7 w-7 place-items-center rounded-full bg-black text-[12px] font-semibold text-white">
+            V
+          </span>
+          <div className="min-w-0">
+            <p className="font-mono text-[9px] uppercase tracking-[0.13em]">
+              Control de ejecución
+            </p>
+            <p className="truncate text-[9px] text-[var(--fg-muted)]">
+              Rama aislada · agentes · preview · aprobación · producción
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="hidden items-center gap-1.5 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)] sm:flex">
+            <span className="status-shape" data-active /> sincronización 3 s
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="grid h-8 w-8 place-items-center rounded-md hover:bg-[var(--color-background)]"
+            aria-label="Cerrar V"
+          >
+            <IconX size={11} />
+          </button>
+        </div>
+      </header>
+
+      {canWrite ? (
+        <form
+          onSubmit={startRun}
+          className="shrink-0 border-b border-[var(--border-1)] bg-[var(--color-background)] p-3"
+        >
+          <div className="grid gap-2 lg:grid-cols-[210px_minmax(0,1fr)_auto]">
+            <select
+              value={repository}
+              onChange={(event) => setRepository(event.target.value)}
+              className="min-h-10 rounded-md border border-[var(--border-1)] bg-white px-3 text-[11px] outline-none focus:border-black"
+              aria-label="Repositorio"
+            >
+              {repositories.map((repo) => (
+                <option key={repo.repo_full_name} value={repo.repo_full_name}>
+                  {repo.repo_full_name}
+                </option>
+              ))}
+            </select>
+            <textarea
+              value={instruction}
+              onChange={(event) => setInstruction(event.target.value)}
+              maxLength={12000}
+              rows={2}
+              placeholder="Dile a V qué debe cambiar, investigar o construir…"
+              className="min-h-14 resize-y rounded-md border border-[var(--border-1)] bg-white px-3 py-2 text-[12px] leading-5 outline-none focus:border-black"
+            />
+            <button
+              type="submit"
+              disabled={busy || !instruction.trim() || !repository}
+              className="btn-primary min-h-10 self-stretch disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {busy ? (
+                <IconLoader size={12} className="animate-spin" />
+              ) : (
+                <IconSend size={12} />
+              )}{" "}
+              Ejecutar
+            </button>
+          </div>
+          <div
+            className="mt-2 flex gap-1 overflow-x-auto"
+            aria-label="Seleccionar ejecutor"
+          >
+            {EXECUTORS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setExecutor(item.id)}
+                title={item.description}
+                className={cn(
+                  "shrink-0 rounded-md border px-2.5 py-1.5 font-mono text-[8px] uppercase tracking-[0.08em]",
+                  executor === item.id
+                    ? "border-black bg-black text-white"
+                    : "border-[var(--border-1)] bg-white hover:border-black",
+                )}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </form>
+      ) : null}
+
+      {error ? (
+        <p className="shrink-0 border-b border-[var(--border-1)] px-3 py-2 text-[10px] text-[var(--color-danger)]">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="grid min-h-0 flex-1 md:grid-cols-[300px_minmax(0,1fr)]">
+        <aside className="min-h-0 overflow-y-auto border-b border-[var(--border-1)] md:border-b-0 md:border-r">
+          {loading ? (
+            <div className="flex items-center gap-2 p-4 text-[11px] text-[var(--fg-muted)]">
+              <IconLoader size={12} className="animate-spin" /> Cargando runs…
+            </div>
+          ) : runs.length ? (
+            <div className="divide-y divide-[var(--border-1)]">
+              {runs.map((run) => (
+                <button
+                  key={run.id}
+                  type="button"
+                  onClick={() => setSelectedId(run.id)}
+                  className={cn(
+                    "w-full p-3 text-left hover:bg-[var(--color-background)]",
+                    selected?.id === run.id &&
+                      "bg-black text-white hover:bg-black",
+                  )}
+                >
+                  <span className="flex items-center justify-between gap-2">
+                    <strong className="truncate text-[11px] font-medium">
+                      {run.instruction}
+                    </strong>
+                    <span
+                      className={cn(
+                        "status-shape shrink-0",
+                        ACTIVE.has(run.status) && "animate-pulse",
+                      )}
+                      data-active={
+                        run.status === "preview_ready" ||
+                        run.status === "approved" ||
+                        run.status === "published"
+                      }
+                    />
+                  </span>
+                  <span
+                    className={cn(
+                      "mt-2 flex items-center justify-between font-mono text-[8px] uppercase tracking-[0.08em]",
+                      selected?.id === run.id
+                        ? "text-white/65"
+                        : "text-[var(--fg-muted)]",
+                    )}
+                  >
+                    <span>
+                      {run.requested_executor === "team"
+                        ? "Equipo"
+                        : run.resolved_executor}
+                    </span>
+                    <span>{STATUS_LABELS[run.status]}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="p-5 text-[11px] leading-5 text-[var(--fg-muted)]">
+              Todavía no hay ejecuciones. Dale una instrucción a V para crear la
+              primera rama aislada.
+            </div>
+          )}
+        </aside>
+
+        <div className="min-h-0 overflow-y-auto bg-[var(--color-background)]">
+          {selected ? (
+            <div className="grid min-h-full gap-3 p-3 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.8fr)]">
+              <div className="space-y-3">
+                <section className="rounded-[8px] border border-[var(--border-1)] bg-white p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <p className="mono-label">Instrucción</p>
+                      <p className="mt-2 whitespace-pre-wrap text-[12px] leading-5">
+                        {selected.instruction}
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-black px-2 py-1 font-mono text-[8px] uppercase tracking-[0.08em]">
+                      {STATUS_LABELS[selected.status]}
+                    </span>
+                  </div>
+                  <div className="mt-3 grid gap-2 border-t border-[var(--border-1)] pt-3 text-[9px] sm:grid-cols-2">
+                    <p className="truncate">
+                      <span className="text-[var(--fg-muted)]">Repo </span>
+                      {selected.repo_full_name}
+                    </p>
+                    <p className="truncate">
+                      <span className="text-[var(--fg-muted)]">Rama </span>
+                      {selected.work_branch}
+                    </p>
+                  </div>
+                </section>
+
+                <section className="rounded-[8px] border border-[var(--border-1)] bg-white">
+                  <header className="border-b border-[var(--border-1)] px-3 py-2">
+                    <p className="mono-label">Circuito</p>
+                  </header>
+                  <div className="divide-y divide-[var(--border-1)]">
+                    {selected.queue_jobs.map((jobRef, index) => {
+                      const job = jobMap.get(jobRef.id);
+                      const done =
+                        job &&
+                        ["done", "completed", "success", "succeeded"].includes(
+                          job.status.toLowerCase(),
+                        );
+                      return (
+                        <div
+                          key={jobRef.id}
+                          className="grid grid-cols-[26px_minmax(0,1fr)_auto] items-start gap-2 px-3 py-3"
+                        >
+                          <span
+                            className={cn(
+                              "grid h-6 w-6 place-items-center rounded-full border text-[9px]",
+                              done
+                                ? "border-black bg-black text-white"
+                                : "border-[var(--border-1)]",
+                            )}
+                          >
+                            {done ? <IconCheck size={10} /> : index + 1}
+                          </span>
+                          <div>
+                            <p className="text-[11px] font-medium capitalize">
+                              {jobRef.agent} · {jobRef.role}
+                            </p>
+                            <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-[9px] leading-4 text-[var(--fg-muted)]">
+                              {job?.logTail ||
+                                job?.result ||
+                                "Esperando al runner…"}
+                            </p>
+                          </div>
+                          <span className="font-mono text-[8px] uppercase text-[var(--fg-muted)]">
+                            {job?.status || "queued"}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+
+                {selected.summary ? (
+                  <section className="rounded-[8px] border border-[var(--border-1)] bg-white p-3">
+                    <p className="mono-label">Resultado más reciente</p>
+                    <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap text-[10px] leading-5">
+                      {selected.summary}
+                    </pre>
+                  </section>
+                ) : null}
+                {selected.error ? (
+                  <section className="rounded-[8px] border border-black bg-white p-3 text-[10px] leading-5">
+                    {selected.error}
+                  </section>
+                ) : null}
+              </div>
+
+              <div className="space-y-3">
+                <section className="overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-white">
+                  <header className="flex items-center justify-between border-b border-[var(--border-1)] px-3 py-2">
+                    <p className="mono-label">Preview antes de publicar</p>
+                    {selected.preview_url ? (
+                      <a
+                        href={selected.preview_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="grid h-7 w-7 place-items-center rounded-md hover:bg-[var(--color-background)]"
+                        aria-label="Abrir preview"
+                      >
+                        <IconExtLink size={10} />
+                      </a>
+                    ) : null}
+                  </header>
+                  {selected.preview_url ? (
+                    <iframe
+                      src={selected.preview_url}
+                      title={`Preview ${selected.id}`}
+                      className="h-[380px] w-full border-0 bg-white"
+                      sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+                      referrerPolicy="no-referrer"
+                    />
+                  ) : (
+                    <div className="grid min-h-52 place-items-center p-6 text-center">
+                      <div>
+                        <IconSparkles size={20} className="mx-auto" />
+                        <p className="mt-3 text-[11px] font-medium">
+                          El preview aparecerá aquí
+                        </p>
+                        <p className="mt-2 max-w-xs text-[9px] leading-4 text-[var(--fg-muted)]">
+                          Cuando el agente haga push a la rama, Vercel enviará
+                          la URL a esta sala. Producción permanece intacta.
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </section>
+
+                <section className="rounded-[8px] border border-black bg-white p-3">
+                  <div className="flex flex-wrap gap-2">
+                    <a
+                      href={`https://github.com/${selected.repo_full_name}/tree/${selected.work_branch}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="btn-ghost"
+                    >
+                      <IconBranch size={11} /> Rama
+                    </a>
+                    {selected.pr_url ? (
+                      <a
+                        href={selected.pr_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="btn-ghost"
+                      >
+                        <IconExtLink size={11} /> PR
+                      </a>
+                    ) : null}
+                    {canWrite && selected.status === "preview_ready" ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void runAction("approve")}
+                        className="btn-primary"
+                      >
+                        <IconCheck size={11} /> Aprobar y crear PR
+                      </button>
+                    ) : null}
+                    {canWrite && selected.status === "approved" ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void runAction("publish")}
+                        className="btn-primary"
+                      >
+                        <IconRocket size={11} /> Publicar
+                      </button>
+                    ) : null}
+                    {canWrite && ACTIVE.has(selected.status) ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void runAction("cancel")}
+                        className="btn-ghost"
+                      >
+                        <IconStop size={11} /> Cancelar
+                      </button>
+                    ) : null}
+                  </div>
+                  <p className="mt-3 text-[9px] leading-4 text-[var(--fg-muted)]">
+                    Aprobar crea el PR. Publicar lo fusiona a{" "}
+                    {selected.base_branch} y entonces comienza producción.
+                  </p>
+                </section>
+              </div>
+            </div>
+          ) : (
+            <div className="grid h-full place-items-center p-8 text-center">
+              <div>
+                <span className="mx-auto grid h-10 w-10 place-items-center rounded-full bg-black font-semibold text-white">
+                  V
+                </span>
+                <p className="mt-3 text-[12px] font-medium">
+                  Tu cabina de ejecución
+                </p>
+                <p className="mt-2 text-[10px] text-[var(--fg-muted)]">
+                  Selecciona un run o inicia una tarea.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/live/agent-runs.ts
+++ b/lib/live/agent-runs.ts
@@ -1,0 +1,214 @@
+import "server-only";
+
+import { queryAll, queryOne } from "@/lib/db/client";
+import {
+  fetchVForgeApi,
+  getCurrentVForgeIdentity,
+  projectApiPath,
+  type VForgeIdentity,
+} from "@/lib/api/vforge-owned";
+import type { LiveRole } from "@/lib/projects/roles";
+
+export type AgentExecutor = "auto" | "codex" | "claude" | "grok" | "team";
+export type AgentPhase =
+  "planning" | "building" | "reviewing" | "validation" | "complete";
+export type AgentRunStatus =
+  | "preparing"
+  | "queued"
+  | "running"
+  | "awaiting_preview"
+  | "preview_ready"
+  | "awaiting_approval"
+  | "approved"
+  | "published"
+  | "failed"
+  | "cancelled";
+
+export interface AgentQueueJob {
+  id: number;
+  agent: "codex" | "claude" | "grok";
+  role: "planner" | "builder" | "reviewer";
+}
+
+export interface AgentRunRow {
+  id: string;
+  project_id: string;
+  instruction: string;
+  requested_executor: AgentExecutor;
+  resolved_executor: string;
+  phase: AgentPhase;
+  status: AgentRunStatus;
+  repo_full_name: string;
+  base_branch: string;
+  work_branch: string;
+  queue_jobs: AgentQueueJob[];
+  preview_url: string | null;
+  pr_number: number | null;
+  pr_url: string | null;
+  summary: string | null;
+  error: string | null;
+  created_by_email: string;
+  created_at: string;
+  updated_at: string;
+  approved_at: string | null;
+  published_at: string | null;
+}
+
+export interface AgentRunRepository {
+  repo_full_name: string;
+  role: string;
+  is_primary: boolean;
+  default_branch: string | null;
+}
+
+export interface AgentRunAccess {
+  identity: VForgeIdentity;
+  role: LiveRole;
+  canWrite: boolean;
+  repositories: AgentRunRepository[];
+}
+
+export async function ensureProjectAgentRunsTable(): Promise<void> {
+  await queryOne(
+    `CREATE TABLE IF NOT EXISTS project_agent_runs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      project_id text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      instruction text NOT NULL CHECK (char_length(instruction) BETWEEN 3 AND 12000),
+      requested_executor text NOT NULL CHECK (requested_executor IN ('auto','codex','claude','grok','team')),
+      resolved_executor text NOT NULL,
+      phase text NOT NULL DEFAULT 'building' CHECK (phase IN ('planning','building','reviewing','validation','complete')),
+      status text NOT NULL DEFAULT 'preparing' CHECK (status IN ('preparing','queued','running','awaiting_preview','preview_ready','awaiting_approval','approved','published','failed','cancelled')),
+      repo_full_name text NOT NULL,
+      base_branch text NOT NULL,
+      work_branch text NOT NULL,
+      queue_jobs jsonb NOT NULL DEFAULT '[]'::jsonb,
+      preview_url text,
+      pr_number integer,
+      pr_url text,
+      summary text,
+      error text,
+      created_by_user_id text NOT NULL,
+      created_by_email text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      approved_at timestamptz,
+      published_at timestamptz
+    )`,
+  );
+  await queryOne(
+    `CREATE UNIQUE INDEX IF NOT EXISTS uq_project_agent_runs_branch ON project_agent_runs (lower(repo_full_name), work_branch)`,
+  );
+  await queryOne(
+    `CREATE INDEX IF NOT EXISTS idx_project_agent_runs_project ON project_agent_runs (project_id, created_at DESC)`,
+  );
+}
+
+export async function authorizeAgentRunAccess(
+  projectId: string,
+  signal: AbortSignal,
+): Promise<AgentRunAccess | null> {
+  const identity = await getCurrentVForgeIdentity();
+  if (!identity) return null;
+  const upstream = await fetchVForgeApi(
+    projectApiPath(projectId, "context"),
+    identity,
+    { signal },
+  );
+  if (!upstream.ok) return null;
+  const payload = (await upstream.json().catch(() => null)) as {
+    repositories?: AgentRunRepository[];
+    me?: { role?: LiveRole };
+  } | null;
+  const role = payload?.me?.role;
+  if (role !== "owner" && role !== "reviewer" && role !== "observer")
+    return null;
+  return {
+    identity,
+    role,
+    canWrite: role === "owner",
+    repositories: Array.isArray(payload?.repositories)
+      ? payload.repositories
+      : [],
+  };
+}
+
+export function selectAgentRepository(
+  access: AgentRunAccess,
+  requested: unknown,
+): AgentRunRepository | null {
+  if (!access.repositories.length) return null;
+  if (typeof requested !== "string" || !requested.trim()) {
+    return (
+      access.repositories.find((repo) => repo.is_primary) ??
+      access.repositories[0]
+    );
+  }
+  const normalized = requested.trim().toLowerCase();
+  return (
+    access.repositories.find(
+      (repo) => repo.repo_full_name.toLowerCase() === normalized,
+    ) ?? null
+  );
+}
+
+export function resolveExecutor(
+  requested: AgentExecutor,
+  instruction: string,
+): Exclude<AgentExecutor, "auto" | "team"> {
+  if (requested !== "auto" && requested !== "team") return requested;
+  const normalized = instruction.toLowerCase();
+  if (/investiga|audita|diagn[oó]stic|compara|revisa mercado/.test(normalized))
+    return "grok";
+  if (/arquitectura|planea|estrategia|diseño de sistema/.test(normalized))
+    return "claude";
+  return "codex";
+}
+
+export function buildAgentPrompt(args: {
+  runId: string;
+  projectId: string;
+  repo: string;
+  baseBranch: string;
+  workBranch: string;
+  instruction: string;
+  role: "planner" | "builder" | "reviewer";
+  priorResult?: string | null;
+}): string {
+  const roleRules =
+    args.role === "planner"
+      ? "Analiza y entrega un plan verificable. NO escribas código ni cambies ramas."
+      : args.role === "reviewer"
+        ? "Revisa la rama de trabajo, pruebas y riesgos. NO escribas ni hagas merge. Emite APROBADO, REVISION o RECHAZADO con evidencia."
+        : "Eres el único escritor. Implementa, prueba y haz push exclusivamente a la rama de trabajo indicada.";
+  return `VFORGE RUN ${args.runId}
+PROYECTO ${args.projectId}
+REPOSITORIO ${args.repo}
+RAMA BASE ${args.baseBranch}
+RAMA DE TRABAJO ${args.workBranch}
+ROL ${args.role.toUpperCase()}
+
+REGLAS OBLIGATORIAS
+- ${roleRules}
+- Nunca escribas, hagas push ni merge directo a ${args.baseBranch}.
+- No despliegues producción.
+- No leas ni expongas secretos ajenos al proyecto.
+- Reporta archivos tocados, comandos de validación, resultado y bloqueos reales.
+
+TAREA
+${args.instruction.trim()}
+${args.priorResult ? `\nCONTEXTO DE LA ETAPA ANTERIOR\n${args.priorResult.slice(0, 8000)}` : ""}`;
+}
+
+export async function listProjectAgentRuns(
+  projectId: string,
+): Promise<AgentRunRow[]> {
+  await ensureProjectAgentRunsTable();
+  return queryAll<AgentRunRow>(
+    `SELECT id, project_id, instruction, requested_executor, resolved_executor, phase, status,
+            repo_full_name, base_branch, work_branch, queue_jobs, preview_url, pr_number, pr_url,
+            summary, error, created_by_email, created_at, updated_at, approved_at, published_at
+       FROM project_agent_runs WHERE project_id = $1
+       ORDER BY created_at DESC LIMIT 30`,
+    [projectId],
+  );
+}

--- a/lib/live/github-user.ts
+++ b/lib/live/github-user.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import { githubClientFromToken } from "@/lib/github/client";
+import { getUserSecret, saveUserSecret } from "@/lib/connect/user-vault";
+
+export type UserGithubClient = ReturnType<typeof githubClientFromToken>;
+
+function githubStatus(caught: unknown): number {
+  return typeof caught === "object" && caught && "status" in caught
+    ? Number(caught.status)
+    : 500;
+}
+
+async function refreshGithubUserToken(userId: string): Promise<string | null> {
+  const refreshToken = await getUserSecret(userId, "GITHUB_REFRESH_TOKEN");
+  const clientId = process.env.GITHUB_APP_CLIENT_ID?.trim();
+  const clientSecret = process.env.GITHUB_APP_CLIENT_SECRET?.trim();
+  if (!refreshToken || !clientId || !clientSecret) return null;
+  const response = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+    cache: "no-store",
+  });
+  const payload = (await response.json().catch(() => null)) as {
+    access_token?: string;
+    refresh_token?: string;
+  } | null;
+  if (!response.ok || !payload?.access_token) return null;
+  await saveUserSecret(
+    userId,
+    "GITHUB_USER_TOKEN",
+    payload.access_token,
+    "github",
+  );
+  if (payload.refresh_token) {
+    await saveUserSecret(
+      userId,
+      "GITHUB_REFRESH_TOKEN",
+      payload.refresh_token,
+      "github",
+    );
+  }
+  return payload.access_token;
+}
+
+export async function withUserGithub<T>(
+  userId: string,
+  operation: (github: UserGithubClient) => Promise<T>,
+): Promise<T | null> {
+  const token = await getUserSecret(userId, "GITHUB_USER_TOKEN");
+  if (!token) return null;
+  try {
+    return await operation(githubClientFromToken(token));
+  } catch (caught) {
+    if (githubStatus(caught) !== 401) throw caught;
+    const refreshed = await refreshGithubUserToken(userId);
+    if (!refreshed) throw caught;
+    return operation(githubClientFromToken(refreshed));
+  }
+}
+
+export function parseRepoFullName(value: string): [string, string] | null {
+  const match = /^([^/\s]+)\/([^/\s]+)$/.exec(value.trim());
+  return match ? [match[1], match[2]] : null;
+}

--- a/lib/projects/live.ts
+++ b/lib/projects/live.ts
@@ -7,7 +7,7 @@
  *
  * Todo es best-effort: cualquier error se traga (el webhook responde 200).
  */
-import { queryOne, queryAll } from "@/lib/db/client";
+import { queryOne } from "@/lib/db/client";
 import { addTimelineEvent } from "@/lib/projects/timeline";
 
 /** Registra el evento crudo (auditoría) y devuelve si se asoció a un proyecto. */
@@ -186,6 +186,7 @@ export interface DeployInfo {
   state: string; // ready|building|error|canceled
   deploymentId: string | null;
   commitSha: string | null;
+  branch: string | null;
 }
 
 /** Webhook de Vercel → project_deploys + timeline + integración. */
@@ -197,11 +198,24 @@ export async function recordVercelDeploy(d: DeployInfo): Promise<boolean> {
   await queryOne(
     `INSERT INTO project_deploys
         (project_id, provider, vercel_project_id, deployment_id, name, url, state, commit_sha, meta)
-     VALUES ($1, 'vercel', $2, $3, $4, $5, $6, $7, '{}'::jsonb)
+     VALUES ($1, 'vercel', $2, $3, $4, $5, $6, $7, $8::jsonb)
      ON CONFLICT (provider, deployment_id) WHERE deployment_id IS NOT NULL
      DO UPDATE SET state = EXCLUDED.state, url = COALESCE(EXCLUDED.url, project_deploys.url)`,
-    [projectId, d.vercelProjectId, d.deploymentId, d.name, d.url, d.state, d.commitSha],
+    [projectId, d.vercelProjectId, d.deploymentId, d.name, d.url, d.state, d.commitSha, JSON.stringify({ branch: d.branch })],
   );
+
+  if (d.branch && d.url) {
+    const previewUrl = d.url.startsWith("http://") || d.url.startsWith("https://") ? d.url : `https://${d.url}`;
+    await queryOne(
+      `UPDATE project_agent_runs
+          SET preview_url = $1,
+              status = CASE WHEN status IN ('awaiting_preview','awaiting_approval','preview_ready') AND $2 IN ('ready','succeeded')
+                            THEN 'preview_ready' ELSE status END,
+              updated_at = now()
+        WHERE project_id = $3 AND work_branch = $4 AND status NOT IN ('published','cancelled','failed')`,
+      [previewUrl, d.state, projectId, d.branch],
+    ).catch(() => null);
+  }
 
   const ok = d.state === "ready" || d.state === "succeeded";
   const err = d.state === "error" || d.state === "canceled";

--- a/lib/vulcano/operator.ts
+++ b/lib/vulcano/operator.ts
@@ -229,6 +229,53 @@ export async function dispatchJob(p: DispatchInput): Promise<{ id: number }> {
   return { id: rows[0].id };
 }
 
+export interface DispatchJobSnapshot {
+  id: number;
+  agent: string | null;
+  status: string;
+  progress: number | null;
+  result: string | null;
+  logTail: string | null;
+  verdict: string | null;
+  updatedAt: string | null;
+}
+
+/** Lee sólo los jobs indicados; se usa para sincronizar runs de una sala. */
+export async function getDispatchJobs(jobIds: number[]): Promise<DispatchJobSnapshot[]> {
+  const unique = Array.from(new Set(jobIds.filter((id) => Number.isInteger(id) && id > 0))).slice(0, 100);
+  if (!unique.length) return [];
+  const sql = getDispatch();
+  const rows = await Promise.all(
+    unique.map(async (id) => {
+      const result = (await sql`
+        SELECT id, agent, status, progress_pct, result, log_tail, grok_verdict,
+               COALESCE(completed_at, started_at, created_at) AS updated_at
+          FROM dispatch_queue WHERE id = ${id} LIMIT 1
+      `) as Array<{
+        id: number;
+        agent: string | null;
+        status: string;
+        progress_pct: number | null;
+        result: string | null;
+        log_tail: string | null;
+        grok_verdict: string | null;
+        updated_at: string | null;
+      }>;
+      return result[0] ?? null;
+    }),
+  );
+  return rows.filter((row): row is NonNullable<typeof row> => Boolean(row)).map((row) => ({
+    id: Number(row.id),
+    agent: row.agent,
+    status: row.status,
+    progress: row.progress_pct == null ? null : Number(row.progress_pct),
+    result: row.result,
+    logTail: row.log_tail,
+    verdict: normalizeVerdict(row.grok_verdict),
+    updatedAt: row.updated_at,
+  }));
+}
+
 /* ---------------------------------- salud --------------------------------- */
 
 export interface SaludFabrica {

--- a/migrations/045_project_agent_runs.sql
+++ b/migrations/045_project_agent_runs.sql
@@ -1,0 +1,38 @@
+-- Circuito profesional V: rama aislada -> agentes -> preview -> aprobación -> publicación.
+
+CREATE TABLE IF NOT EXISTS project_agent_runs (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id          text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  instruction         text NOT NULL CHECK (char_length(instruction) BETWEEN 3 AND 12000),
+  requested_executor  text NOT NULL CHECK (requested_executor IN ('auto','codex','claude','grok','team')),
+  resolved_executor   text NOT NULL,
+  phase               text NOT NULL DEFAULT 'building'
+                        CHECK (phase IN ('planning','building','reviewing','validation','complete')),
+  status              text NOT NULL DEFAULT 'preparing'
+                        CHECK (status IN ('preparing','queued','running','awaiting_preview','preview_ready','awaiting_approval','approved','published','failed','cancelled')),
+  repo_full_name      text NOT NULL,
+  base_branch         text NOT NULL,
+  work_branch         text NOT NULL,
+  queue_jobs          jsonb NOT NULL DEFAULT '[]'::jsonb,
+  preview_url         text,
+  pr_number           integer,
+  pr_url              text,
+  summary             text,
+  error               text,
+  created_by_user_id  text NOT NULL,
+  created_by_email    text NOT NULL,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+  approved_at         timestamptz,
+  published_at        timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_project_agent_runs_branch
+  ON project_agent_runs (lower(repo_full_name), work_branch);
+CREATE INDEX IF NOT EXISTS idx_project_agent_runs_project
+  ON project_agent_runs (project_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_project_agent_runs_active
+  ON project_agent_runs (status, updated_at DESC)
+  WHERE status IN ('preparing','queued','running','awaiting_preview','preview_ready','awaiting_approval','approved');
+
+SELECT 'migracion 045 (project agent runs) OK' AS resultado;


### PR DESCRIPTION
## Qué cambia
- agrega el panel V dentro de cada sala de proyecto
- permite elegir Auto, Codex, Claude, Grok o Equipo
- crea una rama aislada por ejecución
- muestra estado y logs del circuito en vivo
- enlaza previews de Vercel a la ejecución
- exige aprobación explícita antes de crear PR y publicar
- mantiene invitaciones fuera del espacio principal mediante el drawer compacto ya integrado

## Seguridad
- sólo owner puede ejecutar, aprobar, cancelar o publicar
- revisores y observadores conservan lectura
- ningún agente escribe ni mergea `main` directamente
- modo Equipo: Claude planea, Codex construye y Grok revisa

## Verificación
- `npm run typecheck`
- ESLint enfocado
- `git diff --check`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Owners can merge PRs to the base branch and trigger production deploys via GitHub; agent runs also create branches and dispatch autonomous code agents on linked repos.
> 
> **Overview**
> Adds the **V control panel** to each live project room so owners can start agent runs from an instruction, pick **Auto / Codex / Claude / Grok / Equipo**, and follow an isolated-branch workflow through preview, PR approval, and publish.
> 
> **Backend:** New `project_agent_runs` storage and live APIs list/sync runs against the dispatch queue, create a `vforge/run-*` branch via the user’s GitHub token, enqueue agent jobs (team mode chains Claude → Codex → Grok), and expose **cancel / approve (open PR) / publish (squash merge)**. Vercel deploy webhooks now carry branch metadata and attach preview URLs to matching active runs.
> 
> **UI:** `VControlPanel` polls every 3s, shows circuit steps, logs, embedded preview, and gated actions; `LivePortal` adds a standalone **V** panel toggle. Reviewers and observers can read; only **owners** can execute or ship.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846b3ce417760a55c40ed479f425b5bd576820d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->