### PR TITLE
feat(live): V lee comentarios y URLs y arma el plan

### DIFF
--- a/components/live/VConversationPanel.tsx
+++ b/components/live/VConversationPanel.tsx
@@ -113,9 +113,8 @@ export function VConversationPanel({
     endRef.current?.scrollIntoView({ block: "end" });
   }, [visibleMessages.length, busy, mode]);
 
-  async function send(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const trimmed = message.trim();
+  async function sendMessage(raw: string) {
+    const trimmed = raw.trim();
     if (!trimmed || busy || !canWrite) return;
     setBusy(true);
     setError(null);
@@ -146,6 +145,17 @@ export function VConversationPanel({
     } finally {
       setBusy(false);
     }
+  }
+
+  async function send(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await sendMessage(message);
+  }
+
+  function planFromRoom() {
+    void sendMessage(
+      "Arma el plan de ejecución con las observaciones, puntos marcados y URLs de referencia de esta sala. Léelas. No me pidas que te las reescriba.",
+    );
   }
 
   return (
@@ -240,7 +250,7 @@ export function VConversationPanel({
               <p className="mt-2 text-[10px] leading-5 text-[var(--fg-muted)]">
                 {mode === "talk"
                   ? "Pregúntale, explícale el objetivo o revisen juntos qué sigue."
-                  : "Describe el resultado; V organizará alcance, pasos, riesgos y aceptación."}
+                  : "Usa «Armar plan con lo de la sala»: V lee comentarios y URLs."}
               </p>
             </div>
           </div>
@@ -277,15 +287,22 @@ export function VConversationPanel({
         </div>
       ) : null}
 
-      {mode === "plan" && latestPlan ? (
-        <div className="flex shrink-0 justify-end bg-white px-3 py-2">
-          <button
-            type="button"
-            onClick={() => onUseAsTask(latestPlan)}
-            className="btn-ghost"
-          >
-            Usar como tarea <IconArrowR size={11} />
-          </button>
+      {mode === "plan" ? (
+        <div className="flex shrink-0 flex-wrap justify-end gap-2 bg-white px-3 py-2">
+          {canWrite ? (
+            <button type="button" onClick={planFromRoom} className="btn-ghost" disabled={busy}>
+              Armar plan con lo de la sala
+            </button>
+          ) : null}
+          {latestPlan ? (
+            <button
+              type="button"
+              onClick={() => onUseAsTask(latestPlan)}
+              className="btn-ghost"
+            >
+              Usar como tarea <IconArrowR size={11} />
+            </button>
+          ) : null}
         </div>
       ) : null}
 

--- a/lib/forge/ask-v-policy.ts
+++ b/lib/forge/ask-v-policy.ts
@@ -46,6 +46,8 @@ export function modeSystemRules(mode: VConversationMode): string {
     return [
       "MODO PLANEACIÓN.",
       "Eres traductora de planeación. No ejecutas. Las IAs grandes sólo actúan en Ejecución.",
+      "Si hay observaciones, puntos marcados o URLs de referencia, entrega el plan ahora: alcance, pasos, riesgos y criterios de aceptación.",
+      "No pidas que te reescriban lo que ya está en la sala. No afirmes que no puedes leer las URLs si su contenido viene en el contexto.",
       "Entrega alcance, pasos, riesgos y criterios de aceptación.",
       "Parte de las observaciones, referencias y contenido de la sala; no pidas que te los reescriban.",
       "No escribas código, no crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios.",

--- a/lib/live/load-page-text.ts
+++ b/lib/live/load-page-text.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import { normalizeReferenceUrl } from "@/lib/live/project-references";
+import { extractReadableText } from "@/lib/live/read-page";
+
+export interface ReadPageResult {
+  url: string;
+  title: string;
+  text: string;
+}
+
+const MAX_PAGES = 5;
+const MAX_BYTES = 80_000;
+const TIMEOUT_MS = 4_000;
+
+async function readOne(url: string): Promise<ReadPageResult | null> {
+  const safe = normalizeReferenceUrl(url);
+  if (!safe) return null;
+  try {
+    const response = await fetch(safe, {
+      method: "GET",
+      redirect: "follow",
+      cache: "no-store",
+      credentials: "omit",
+      headers: {
+        Accept: "text/html, text/plain;q=0.9",
+        "User-Agent": "VForgeRoomReader/1.0",
+      },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const type = (response.headers.get("content-type") || "").toLowerCase();
+    if (
+      !type.includes("text/html") &&
+      !type.includes("text/plain") &&
+      !type.includes("application/xhtml")
+    ) {
+      return null;
+    }
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    const slice = buffer.byteLength > MAX_BYTES ? buffer.slice(0, MAX_BYTES) : buffer;
+    const html = new TextDecoder("utf-8", { fatal: false }).decode(slice);
+    const extracted = extractReadableText(html);
+    if (!extracted.text) return null;
+    return { url: safe, title: extracted.title, text: extracted.text.slice(0, 1800) };
+  } catch {
+    return null;
+  }
+}
+
+export async function readPublicPages(urls: string[]): Promise<ReadPageResult[]> {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const url of urls) {
+    const safe = normalizeReferenceUrl(url);
+    if (!safe || seen.has(safe)) continue;
+    seen.add(safe);
+    unique.push(safe);
+    if (unique.length >= MAX_PAGES) break;
+  }
+  const pages = await Promise.all(unique.map(readOne));
+  return pages.filter((page): page is ReadPageResult => Boolean(page));
+}

--- a/lib/live/load-room-context.ts
+++ b/lib/live/load-room-context.ts
@@ -12,6 +12,8 @@ import {
   type RoomProjectInfo,
   type RoomReference,
 } from "@/lib/live/room-context";
+import { parseReviewAnchor } from "@/lib/live/review-context";
+import { readPublicPages } from "@/lib/live/load-page-text";
 import { listProjectDecisionLog } from "@/lib/live/load-project-memory";
 import { ensureProjectReferencesTable } from "@/lib/live/project-references";
 
@@ -80,6 +82,21 @@ export async function loadRoomContextBrief(
         }))
     : [];
 
+  const pageUrls = [
+    ...references.map((item) => item.url),
+    ...comments.flatMap((comment) => {
+      const anchor = parseReviewAnchor(comment.anchor);
+      return anchor?.url ? [anchor.url] : [];
+    }),
+  ];
+  const pages = await readPublicPages(pageUrls).catch(() => []);
+  console.info("[room-context]", {
+    projectId,
+    comments: comments.length,
+    references: references.length,
+    pages: pages.length,
+  });
+
   return formatRoomContext({
     projectId,
     project,
@@ -89,5 +106,6 @@ export async function loadRoomContextBrief(
     assets,
     repositories,
     decisions,
+    pages,
   });
 }

--- a/lib/live/read-page.ts
+++ b/lib/live/read-page.ts
@@ -1,0 +1,37 @@
+const SCRIPT_STYLE = /<(script|style|noscript|svg)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const TAGS = /<[^>]+>/g;
+const WHITESPACE = /\s+/g;
+
+export function extractReadableText(html: string): { title: string; text: string } {
+  const raw = html.replace(/\0/g, "");
+  const titleMatch = raw.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = decodeEntities((titleMatch?.[1] || "").replace(TAGS, ""))
+    .replace(WHITESPACE, " ")
+    .trim()
+    .slice(0, 160);
+  const text = decodeEntities(
+    raw
+      .replace(SCRIPT_STYLE, " ")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/(p|div|h1|h2|h3|li|tr|section|article)>/gi, "\n")
+      .replace(TAGS, " ")
+      .replace(WHITESPACE, " "),
+  )
+    .trim()
+    .slice(0, 8000);
+  return { title, text };
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&/gi, "&")
+    .replace(/</gi, "<")
+    .replace(/>/gi, ">")
+    .replace(/"/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (_, n: string) => {
+      const code = Number(n);
+      return code > 31 && code < 65535 ? String.fromCharCode(code) : " ";
+    });
+}

--- a/lib/live/room-context.ts
+++ b/lib/live/room-context.ts
@@ -25,6 +25,12 @@ export interface RoomProjectInfo {
   status?: string | null;
 }
 
+export interface RoomPage {
+  url: string;
+  title?: string | null;
+  text: string;
+}
+
 export interface RoomRepository {
   repo_full_name: string;
   role?: string | null;
@@ -40,6 +46,7 @@ export interface RoomContextInput {
   assets?: Array<{ filename: string }>;
   repositories?: RoomRepository[];
   decisions?: string | null;
+  pages?: RoomPage[];
 }
 
 export function isSystemComment(comment: RoomComment): boolean {
@@ -145,6 +152,17 @@ export function formatRoomContext(input: RoomContextInput): string {
     }
   }
 
+  const pages = (input.pages ?? []).filter((page) => page.text?.trim()).slice(0, 5);
+  if (pages.length) {
+    lines.push("");
+    lines.push(`CONTENIDO LEÍDO DE LAS URLS (${pages.length}):`);
+    for (const page of pages) {
+      const title = page.title?.trim() ? ` — ${page.title.trim()}` : "";
+      lines.push(`### ${page.url}${title}`);
+      lines.push(clip(page.text, 1600));
+    }
+  }
+
   const document = input.document?.trim();
   lines.push("");
   if (document) {
@@ -164,6 +182,6 @@ export function formatRoomContext(input: RoomContextInput): string {
   }
 
   let text = lines.join("\n");
-  if (text.length > 9000) text = `${text.slice(0, 8999)}…`;
+  if (text.length > 14000) text = `${text.slice(0, 13999)}…`;
   return text;
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/read-page.test.ts
+++ b/tests/read-page.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractReadableText } from "../lib/live/read-page";
+import { formatRoomContext } from "../lib/live/room-context";
+import { modeSystemRules } from "../lib/forge/ask-v-policy";
+
+test("html pages become readable text without scripts", () => {
+  const extracted = extractReadableText(`
+    <html><head><title>APSUS Onboarding</title>
+    <script>alert(1)</script></head>
+    <body><h1>Contraste</h1><p>El CTA no se lee.</p></body></html>
+  `);
+  assert.equal(extracted.title, "APSUS Onboarding");
+  assert.match(extracted.text, /Contraste/);
+  assert.match(extracted.text, /El CTA no se lee/);
+  assert.doesNotMatch(extracted.text, /alert/);
+});
+
+test("room brief includes fetched page content", () => {
+  const brief = formatRoomContext({
+    projectId: "apsus",
+    references: [
+      { label: "Onboarding", url: "https://apsus.site/onboarding", kind: "page" },
+    ],
+    pages: [
+      {
+        url: "https://apsus.site/onboarding",
+        title: "Onboarding",
+        text: "Paso 1: valida INE. Paso 2: deposita.",
+      },
+    ],
+  });
+  assert.match(brief, /CONTENIDO LEÍDO DE LAS URLS/);
+  assert.match(brief, /valida INE/);
+});
+
+test("plan mode must write the plan from room content", () => {
+  assert.match(modeSystemRules("plan"), /entrega el plan ahora/);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -26,6 +26,7 @@
     "lib/live/room-context.ts",
     "lib/live/project-memory.ts",
     "lib/forge/cerebras-usage.ts",
-    "lib/projects/repository-groups.ts"
+    "lib/projects/repository-groups.ts",
+    "lib/live/read-page.ts"
   ]
 }


### PR DESCRIPTION
V ya no sólo ve el link. Descarga el HTML público de referencias y anclas, extrae el texto y lo mete al brief de Planeación.

En Planeación aparece «Armar plan con lo de la sala».

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds server-side HTTP fetches driven by user-supplied URLs (with `normalizeReferenceUrl` blocking private/localhost targets); increases prompt size and assistant context surface.
> 
> **Overview**
> **Planeación** can now use room content end-to-end: the server fetches public HTML from project reference URLs and review-anchor URLs (up to 5 pages, timeouts/size caps), strips scripts, and injects **CONTENIDO LEÍDO DE LAS URLS** into the V room brief. The context budget grows (~9k → ~14k chars).
> 
> In **VConversationPanel**, send logic is refactored to `sendMessage` so **«Armar plan con lo de la sala»** posts a fixed prompt that asks V to build scope/steps/risks/acceptance from observations, marked points, and references without re-pasting. Plan mode copy and footer actions are updated (plan button always visible when writable; **Usar como tarea** only when there is a latest plan). **ask-v-policy** plan-mode rules now tell V to deliver the plan immediately when that content is in context and not claim it cannot read URLs.
> 
> Tests cover HTML extraction, brief formatting, and plan-mode rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1bf36d6e36188dafcfc26c5faf4bbb0f4a5b19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->