### PR TITLE
Fix V project chat model routing and provider fallback

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { textBrain } from "@/lib/forge/v-brain";
+import { askV, ProviderUnavailable } from "@/lib/forge/v-router";
 import {
   authorizeAgentRunAccess,
   selectAgentRepository,
@@ -80,8 +80,13 @@ REPOSITORIO AUTORIZADO: ${repoContext}
 
 MENSAJE DEL USUARIO:
 ${message}`;
-    const reply = await textBrain(prompt, history);
-    if (!reply.trim()) throw new Error("V no devolvió una respuesta.");
+    const result = await askV({
+      mode,
+      projectId,
+      repository: repository?.repo_full_name || null,
+      message: prompt,
+      history,
+    });
 
     await saveProjectAssistantTurn({
       projectId,
@@ -89,17 +94,39 @@ ${message}`;
       userId: access.identity.userId,
       email: access.identity.email,
       userText: message,
-      assistantText: reply.slice(0, 12000),
+      assistantText: result.text.slice(0, 12000),
+      provider: result.provider,
+      model: result.model,
+      status: result.status,
+      durationMs: result.durationMs,
     });
     const messages = await listProjectAssistantMessages(projectId);
-    return json({ messages, reply });
+    return json({
+      messages,
+      reply: result.text,
+      provider: result.provider,
+      model: result.model,
+      status: result.status,
+      durationMs: result.durationMs,
+      systemNotice: result.systemNotice || null,
+    });
   } catch (caught) {
     const detail = caught instanceof Error ? caught.message : String(caught);
     console.error("[project assistant] response failed", {
       projectId,
       mode,
       detail,
+      providerUnavailable: caught instanceof ProviderUnavailable,
     });
+    if (caught instanceof ProviderUnavailable) {
+      return json(
+        {
+          error: "provider_unavailable",
+          systemNotice: "Los proveedores de V no están disponibles en este momento.",
+        },
+        503,
+      );
+    }
     return json({ error: "V no pudo responder en este momento." }, 502);
   }
 }

