### PR TITLE
fix(pwa): refresh stale production clients

### DIFF
--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  const version =
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    process.env.VERCEL_DEPLOYMENT_ID ??
+    "development";
+
+  return NextResponse.json(
+    { version },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0, must-revalidate",
+        "CDN-Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -253,7 +253,7 @@ export function LivePortal({
             onClick={() => setInviteOpen(false)}
             aria-label="Cerrar invitaciones"
           />
-          <aside className="absolute inset-y-0 right-0 w-[min(92vw,420px)] overflow-y-auto border-l border-black bg-white shadow-2xl">
+          <aside className="absolute inset-y-0 right-0 w-[min(88vw,360px)] overflow-y-auto border-l border-black bg-white shadow-2xl">
             <button
               type="button"
               onClick={() => setInviteOpen(false)}

--- a/components/live/LivePortalMobileEntry.tsx
+++ b/components/live/LivePortalMobileEntry.tsx
@@ -48,7 +48,9 @@ export function LivePortalMobileEntry({
             <IconMenu size={16} />
           </button>
           <div className="min-w-0">
-            <p className="truncate text-[14px] font-medium tracking-[-0.02em]">{project.name}</p>
+            <p className="truncate text-[14px] font-medium tracking-[-0.02em]">
+              {project.name}
+            </p>
             <p className="font-mono text-[8px] uppercase tracking-[0.12em] text-[var(--fg-muted)]">
               Live · {ROLE_LABEL[me.role]}
             </p>
@@ -98,7 +100,7 @@ export function LivePortalMobileEntry({
               </Link>
               {canInvite ? (
                 <div id="invite">
-                  <InvitePanel projectId={project.id} />
+                  <InvitePanel projectId={project.id} compact />
                 </div>
               ) : null}
             </div>

--- a/components/pwa/RegisterSW.tsx
+++ b/components/pwa/RegisterSW.tsx
@@ -19,6 +19,8 @@ export function RegisterSW() {
 
     let reg: ServiceWorkerRegistration | null = null;
     let reloading = false;
+    let checkingVersion = false;
+    const versionKey = "vforge:deployment-version";
 
     // Si el SW nuevo toma control, recargamos una sola vez para servir fresco.
     const onControllerChange = () => {
@@ -26,7 +28,10 @@ export function RegisterSW() {
       reloading = true;
       window.location.reload();
     };
-    navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      onControllerChange,
+    );
 
     const promote = (sw: ServiceWorker | null) => {
       // Solo ofrecer "actualizar" si YA había un SW controlando (es update, no
@@ -47,7 +52,8 @@ export function RegisterSW() {
           const installing = registration.installing;
           if (!installing) return;
           installing.addEventListener("statechange", () => {
-            if (installing.state === "installed") promote(registration.waiting || installing);
+            if (installing.state === "installed")
+              promote(registration.waiting || installing);
           });
         });
       })
@@ -55,17 +61,55 @@ export function RegisterSW() {
         /* offline shell no disponible */
       });
 
+    // Una pestaña puede seguir viva entre deployments aunque el build nuevo ya
+    // esté en producción. Comparamos el SHA servido por Vercel y recargamos una
+    // sola vez cuando cambie, sin depender de recordar cambiar el SW a mano.
+    const checkAppVersion = async () => {
+      if (checkingVersion || reloading) return;
+      checkingVersion = true;
+      try {
+        const response = await fetch("/api/version", { cache: "no-store" });
+        if (!response.ok) return;
+        const payload = (await response.json()) as { version?: string };
+        const nextVersion = payload.version?.trim();
+        if (!nextVersion || nextVersion === "development") return;
+
+        const currentVersion = window.localStorage.getItem(versionKey);
+        window.localStorage.setItem(versionKey, nextVersion);
+        if (currentVersion && currentVersion !== nextVersion) {
+          reloading = true;
+          window.location.reload();
+        }
+      } catch {
+        /* La app sigue funcionando aunque la revisión de versión falle. */
+      } finally {
+        checkingVersion = false;
+      }
+    };
+
+    void checkAppVersion();
+    const versionInterval = window.setInterval(
+      () => void checkAppVersion(),
+      60_000,
+    );
+
     // Revisar updates cuando el usuario vuelve a la app (clave en móvil/PWA).
     const checkForUpdate = () => {
-      if (document.visibilityState === "visible") reg?.update().catch(() => {});
+      if (document.visibilityState !== "visible") return;
+      reg?.update().catch(() => {});
+      void checkAppVersion();
     };
     document.addEventListener("visibilitychange", checkForUpdate);
     window.addEventListener("focus", checkForUpdate);
 
     return () => {
-      navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        onControllerChange,
+      );
       document.removeEventListener("visibilitychange", checkForUpdate);
       window.removeEventListener("focus", checkForUpdate);
+      window.clearInterval(versionInterval);
     };
   }, []);
 
