### PR TITLE
feat(live): add V talk and planning modes

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { textBrain } from "@/lib/forge/v-brain";
+import {
+  authorizeAgentRunAccess,
+  selectAgentRepository,
+} from "@/lib/live/agent-runs";
+import {
+  listProjectAssistantMessages,
+  projectAssistantHistory,
+  saveProjectAssistantTurn,
+  type ProjectAssistantMode,
+} from "@/lib/live/project-assistant";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+
+function json(value: unknown, status = 200) {
+  return NextResponse.json(value, { status, headers: noStore });
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await authorizeAgentRunAccess(projectId, req.signal);
+  if (!access) return json({ error: "not_found" }, 404);
+
+  try {
+    const messages = await listProjectAssistantMessages(projectId);
+    return json({
+      messages,
+      canWrite: access.canWrite,
+      repositories: access.repositories,
+    });
+  } catch (caught) {
+    console.error("[project assistant] read failed", caught);
+    return json({ error: "service_unavailable" }, 503);
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const access = await authorizeAgentRunAccess(projectId, req.signal);
+  if (!access) return json({ error: "not_found" }, 404);
+  if (!access.canWrite) return json({ error: "forbidden" }, 403);
+
+  const payload = (await req.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const mode: ProjectAssistantMode | null =
+    payload?.mode === "talk" || payload?.mode === "plan" ? payload.mode : null;
+  const message =
+    typeof payload?.message === "string"
+      ? payload.message.trim().slice(0, 6000)
+      : "";
+  const repository = selectAgentRepository(access, payload?.repository);
+  if (!mode || message.length < 1)
+    return json({ error: "invalid_message" }, 400);
+
+  try {
+    const history = await projectAssistantHistory(projectId, mode);
+    const repoContext = repository
+      ? `${repository.repo_full_name} (rama ${repository.default_branch || "main"})`
+      : "sin repositorio seleccionado";
+    const modeRules =
+      mode === "plan"
+        ? `MODO PLANEACIÓN. Analiza y entrega un plan concreto, ordenado y verificable para el proyecto. No escribas código, no crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios. Señala decisiones, riesgos y criterios de aceptación. El usuario podrá convertir después este plan en una tarea de Ejecución.`
+        : `MODO PLÁTICA. Conversa naturalmente sobre el proyecto, haz preguntas cuando falte contexto y ayuda a pensar. No crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios.`;
+    const prompt = `${modeRules}
+
+SALA VFORGE: ${projectId}
+REPOSITORIO AUTORIZADO: ${repoContext}
+
+MENSAJE DEL USUARIO:
+${message}`;
+    const reply = await textBrain(prompt, history);
+    if (!reply.trim()) throw new Error("V no devolvió una respuesta.");
+
+    await saveProjectAssistantTurn({
+      projectId,
+      mode,
+      userId: access.identity.userId,
+      email: access.identity.email,
+      userText: message,
+      assistantText: reply.slice(0, 12000),
+    });
+    const messages = await listProjectAssistantMessages(projectId);
+    return json({ messages, reply });
+  } catch (caught) {
+    const detail = caught instanceof Error ? caught.message : String(caught);
+    console.error("[project assistant] response failed", {
+      projectId,
+      mode,
+      detail,
+    });
+    return json({ error: "V no pudo responder en este momento." }, 502);
+  }
+}

--- a/components/live/VControlPanel.tsx
+++ b/components/live/VControlPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
+import { VConversationPanel } from "@/components/live/VConversationPanel";
 import {
   IconBranch,
   IconCheck,
@@ -15,6 +16,7 @@ import {
 } from "@/components/brand/VFIcons";
 
 type Executor = "auto" | "codex" | "claude" | "grok" | "team";
+type ControlMode = "talk" | "plan" | "execute";
 type RunStatus =
   | "preparing"
   | "queued"
@@ -117,6 +119,7 @@ export function VControlPanel({
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [controlMode, setControlMode] = useState<ControlMode>("talk");
   const pollingRef = useRef(false);
 
   const load = useCallback(async () => {
@@ -264,10 +267,10 @@ export function VControlPanel({
           </span>
           <div className="min-w-0">
             <p className="font-mono text-[9px] uppercase tracking-[0.13em]">
-              Control de ejecución
+              V · conversación y control
             </p>
             <p className="truncate text-[9px] text-[var(--fg-muted)]">
-              Rama aislada · agentes · preview · aprobación · producción
+              Plática · planeación · ejecución protegida
             </p>
           </div>
         </div>
@@ -286,7 +289,34 @@ export function VControlPanel({
         </div>
       </header>
 
-      {canWrite ? (
+      <nav
+        className="flex shrink-0 gap-1 border-b border-[var(--border-1)] bg-white px-3 py-2"
+        aria-label="Modo de V"
+      >
+        {(
+          [
+            ["talk", "Plática"],
+            ["plan", "Planeación"],
+            ["execute", "Ejecución"],
+          ] as Array<[ControlMode, string]>
+        ).map(([id, label]) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setControlMode(id)}
+            className={cn(
+              "rounded-md border px-3 py-1.5 text-[10px] font-medium",
+              controlMode === id
+                ? "border-black bg-black text-white"
+                : "border-[var(--border-1)] bg-white hover:border-black",
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      {canWrite && controlMode === "execute" ? (
         <form
           onSubmit={startRun}
           className="shrink-0 border-b border-[var(--border-1)] bg-[var(--color-background)] p-3"
@@ -355,271 +385,289 @@ export function VControlPanel({
         </p>
       ) : null}
 
-      <div className="grid min-h-0 flex-1 md:grid-cols-[300px_minmax(0,1fr)]">
-        <aside className="min-h-0 overflow-y-auto border-b border-[var(--border-1)] md:border-b-0 md:border-r">
-          {loading ? (
-            <div className="flex items-center gap-2 p-4 text-[11px] text-[var(--fg-muted)]">
-              <IconLoader size={12} className="animate-spin" /> Cargando runs…
-            </div>
-          ) : runs.length ? (
-            <div className="divide-y divide-[var(--border-1)]">
-              {runs.map((run) => (
-                <button
-                  key={run.id}
-                  type="button"
-                  onClick={() => setSelectedId(run.id)}
-                  className={cn(
-                    "w-full p-3 text-left hover:bg-[var(--color-background)]",
-                    selected?.id === run.id &&
-                      "bg-black text-white hover:bg-black",
-                  )}
-                >
-                  <span className="flex items-center justify-between gap-2">
-                    <strong className="truncate text-[11px] font-medium">
-                      {run.instruction}
-                    </strong>
-                    <span
-                      className={cn(
-                        "status-shape shrink-0",
-                        ACTIVE.has(run.status) && "animate-pulse",
-                      )}
-                      data-active={
-                        run.status === "preview_ready" ||
-                        run.status === "approved" ||
-                        run.status === "published"
-                      }
-                    />
-                  </span>
-                  <span
+      {controlMode !== "execute" ? (
+        <VConversationPanel
+          projectId={projectId}
+          mode={controlMode}
+          canWrite={canWrite}
+          repositories={repositories}
+          repository={repository}
+          onRepositoryChange={setRepository}
+          onUseAsTask={(plan) => {
+            setInstruction(plan.slice(0, 12000));
+            setControlMode("execute");
+          }}
+        />
+      ) : (
+        <div className="grid min-h-0 flex-1 md:grid-cols-[300px_minmax(0,1fr)]">
+          <aside className="min-h-0 overflow-y-auto border-b border-[var(--border-1)] md:border-b-0 md:border-r">
+            {loading ? (
+              <div className="flex items-center gap-2 p-4 text-[11px] text-[var(--fg-muted)]">
+                <IconLoader size={12} className="animate-spin" /> Cargando runs…
+              </div>
+            ) : runs.length ? (
+              <div className="divide-y divide-[var(--border-1)]">
+                {runs.map((run) => (
+                  <button
+                    key={run.id}
+                    type="button"
+                    onClick={() => setSelectedId(run.id)}
                     className={cn(
-                      "mt-2 flex items-center justify-between font-mono text-[8px] uppercase tracking-[0.08em]",
-                      selected?.id === run.id
-                        ? "text-white/65"
-                        : "text-[var(--fg-muted)]",
+                      "w-full p-3 text-left hover:bg-[var(--color-background)]",
+                      selected?.id === run.id &&
+                        "bg-black text-white hover:bg-black",
                     )}
                   >
-                    <span>
-                      {run.requested_executor === "team"
-                        ? "Equipo"
-                        : run.resolved_executor}
+                    <span className="flex items-center justify-between gap-2">
+                      <strong className="truncate text-[11px] font-medium">
+                        {run.instruction}
+                      </strong>
+                      <span
+                        className={cn(
+                          "status-shape shrink-0",
+                          ACTIVE.has(run.status) && "animate-pulse",
+                        )}
+                        data-active={
+                          run.status === "preview_ready" ||
+                          run.status === "approved" ||
+                          run.status === "published"
+                        }
+                      />
                     </span>
-                    <span>{STATUS_LABELS[run.status]}</span>
-                  </span>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="p-5 text-[11px] leading-5 text-[var(--fg-muted)]">
-              Todavía no hay ejecuciones. Dale una instrucción a V para crear la
-              primera rama aislada.
-            </div>
-          )}
-        </aside>
-
-        <div className="min-h-0 overflow-y-auto bg-[var(--color-background)]">
-          {selected ? (
-            <div className="grid min-h-full gap-3 p-3 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.8fr)]">
-              <div className="space-y-3">
-                <section className="rounded-[8px] border border-[var(--border-1)] bg-white p-3">
-                  <div className="flex flex-wrap items-start justify-between gap-2">
-                    <div>
-                      <p className="mono-label">Instrucción</p>
-                      <p className="mt-2 whitespace-pre-wrap text-[12px] leading-5">
-                        {selected.instruction}
-                      </p>
-                    </div>
-                    <span className="rounded-full border border-black px-2 py-1 font-mono text-[8px] uppercase tracking-[0.08em]">
-                      {STATUS_LABELS[selected.status]}
+                    <span
+                      className={cn(
+                        "mt-2 flex items-center justify-between font-mono text-[8px] uppercase tracking-[0.08em]",
+                        selected?.id === run.id
+                          ? "text-white/65"
+                          : "text-[var(--fg-muted)]",
+                      )}
+                    >
+                      <span>
+                        {run.requested_executor === "team"
+                          ? "Equipo"
+                          : run.resolved_executor}
+                      </span>
+                      <span>{STATUS_LABELS[run.status]}</span>
                     </span>
-                  </div>
-                  <div className="mt-3 grid gap-2 border-t border-[var(--border-1)] pt-3 text-[9px] sm:grid-cols-2">
-                    <p className="truncate">
-                      <span className="text-[var(--fg-muted)]">Repo </span>
-                      {selected.repo_full_name}
-                    </p>
-                    <p className="truncate">
-                      <span className="text-[var(--fg-muted)]">Rama </span>
-                      {selected.work_branch}
-                    </p>
-                  </div>
-                </section>
-
-                <section className="rounded-[8px] border border-[var(--border-1)] bg-white">
-                  <header className="border-b border-[var(--border-1)] px-3 py-2">
-                    <p className="mono-label">Circuito</p>
-                  </header>
-                  <div className="divide-y divide-[var(--border-1)]">
-                    {selected.queue_jobs.map((jobRef, index) => {
-                      const job = jobMap.get(jobRef.id);
-                      const done =
-                        job &&
-                        ["done", "completed", "success", "succeeded"].includes(
-                          job.status.toLowerCase(),
-                        );
-                      return (
-                        <div
-                          key={jobRef.id}
-                          className="grid grid-cols-[26px_minmax(0,1fr)_auto] items-start gap-2 px-3 py-3"
-                        >
-                          <span
-                            className={cn(
-                              "grid h-6 w-6 place-items-center rounded-full border text-[9px]",
-                              done
-                                ? "border-black bg-black text-white"
-                                : "border-[var(--border-1)]",
-                            )}
-                          >
-                            {done ? <IconCheck size={10} /> : index + 1}
-                          </span>
-                          <div>
-                            <p className="text-[11px] font-medium capitalize">
-                              {jobRef.agent} · {jobRef.role}
-                            </p>
-                            <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-[9px] leading-4 text-[var(--fg-muted)]">
-                              {job?.logTail ||
-                                job?.result ||
-                                "Esperando al runner…"}
-                            </p>
-                          </div>
-                          <span className="font-mono text-[8px] uppercase text-[var(--fg-muted)]">
-                            {job?.status || "queued"}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </section>
-
-                {selected.summary ? (
-                  <section className="rounded-[8px] border border-[var(--border-1)] bg-white p-3">
-                    <p className="mono-label">Resultado más reciente</p>
-                    <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap text-[10px] leading-5">
-                      {selected.summary}
-                    </pre>
-                  </section>
-                ) : null}
-                {selected.error ? (
-                  <section className="rounded-[8px] border border-black bg-white p-3 text-[10px] leading-5">
-                    {selected.error}
-                  </section>
-                ) : null}
+                  </button>
+                ))}
               </div>
+            ) : (
+              <div className="p-5 text-[11px] leading-5 text-[var(--fg-muted)]">
+                Todavía no hay ejecuciones. Dale una instrucción a V para crear
+                la primera rama aislada.
+              </div>
+            )}
+          </aside>
 
-              <div className="space-y-3">
-                <section className="overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-white">
-                  <header className="flex items-center justify-between border-b border-[var(--border-1)] px-3 py-2">
-                    <p className="mono-label">Preview antes de publicar</p>
-                    {selected.preview_url ? (
-                      <a
-                        href={selected.preview_url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="grid h-7 w-7 place-items-center rounded-md hover:bg-[var(--color-background)]"
-                        aria-label="Abrir preview"
-                      >
-                        <IconExtLink size={10} />
-                      </a>
-                    ) : null}
-                  </header>
-                  {selected.preview_url ? (
-                    <iframe
-                      src={selected.preview_url}
-                      title={`Preview ${selected.id}`}
-                      className="h-[380px] w-full border-0 bg-white"
-                      sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-                      referrerPolicy="no-referrer"
-                    />
-                  ) : (
-                    <div className="grid min-h-52 place-items-center p-6 text-center">
+          <div className="min-h-0 overflow-y-auto bg-[var(--color-background)]">
+            {selected ? (
+              <div className="grid min-h-full gap-3 p-3 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.8fr)]">
+                <div className="space-y-3">
+                  <section className="rounded-[8px] border border-[var(--border-1)] bg-white p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
                       <div>
-                        <IconSparkles size={20} className="mx-auto" />
-                        <p className="mt-3 text-[11px] font-medium">
-                          El preview aparecerá aquí
-                        </p>
-                        <p className="mt-2 max-w-xs text-[9px] leading-4 text-[var(--fg-muted)]">
-                          Cuando el agente haga push a la rama, Vercel enviará
-                          la URL a esta sala. Producción permanece intacta.
+                        <p className="mono-label">Instrucción</p>
+                        <p className="mt-2 whitespace-pre-wrap text-[12px] leading-5">
+                          {selected.instruction}
                         </p>
                       </div>
+                      <span className="rounded-full border border-black px-2 py-1 font-mono text-[8px] uppercase tracking-[0.08em]">
+                        {STATUS_LABELS[selected.status]}
+                      </span>
                     </div>
-                  )}
-                </section>
+                    <div className="mt-3 grid gap-2 border-t border-[var(--border-1)] pt-3 text-[9px] sm:grid-cols-2">
+                      <p className="truncate">
+                        <span className="text-[var(--fg-muted)]">Repo </span>
+                        {selected.repo_full_name}
+                      </p>
+                      <p className="truncate">
+                        <span className="text-[var(--fg-muted)]">Rama </span>
+                        {selected.work_branch}
+                      </p>
+                    </div>
+                  </section>
 
-                <section className="rounded-[8px] border border-black bg-white p-3">
-                  <div className="flex flex-wrap gap-2">
-                    <a
-                      href={`https://github.com/${selected.repo_full_name}/tree/${selected.work_branch}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="btn-ghost"
-                    >
-                      <IconBranch size={11} /> Rama
-                    </a>
-                    {selected.pr_url ? (
+                  <section className="rounded-[8px] border border-[var(--border-1)] bg-white">
+                    <header className="border-b border-[var(--border-1)] px-3 py-2">
+                      <p className="mono-label">Circuito</p>
+                    </header>
+                    <div className="divide-y divide-[var(--border-1)]">
+                      {selected.queue_jobs.map((jobRef, index) => {
+                        const job = jobMap.get(jobRef.id);
+                        const done =
+                          job &&
+                          [
+                            "done",
+                            "completed",
+                            "success",
+                            "succeeded",
+                          ].includes(job.status.toLowerCase());
+                        return (
+                          <div
+                            key={jobRef.id}
+                            className="grid grid-cols-[26px_minmax(0,1fr)_auto] items-start gap-2 px-3 py-3"
+                          >
+                            <span
+                              className={cn(
+                                "grid h-6 w-6 place-items-center rounded-full border text-[9px]",
+                                done
+                                  ? "border-black bg-black text-white"
+                                  : "border-[var(--border-1)]",
+                              )}
+                            >
+                              {done ? <IconCheck size={10} /> : index + 1}
+                            </span>
+                            <div>
+                              <p className="text-[11px] font-medium capitalize">
+                                {jobRef.agent} · {jobRef.role}
+                              </p>
+                              <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-[9px] leading-4 text-[var(--fg-muted)]">
+                                {job?.logTail ||
+                                  job?.result ||
+                                  "Esperando al runner…"}
+                              </p>
+                            </div>
+                            <span className="font-mono text-[8px] uppercase text-[var(--fg-muted)]">
+                              {job?.status || "queued"}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </section>
+
+                  {selected.summary ? (
+                    <section className="rounded-[8px] border border-[var(--border-1)] bg-white p-3">
+                      <p className="mono-label">Resultado más reciente</p>
+                      <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap text-[10px] leading-5">
+                        {selected.summary}
+                      </pre>
+                    </section>
+                  ) : null}
+                  {selected.error ? (
+                    <section className="rounded-[8px] border border-black bg-white p-3 text-[10px] leading-5">
+                      {selected.error}
+                    </section>
+                  ) : null}
+                </div>
+
+                <div className="space-y-3">
+                  <section className="overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-white">
+                    <header className="flex items-center justify-between border-b border-[var(--border-1)] px-3 py-2">
+                      <p className="mono-label">Preview antes de publicar</p>
+                      {selected.preview_url ? (
+                        <a
+                          href={selected.preview_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="grid h-7 w-7 place-items-center rounded-md hover:bg-[var(--color-background)]"
+                          aria-label="Abrir preview"
+                        >
+                          <IconExtLink size={10} />
+                        </a>
+                      ) : null}
+                    </header>
+                    {selected.preview_url ? (
+                      <iframe
+                        src={selected.preview_url}
+                        title={`Preview ${selected.id}`}
+                        className="h-[380px] w-full border-0 bg-white"
+                        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+                        referrerPolicy="no-referrer"
+                      />
+                    ) : (
+                      <div className="grid min-h-52 place-items-center p-6 text-center">
+                        <div>
+                          <IconSparkles size={20} className="mx-auto" />
+                          <p className="mt-3 text-[11px] font-medium">
+                            El preview aparecerá aquí
+                          </p>
+                          <p className="mt-2 max-w-xs text-[9px] leading-4 text-[var(--fg-muted)]">
+                            Cuando el agente haga push a la rama, Vercel enviará
+                            la URL a esta sala. Producción permanece intacta.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </section>
+
+                  <section className="rounded-[8px] border border-black bg-white p-3">
+                    <div className="flex flex-wrap gap-2">
                       <a
-                        href={selected.pr_url}
+                        href={`https://github.com/${selected.repo_full_name}/tree/${selected.work_branch}`}
                         target="_blank"
                         rel="noreferrer"
                         className="btn-ghost"
                       >
-                        <IconExtLink size={11} /> PR
+                        <IconBranch size={11} /> Rama
                       </a>
-                    ) : null}
-                    {canWrite && selected.status === "preview_ready" ? (
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() => void runAction("approve")}
-                        className="btn-primary"
-                      >
-                        <IconCheck size={11} /> Aprobar y crear PR
-                      </button>
-                    ) : null}
-                    {canWrite && selected.status === "approved" ? (
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() => void runAction("publish")}
-                        className="btn-primary"
-                      >
-                        <IconRocket size={11} /> Publicar
-                      </button>
-                    ) : null}
-                    {canWrite && ACTIVE.has(selected.status) ? (
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() => void runAction("cancel")}
-                        className="btn-ghost"
-                      >
-                        <IconStop size={11} /> Cancelar
-                      </button>
-                    ) : null}
-                  </div>
-                  <p className="mt-3 text-[9px] leading-4 text-[var(--fg-muted)]">
-                    Aprobar crea el PR. Publicar lo fusiona a{" "}
-                    {selected.base_branch} y entonces comienza producción.
+                      {selected.pr_url ? (
+                        <a
+                          href={selected.pr_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="btn-ghost"
+                        >
+                          <IconExtLink size={11} /> PR
+                        </a>
+                      ) : null}
+                      {canWrite && selected.status === "preview_ready" ? (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => void runAction("approve")}
+                          className="btn-primary"
+                        >
+                          <IconCheck size={11} /> Aprobar y crear PR
+                        </button>
+                      ) : null}
+                      {canWrite && selected.status === "approved" ? (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => void runAction("publish")}
+                          className="btn-primary"
+                        >
+                          <IconRocket size={11} /> Publicar
+                        </button>
+                      ) : null}
+                      {canWrite && ACTIVE.has(selected.status) ? (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => void runAction("cancel")}
+                          className="btn-ghost"
+                        >
+                          <IconStop size={11} /> Cancelar
+                        </button>
+                      ) : null}
+                    </div>
+                    <p className="mt-3 text-[9px] leading-4 text-[var(--fg-muted)]">
+                      Aprobar crea el PR. Publicar lo fusiona a{" "}
+                      {selected.base_branch} y entonces comienza producción.
+                    </p>
+                  </section>
+                </div>
+              </div>
+            ) : (
+              <div className="grid h-full place-items-center p-8 text-center">
+                <div>
+                  <span className="mx-auto grid h-10 w-10 place-items-center rounded-full bg-black font-semibold text-white">
+                    V
+                  </span>
+                  <p className="mt-3 text-[12px] font-medium">
+                    Tu cabina de ejecución
                   </p>
-                </section>
+                  <p className="mt-2 text-[10px] text-[var(--fg-muted)]">
+                    Selecciona un run o inicia una tarea.
+                  </p>
+                </div>
               </div>
-            </div>
-          ) : (
-            <div className="grid h-full place-items-center p-8 text-center">
-              <div>
-                <span className="mx-auto grid h-10 w-10 place-items-center rounded-full bg-black font-semibold text-white">
-                  V
-                </span>
-                <p className="mt-3 text-[12px] font-medium">
-                  Tu cabina de ejecución
-                </p>
-                <p className="mt-2 text-[10px] text-[var(--fg-muted)]">
-                  Selecciona un run o inicia una tarea.
-                </p>
-              </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/components/live/VConversationPanel.tsx
+++ b/components/live/VConversationPanel.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  IconArrowR,
+  IconLoader,
+  IconSend,
+  IconSparkles,
+} from "@/components/brand/VFIcons";
+
+type ConversationMode = "talk" | "plan";
+
+interface AssistantMessage {
+  id: string;
+  mode: ConversationMode;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+}
+
+interface Repository {
+  repo_full_name: string;
+  is_primary: boolean;
+  default_branch: string | null;
+}
+
+export function VConversationPanel({
+  projectId,
+  mode,
+  canWrite,
+  repositories,
+  repository,
+  onRepositoryChange,
+  onUseAsTask,
+}: {
+  projectId: string;
+  mode: ConversationMode;
+  canWrite: boolean;
+  repositories: Repository[];
+  repository: string;
+  onRepositoryChange: (repository: string) => void;
+  onUseAsTask: (plan: string) => void;
+}) {
+  const [messages, setMessages] = useState<AssistantMessage[]>([]);
+  const [message, setMessage] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const pollingRef = useRef(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  const load = useCallback(async () => {
+    if (pollingRef.current) return;
+    pollingRef.current = true;
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/assistant`,
+        { cache: "no-store" },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        messages?: AssistantMessage[];
+      } | null;
+      if (!response.ok) throw new Error("No se pudo cargar la conversación.");
+      setMessages(Array.isArray(payload?.messages) ? payload.messages : []);
+      setError(null);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "No se pudo cargar la conversación.",
+      );
+    } finally {
+      pollingRef.current = false;
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void load();
+    const timer = window.setInterval(() => void load(), 5000);
+    return () => window.clearInterval(timer);
+  }, [load]);
+
+  const visibleMessages = useMemo(
+    () => messages.filter((item) => item.mode === mode),
+    [messages, mode],
+  );
+  const latestPlan = useMemo(
+    () =>
+      mode === "plan"
+        ? ([...visibleMessages]
+            .reverse()
+            .find((item) => item.role === "assistant")?.content ?? null)
+        : null,
+    [mode, visibleMessages],
+  );
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ block: "end" });
+  }, [visibleMessages.length, busy, mode]);
+
+  async function send(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = message.trim();
+    if (!trimmed || busy || !canWrite) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/assistant`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode, message: trimmed, repository }),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        messages?: AssistantMessage[];
+        error?: string;
+      } | null;
+      if (!response.ok)
+        throw new Error(payload?.error || "V no pudo responder.");
+      setMessages(Array.isArray(payload?.messages) ? payload.messages : []);
+      setMessage("");
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "V no pudo responder.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-[var(--color-background)]">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-[var(--border-1)] bg-white px-3 py-2">
+        <div>
+          <p className="text-[11px] font-medium">
+            {mode === "talk" ? "Plática con V" : "Planeación con V"}
+          </p>
+          <p className="mt-0.5 text-[9px] text-[var(--fg-muted)]">
+            {mode === "talk"
+              ? "Conversa sin crear ramas ni ejecutar agentes."
+              : "Define el trabajo antes de permitir cualquier cambio."}
+          </p>
+        </div>
+        <select
+          value={repository}
+          onChange={(event) => onRepositoryChange(event.target.value)}
+          className="min-h-8 max-w-[280px] rounded-md border border-[var(--border-1)] bg-white px-2 text-[10px] outline-none focus:border-black"
+          aria-label="Repositorio de contexto"
+        >
+          {repositories.map((repo) => (
+            <option key={repo.repo_full_name} value={repo.repo_full_name}>
+              {repo.repo_full_name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div
+        className="min-h-0 flex-1 overflow-y-auto px-3 py-4"
+        aria-live="polite"
+      >
+        {loading ? (
+          <div className="flex h-full items-center justify-center gap-2 text-[10px] text-[var(--fg-muted)]">
+            <IconLoader size={12} className="animate-spin" /> Cargando
+            conversación…
+          </div>
+        ) : visibleMessages.length ? (
+          <div className="mx-auto flex w-full max-w-4xl flex-col gap-3">
+            {visibleMessages.map((item) => (
+              <article
+                key={item.id}
+                className={cn(
+                  "max-w-[86%] rounded-[12px] px-4 py-3 text-[12px] leading-5",
+                  item.role === "user"
+                    ? "ml-auto bg-black text-white"
+                    : "mr-auto border border-[var(--border-1)] bg-white text-black",
+                )}
+              >
+                <p className="mb-1 font-mono text-[8px] uppercase tracking-[0.1em] opacity-55">
+                  {item.role === "user" ? "Tú" : "V"}
+                </p>
+                <p className="whitespace-pre-wrap">{item.content}</p>
+              </article>
+            ))}
+            {busy ? (
+              <div className="mr-auto flex items-center gap-2 rounded-[12px] border border-[var(--border-1)] bg-white px-4 py-3 text-[10px] text-[var(--fg-muted)]">
+                <IconLoader size={12} className="animate-spin" /> V está
+                pensando…
+              </div>
+            ) : null}
+            <div ref={endRef} />
+          </div>
+        ) : (
+          <div className="grid h-full place-items-center text-center">
+            <div className="max-w-sm">
+              <span className="mx-auto grid h-11 w-11 place-items-center rounded-full bg-black text-white">
+                <IconSparkles size={17} />
+              </span>
+              <p className="mt-3 text-[12px] font-medium">
+                {mode === "talk"
+                  ? "Platícale a V"
+                  : "Planea antes de construir"}
+              </p>
+              <p className="mt-2 text-[10px] leading-5 text-[var(--fg-muted)]">
+                {mode === "talk"
+                  ? "Pregúntale, explícale el objetivo o revisen juntos qué sigue."
+                  : "Describe el resultado; V organizará alcance, pasos, riesgos y aceptación."}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {error ? (
+        <p className="shrink-0 border-t border-[var(--border-1)] px-3 py-2 text-[10px] text-[var(--color-danger)]">
+          {error}
+        </p>
+      ) : null}
+
+      {mode === "plan" && latestPlan ? (
+        <div className="flex shrink-0 justify-end border-t border-[var(--border-1)] bg-white px-3 py-2">
+          <button
+            type="button"
+            onClick={() => onUseAsTask(latestPlan)}
+            className="btn-ghost"
+          >
+            Usar como tarea <IconArrowR size={11} />
+          </button>
+        </div>
+      ) : null}
+
+      {canWrite ? (
+        <form
+          onSubmit={send}
+          className="shrink-0 border-t border-[var(--border-1)] bg-white p-3"
+        >
+          <div className="mx-auto flex max-w-4xl items-end gap-2">
+            <textarea
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  event.currentTarget.form?.requestSubmit();
+                }
+              }}
+              rows={2}
+              maxLength={6000}
+              placeholder={
+                mode === "talk"
+                  ? "Platícale a V…"
+                  : "¿Qué necesitamos planear antes de ejecutar?"
+              }
+              className="min-h-12 flex-1 resize-y rounded-[10px] border border-[var(--border-1)] px-3 py-2 text-[12px] leading-5 outline-none focus:border-black"
+            />
+            <button
+              type="submit"
+              disabled={busy || !message.trim()}
+              className="btn-primary min-h-12 px-4 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {busy ? (
+                <IconLoader size={12} className="animate-spin" />
+              ) : (
+                <IconSend size={12} />
+              )}
+              Enviar
+            </button>
+          </div>
+          <p className="mx-auto mt-2 max-w-4xl font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">
+            Enter envía · Shift + Enter agrega línea · sin cambios en GitHub
+          </p>
+        </form>
+      ) : (
+        <p className="shrink-0 border-t border-[var(--border-1)] bg-white px-3 py-3 text-[10px] text-[var(--fg-muted)]">
+          Vista de lectura. Sólo el owner puede conversar o planear con V.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/live/project-assistant.ts
+++ b/lib/live/project-assistant.ts
@@ -1,0 +1,97 @@
+import "server-only";
+
+import { queryAll, queryOne } from "@/lib/db/client";
+
+export type ProjectAssistantMode = "talk" | "plan";
+
+export interface ProjectAssistantMessage {
+  id: string;
+  mode: ProjectAssistantMode;
+  role: "user" | "assistant";
+  created_by_email: string;
+  content: string;
+  created_at: string;
+}
+
+export async function ensureProjectAssistantTable(): Promise<void> {
+  await queryOne(
+    `CREATE TABLE IF NOT EXISTS project_v_messages (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      project_id text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      mode text NOT NULL CHECK (mode IN ('talk', 'plan')),
+      role text NOT NULL CHECK (role IN ('user', 'assistant')),
+      created_by_user_id text NOT NULL,
+      created_by_email text NOT NULL,
+      content text NOT NULL CHECK (char_length(content) BETWEEN 1 AND 12000),
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`,
+  );
+  await queryOne(
+    `CREATE INDEX IF NOT EXISTS idx_project_v_messages_thread
+       ON project_v_messages (project_id, mode, created_at DESC)`,
+  );
+}
+
+export async function listProjectAssistantMessages(
+  projectId: string,
+): Promise<ProjectAssistantMessage[]> {
+  await ensureProjectAssistantTable();
+  return queryAll<ProjectAssistantMessage>(
+    `SELECT id::text, mode, role, created_by_email, content, created_at
+       FROM (
+         SELECT id, mode, role, created_by_email, content, created_at
+           FROM project_v_messages
+          WHERE project_id = $1
+          ORDER BY created_at DESC, id DESC
+          LIMIT 200
+       ) recent
+      ORDER BY created_at ASC, id ASC`,
+    [projectId],
+  );
+}
+
+export async function projectAssistantHistory(
+  projectId: string,
+  mode: ProjectAssistantMode,
+): Promise<Array<{ role: "user" | "assistant"; content: string }>> {
+  await ensureProjectAssistantTable();
+  const rows = await queryAll<{ role: "user" | "assistant"; content: string }>(
+    `SELECT role, content
+       FROM (
+         SELECT role, content, created_at, id
+           FROM project_v_messages
+          WHERE project_id = $1 AND mode = $2
+          ORDER BY created_at DESC, id DESC
+          LIMIT 20
+       ) recent
+      ORDER BY created_at ASC, id ASC`,
+    [projectId, mode],
+  );
+  return rows;
+}
+
+export async function saveProjectAssistantTurn(args: {
+  projectId: string;
+  mode: ProjectAssistantMode;
+  userId: string;
+  email: string;
+  userText: string;
+  assistantText: string;
+}): Promise<void> {
+  await ensureProjectAssistantTable();
+  await queryOne(
+    `INSERT INTO project_v_messages
+      (project_id, mode, role, created_by_user_id, created_by_email, content)
+     VALUES
+      ($1, $2, 'user', $3, $4, $5),
+      ($1, $2, 'assistant', $3, $4, $6)`,
+    [
+      args.projectId,
+      args.mode,
+      args.userId,
+      args.email,
+      args.userText,
+      args.assistantText,
+    ],
+  );
+}

--- a/migrations/046_project_v_messages.sql
+++ b/migrations/046_project_v_messages.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS project_v_messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  mode text NOT NULL CHECK (mode IN ('talk', 'plan')),
+  role text NOT NULL CHECK (role IN ('user', 'assistant')),
+  created_by_user_id text NOT NULL,
+  created_by_email text NOT NULL,
+  content text NOT NULL CHECK (char_length(content) BETWEEN 1 AND 12000),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_v_messages_thread
+  ON project_v_messages (project_id, mode, created_at DESC);


### PR DESCRIPTION
## Cambios
- separa Plática, Planeación y Ejecución en la cabina V
- Plática y Planeación no crean ramas ni llaman runners
- guarda conversación por proyecto en Neon
- limita escritura al owner; revisores y observadores leen
- permite convertir el último plan en tarea sin ejecutarla automáticamente
- mantiene selección de repositorio como contexto autorizado

## Verificación
- `npm run typecheck`
- ESLint enfocado
- `git diff --check`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated API persists user content and calls the LLM; execution paths are unchanged, but mis-prompted assistant replies could mislead users about repo actions until they explicitly run Ejecución.
> 
> **Overview**
> The V cabina now splits **Plática**, **Planeación**, and **Ejecución** behind a mode switch instead of only showing the execution workflow.
> 
> **Plática** and **Planeación** use a new project-scoped assistant API and `VConversationPanel`: messages go to `textBrain` with mode-specific prompts (plan mode forbids claiming code or agent actions), history is loaded per mode, and turns persist in Neon (`project_v_messages`). Access reuses `authorizeAgentRunAccess`—owners can post; reviewers and observers can read. Repository selection is context-only for the model, not execution.
> 
> From **Planeación**, **Usar como tarea** copies the latest assistant plan into the execution instruction and switches to **Ejecución** without starting a run. The existing runs UI, preview, and approve/publish flow stay under Ejecución only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9688179f64022e5870796b02f764cbb118fd9f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->