--- a/components/live/VConversationPanel.tsx
+++ b/components/live/VConversationPanel.tsx
@@ -17,6 +17,10 @@ interface AssistantMessage {
   role: "user" | "assistant";
   content: string;
   created_at: string;
+  provider?: string | null;
+  model?: string | null;
+  status?: string | null;
+  duration_ms?: number | null;
 }
 
 interface Repository {
@@ -47,6 +51,7 @@ export function VConversationPanel({
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [systemNotice, setSystemNotice] = useState<string | null>(null);
   const pollingRef = useRef(false);
   const endRef = useRef<HTMLDivElement>(null);
 
@@ -118,10 +123,18 @@ export function VConversationPanel({
       const payload = (await response.json().catch(() => null)) as {
         messages?: AssistantMessage[];
         error?: string;
+        systemNotice?: string | null;
       } | null;
-      if (!response.ok)
-        throw new Error(payload?.error || "V no pudo responder.");
+      if (!response.ok) {
+        setSystemNotice(payload?.systemNotice || null);
+        throw new Error(
+          payload?.error === "provider_unavailable"
+            ? "V no tiene un proveedor disponible en este momento."
+            : payload?.error || "V no pudo responder.",
+        );
+      }
       setMessages(Array.isArray(payload?.messages) ? payload.messages : []);
+      setSystemNotice(payload?.systemNotice || null);
       setMessage("");
     } catch (caught) {
       setError(
@@ -174,7 +187,7 @@ export function VConversationPanel({
               <article
                 key={item.id}
                 className={cn(
-                  "max-w-[86%] rounded-[12px] px-4 py-3 text-[12px] leading-5",
+                  "min-w-[96px] max-w-[86%] break-words rounded-[12px] px-4 py-3 text-[12px] leading-5 [overflow-wrap:anywhere]",
                   item.role === "user"
                     ? "ml-auto bg-black text-white"
                     : "mr-auto border border-[var(--border-1)] bg-white text-black",
@@ -183,7 +196,7 @@ export function VConversationPanel({
                 <p className="mb-1 font-mono text-[8px] uppercase tracking-[0.1em] opacity-55">
                   {item.role === "user" ? "Tú" : "V"}
                 </p>
-                <p className="whitespace-pre-wrap">{item.content}</p>
+                <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{item.content}</p>
               </article>
             ))}
             {busy ? (
@@ -215,6 +228,12 @@ export function VConversationPanel({
         )}
       </div>
 
+      {systemNotice ? (
+        <p className="shrink-0 px-3 py-1.5 text-center text-[9px] text-[var(--fg-muted)]">
+          {systemNotice}
+        </p>
+      ) : null}
+
       {error ? (
         <p className="shrink-0 border-t border-[var(--border-1)] px-3 py-2 text-[10px] text-[var(--color-danger)]">
           {error}
@@ -236,7 +255,7 @@ export function VConversationPanel({
       {canWrite ? (
         <form
           onSubmit={send}
-          className="shrink-0 border-t border-[var(--border-1)] bg-white p-3"
+          className="shrink-0 bg-white p-3"
         >
           <div className="mx-auto flex max-w-4xl items-end gap-2">
             <textarea

--- a/lib/forge/v-router.ts
+++ b/lib/forge/v-router.ts
@@ -1,0 +1,224 @@
+import "server-only";
+
+import OpenAI from "openai";
+import { modelForEngine, resolveLlmEngine } from "@/lib/forge/llm-engine";
+import { textBrain, type ChatTurn } from "@/lib/forge/v-brain";
+
+export type VMode = "talk" | "plan";
+
+export class ProviderUnavailable extends Error {
+  provider: string;
+  causeText: string;
+
+  constructor(provider: string, causeText: string) {
+    super(`${provider} unavailable`);
+    this.name = "ProviderUnavailable";
+    this.provider = provider;
+    this.causeText = causeText;
+  }
+}
+
+export interface AskVResult {
+  text: string;
+  provider: string;
+  model: string;
+  status: "ok" | "fallback";
+  durationMs: number;
+  systemNotice?: string;
+}
+
+const PROVIDER_FAILURE = [
+  /weekly limit/i,
+  /usage limit/i,
+  /rate limit/i,
+  /c[oó]digo\s*1/i,
+  /code\s*1/i,
+  /command failed/i,
+  /provider unavailable/i,
+  /timed?\s*out/i,
+  /timeout/i,
+  /termin[oó]\s+con\s+(?:c[oó]digo|code|estado)\s*1/i,
+  /termin[oó]\s+con\s+estado\s+failed/i,
+];
+
+function providerFailure(text: string): boolean {
+  const trimmed = text.trim();
+  return !trimmed || PROVIDER_FAILURE.some((pattern) => pattern.test(trimmed));
+}
+
+function modeInstruction(mode: VMode): string {
+  return mode === "plan"
+    ? "MODO PLANEACIÓN. Entrega alcance, pasos, riesgos y criterios de aceptación. No escribas código, no crees ramas, no llames dispatch ni agentes y nunca afirmes que ejecutaste cambios."
+    : "MODO PLÁTICA. Conversa naturalmente, pregunta cuando falte contexto y ayuda a pensar. No crees ramas, no llames dispatch ni agentes y nunca afirmes que modificaste código.";
+}
+
+function buildMessages(args: {
+  mode: VMode;
+  projectId: string;
+  repository?: string | null;
+  message: string;
+  history: ChatTurn[];
+}) {
+  return [
+    {
+      role: "system" as const,
+      content: [
+        "Eres V dentro de VForge.",
+        modeInstruction(args.mode),
+        `Proyecto: ${args.projectId}.`,
+        `Repositorio de contexto: ${args.repository || "sin repositorio seleccionado"}.`,
+        "Responde en español claro y directo.",
+      ].join("\n"),
+    },
+    ...args.history.slice(-20).map((turn) => ({
+      role: turn.role,
+      content: turn.content,
+    })),
+    { role: "user" as const, content: args.message },
+  ];
+}
+
+async function callPrimary(args: {
+  mode: VMode;
+  projectId: string;
+  repository?: string | null;
+  message: string;
+  history: ChatTurn[];
+  preferredModel?: string;
+}): Promise<{ text: string; provider: string; model: string }> {
+  const engine = resolveLlmEngine();
+  if (!engine.client || engine.name === "none") {
+    throw new ProviderUnavailable("mesh", "No primary LLM engine configured");
+  }
+
+  const model = modelForEngine(
+    engine,
+    args.preferredModel?.trim() || engine.defaultChatModel,
+  );
+  try {
+    const completion = await engine.client.chat.completions.create({
+      model,
+      messages: buildMessages(args),
+      temperature: args.mode === "plan" ? 0.2 : 0.5,
+    });
+    const text = completion.choices[0]?.message?.content?.trim() || "";
+    if (providerFailure(text)) {
+      throw new ProviderUnavailable(engine.name, text || "empty response");
+    }
+    return { text, provider: engine.name, model: completion.model || model };
+  } catch (caught) {
+    if (caught instanceof ProviderUnavailable) throw caught;
+    const detail = caught instanceof Error ? caught.message : String(caught);
+    throw new ProviderUnavailable(engine.name, detail);
+  }
+}
+
+async function callOpenRouterFallback(args: {
+  mode: VMode;
+  projectId: string;
+  repository?: string | null;
+  message: string;
+  history: ChatTurn[];
+}): Promise<{ text: string; provider: string; model: string }> {
+  const key = process.env.OPENROUTER_API_KEY?.trim();
+  if (!key) throw new ProviderUnavailable("openrouter", "not configured");
+  const client = new OpenAI({
+    apiKey: key,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer": "https://vforge.site",
+      "X-Title": "vForge",
+    },
+  });
+  const model = process.env.MODEL_CHAT_MAIN?.trim() || "openai/gpt-oss-120b";
+  try {
+    const completion = await client.chat.completions.create({
+      model,
+      messages: buildMessages(args),
+      temperature: args.mode === "plan" ? 0.2 : 0.5,
+    });
+    const text = completion.choices[0]?.message?.content?.trim() || "";
+    if (providerFailure(text)) {
+      throw new ProviderUnavailable("openrouter", text || "empty response");
+    }
+    return { text, provider: "openrouter", model: completion.model || model };
+  } catch (caught) {
+    if (caught instanceof ProviderUnavailable) throw caught;
+    const detail = caught instanceof Error ? caught.message : String(caught);
+    throw new ProviderUnavailable("openrouter", detail);
+  }
+}
+
+export async function askV(args: {
+  mode: VMode;
+  projectId: string;
+  repository?: string | null;
+  message: string;
+  history?: ChatTurn[];
+  preferredModel?: string;
+}): Promise<AskVResult> {
+  const started = Date.now();
+  const history = args.history || [];
+  const failures: string[] = [];
+
+  try {
+    const primary = await callPrimary({ ...args, history });
+    return {
+      text: primary.text,
+      provider: primary.provider,
+      model: primary.model,
+      status: "ok",
+      durationMs: Date.now() - started,
+    };
+  } catch (caught) {
+    const error = caught instanceof ProviderUnavailable
+      ? caught
+      : new ProviderUnavailable("primary", String(caught));
+    failures.push(error.provider);
+  }
+
+  // OpenRouter is only used when our primary engine is unavailable.
+  try {
+    const fallback = await callOpenRouterFallback({ ...args, history });
+    return {
+      text: fallback.text,
+      provider: fallback.provider,
+      model: fallback.model,
+      status: "fallback",
+      durationMs: Date.now() - started,
+      systemNotice: `${failures[0] || "Proveedor principal"} no disponible; continuamos con ${fallback.provider}.`,
+    };
+  } catch (caught) {
+    const error = caught instanceof ProviderUnavailable
+      ? caught
+      : new ProviderUnavailable("openrouter", String(caught));
+    failures.push(error.provider);
+  }
+
+  // Claude CLI is last resort, never the only dependency.
+  try {
+    const prompt = `${modeInstruction(args.mode)}\n\nPROYECTO: ${args.projectId}\nREPOSITORIO: ${args.repository || "sin repositorio"}\n\nMENSAJE:\n${args.message}`;
+    const text = (await textBrain(prompt, history)).trim();
+    if (providerFailure(text)) {
+      throw new ProviderUnavailable("claude-hetzner", text || "empty response");
+    }
+    return {
+      text,
+      provider: "claude-hetzner",
+      model: "claude-cli",
+      status: "fallback",
+      durationMs: Date.now() - started,
+      systemNotice: `${failures.join(" y ")} no disponibles; continuamos con Claude.`,
+    };
+  } catch (caught) {
+    const error = caught instanceof ProviderUnavailable
+      ? caught
+      : new ProviderUnavailable("claude-hetzner", String(caught));
+    console.error("[V router] providers unavailable", {
+      projectId: args.projectId,
+      mode: args.mode,
+      providers: [...failures, error.provider],
+    });
+    throw new ProviderUnavailable("all", "No healthy provider available");
+  }
+}

--- a/lib/live/project-assistant.ts
+++ b/lib/live/project-assistant.ts
@@ -11,6 +11,10 @@ export interface ProjectAssistantMessage {
   created_by_email: string;
   content: string;
   created_at: string;
+  provider: string | null;
+  model: string | null;
+  status: string | null;
+  duration_ms: number | null;
 }
 
 export async function ensureProjectAssistantTable(): Promise<void> {
@@ -26,6 +30,10 @@ export async function ensureProjectAssistantTable(): Promise<void> {
       created_at timestamptz NOT NULL DEFAULT now()
     )`,
   );
+  await queryOne(`ALTER TABLE project_v_messages ADD COLUMN IF NOT EXISTS provider text`);
+  await queryOne(`ALTER TABLE project_v_messages ADD COLUMN IF NOT EXISTS model text`);
+  await queryOne(`ALTER TABLE project_v_messages ADD COLUMN IF NOT EXISTS status text`);
+  await queryOne(`ALTER TABLE project_v_messages ADD COLUMN IF NOT EXISTS duration_ms integer`);
   await queryOne(
     `CREATE INDEX IF NOT EXISTS idx_project_v_messages_thread
        ON project_v_messages (project_id, mode, created_at DESC)`,
@@ -37,9 +45,9 @@ export async function listProjectAssistantMessages(
 ): Promise<ProjectAssistantMessage[]> {
   await ensureProjectAssistantTable();
   return queryAll<ProjectAssistantMessage>(
-    `SELECT id::text, mode, role, created_by_email, content, created_at
+    `SELECT id::text, mode, role, created_by_email, content, created_at, provider, model, status, duration_ms
        FROM (
-         SELECT id, mode, role, created_by_email, content, created_at
+         SELECT id, mode, role, created_by_email, content, created_at, provider, model, status, duration_ms
            FROM project_v_messages
           WHERE project_id = $1
           ORDER BY created_at DESC, id DESC
@@ -77,14 +85,18 @@ export async function saveProjectAssistantTurn(args: {
   email: string;
   userText: string;
   assistantText: string;
+  provider: string;
+  model: string;
+  status: string;
+  durationMs: number;
 }): Promise<void> {
   await ensureProjectAssistantTable();
   await queryOne(
     `INSERT INTO project_v_messages
-      (project_id, mode, role, created_by_user_id, created_by_email, content)
+      (project_id, mode, role, created_by_user_id, created_by_email, content, provider, model, status, duration_ms)
      VALUES
-      ($1, $2, 'user', $3, $4, $5),
-      ($1, $2, 'assistant', $3, $4, $6)`,
+      ($1, $2, 'user', $3, $4, $5, NULL, NULL, NULL, NULL),
+      ($1, $2, 'assistant', $3, $4, $6, $7, $8, $9, $10)`,
     [
       args.projectId,
       args.mode,
@@ -92,6 +104,10 @@ export async function saveProjectAssistantTurn(args: {
       args.email,
       args.userText,
       args.assistantText,
+      args.provider,
+      args.model,
+      args.status,
+      args.durationMs,
     ],
   );
 }


### PR DESCRIPTION
Diagnóstico y corrección del circuito de V en salas de proyecto.

Cambios:
- `/app/live/[projectId]` deja de depender directamente de Claude CLI.
- Nuevo router central `askV()` reutiliza el motor configurado por `resolveLlmEngine()` (Cerebras/GPT OSS primero), con fallback controlado.
- Clasifica respuestas de cuota/rate limit/código 1/timeout/vacías como proveedor no disponible.
- Nunca persiste el error crudo del proveedor como mensaje de V.
- Persistencia añade metadata de provider/model/status/duration_ms de forma idempotente.
- UI muestra notice de fallback como estado del sistema; corrige burbujas cortas y doble borde del compose.
- Plática y Planeación siguen sin crear ramas ni llamar dispatch.

Validación local:
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅
- `npm run build` con Node 20.20.2 ✅

Diagnóstico adicional de Ejecución:
- Runs ruta618 1166/1167 fallaron antes de Codex.
- El daemon recibe prompt plano; `run_codex()` cae a defaults `repo=/root`, `gajo=X` y ejecuta `git -C /root worktree add`, que retorna 128.
- No se reejecutó ninguna tarea real.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live assistant LLM path, external API keys, and DB schema; mis-routing or fallback behavior would affect all project chat responses.
> 
> **Overview**
> **Project assistant chat** no longer calls Claude CLI (`textBrain`) directly. Requests go through new **`askV()`**, which tries the configured primary engine (`resolveLlmEngine()`), then **OpenRouter**, then **Claude CLI** as last resort.
> 
> Failed or junk replies (empty text, rate limits, timeouts, CLI exit codes) are treated as **`ProviderUnavailable`** so raw provider errors are not saved as V messages. Successful and fallback turns return **provider, model, status, duration**, and an optional **`systemNotice`**; the API maps total failure to **503** `provider_unavailable`.
> 
> **Persistence** adds idempotent columns on `project_v_messages` and stores routing metadata on assistant rows only. **VConversationPanel** shows fallback notices, clearer errors when no provider is up, and small layout fixes for message bubbles and the compose area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713299203be39f8bc4a9e29888a223069eb7834c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->