@@ -89,8 +133,12 @@ export function RegisterSW() {
           className="h-2.5 w-2.5 shrink-0 rounded-full bg-black"
         />
         <div className="min-w-0 flex-1">
-          <p className="text-[13px] font-semibold text-black">Nueva versión disponible</p>
-          <p className="truncate text-[11px] text-[var(--fg-muted)]">Actualiza para ver lo último de VForge.</p>
+          <p className="text-[13px] font-semibold text-black">
+            Nueva versión disponible
+          </p>
+          <p className="truncate text-[11px] text-[var(--fg-muted)]">
+            Actualiza para ver lo último de VForge.
+          </p>
         </div>
         <button
           onClick={applyUpdate}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,18 +1,29 @@
 // VForge minimal service worker — offline shell + network-first for documents
 // Bump VERSION on every deploy where you want forced cache invalidation
-const VERSION = "vforge-project-repos-2026-08-30-2";
+const VERSION = "vforge-live-invite-2026-08-30-3";
 // Nunca precachear pantallas autenticadas: su HTML debe corresponder siempre
 // al deployment actual y a la sesión activa.
 const SHELL = ["/", "/offline"];
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(caches.open(VERSION).then((c) => c.addAll(SHELL)).catch(() => {}));
+  event.waitUntil(
+    caches
+      .open(VERSION)
+      .then((c) => c.addAll(SHELL))
+      .catch(() => {}),
+  );
   self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== VERSION).map((k) => caches.delete(k))))
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k !== VERSION).map((k) => caches.delete(k)),
+        ),
+      ),
   );
   self.clients.claim();
 });
@@ -31,7 +42,8 @@ self.addEventListener("fetch", (event) => {
   // Datos, bundles y respuestas RSC siempre pasan por red. Next.js ya publica
   // sus assets con hashes; guardarlos aquí puede mezclar dos releases.
   const isNextAsset = url.pathname.startsWith("/_next/");
-  const isRscRequest = url.searchParams.has("_rsc") || req.headers.get("RSC") === "1";
+  const isRscRequest =
+    url.searchParams.has("_rsc") || req.headers.get("RSC") === "1";
   if (url.pathname.startsWith("/api/") || isNextAsset || isRscRequest) {
     return;
   }
@@ -47,7 +59,9 @@ self.addEventListener("fetch", (event) => {
   // peligroso que mostrar la pantalla offline correcta.
   if (isAuthenticatedApp) {
     event.respondWith(
-      fetch(new Request(req, { cache: "no-store" })).catch(() => caches.match("/offline"))
+      fetch(new Request(req, { cache: "no-store" })).catch(() =>
+        caches.match("/offline"),
+      ),
     );
     return;
   }
@@ -61,7 +75,9 @@ self.addEventListener("fetch", (event) => {
           caches.open(VERSION).then((c) => c.put(req, copy));
           return res;
         })
-        .catch(() => caches.match(req).then((r) => r || caches.match("/offline")))
+        .catch(() =>
+          caches.match(req).then((r) => r || caches.match("/offline")),
+        ),
     );
     return;
   }
@@ -75,14 +91,16 @@ self.addEventListener("fetch", (event) => {
         return res;
       });
       return cached || networkPromise;
-    })
+    }),
   );
 });
 
 // ── Push notifications (VAPID) ──
 self.addEventListener("push", (event) => {
   let data = { title: "VForge", body: "Tienes una novedad.", url: "/app" };
-  try { if (event.data) data = { ...data, ...event.data.json() }; } catch {}
+  try {
+    if (event.data) data = { ...data, ...event.data.json() };
+  } catch {}
   event.waitUntil(
     self.registration.showNotification(data.title, {
       body: data.body,
@@ -90,17 +108,25 @@ self.addEventListener("push", (event) => {
       badge: "/icon.svg",
       data: { url: data.url || "/app" },
       vibrate: [80, 40, 80],
-    })
+    }),
   );
 });
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const url = (event.notification.data && event.notification.data.url) || "/app";
+  const url =
+    (event.notification.data && event.notification.data.url) || "/app";
   event.waitUntil(
-    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((wins) => {
-      for (const w of wins) { if ("focus" in w) { w.navigate(url); return w.focus(); } }
-      return self.clients.openWindow(url);
-    })
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((wins) => {
+        for (const w of wins) {
+          if ("focus" in w) {
+            w.navigate(url);
+            return w.focus();
+          }
+        }
+        return self.clients.openWindow(url);
+      }),
   );
 });


### PR DESCRIPTION
## Corrección
- detecta automáticamente cambios de commit en producción
- recarga una sola vez las pestañas que conservaron el bundle anterior
- fuerza actualización del service worker actual
- reduce el drawer de invitaciones a 360 px
- usa la variante compacta también en móvil

## Evidencia
- typecheck
- ESLint enfocado
- diff check
- build de producción

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production clients may auto-reload after deploys when version polling detects a new SHA, which can interrupt in-progress work but is intentional for cache correctness.
> 
> **Overview**
> **Stale PWA tabs** that keep an old JS bundle after a Vercel deploy are now detected and refreshed automatically, without relying only on bumping the service worker `VERSION` string.
> 
> A new **`GET /api/version`** route returns the deployment identity (`VERCEL_GIT_COMMIT_SHA` or `VERCEL_DEPLOYMENT_ID`) with **no-store** cache headers. **`RegisterSW`** polls that endpoint on load, every 60s, and when the tab regains focus; it stores the value in `localStorage` and triggers a **single** `location.reload()` when it changes (skipped in development). Existing SW update toasts and `controllerchange` reload behavior stay in place.
> 
> **Live invite UI:** the desktop invite drawer is slightly narrower (`88vw` / **360px** max), and the mobile menu uses **`InvitePanel` with `compact`**, matching the desktop drawer. **`public/sw.js`** bumps the cache `VERSION` for this release (plus formatting-only edits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0bc2cc071a4a73c5f0ac70ac20c537534e8fc94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->