### PR TITLE
fix(live): dock expandible y ZIP de WhatsApp

### DIFF
--- a/app/api/live/[projectId]/assets/route.ts
+++ b/app/api/live/[projectId]/assets/route.ts
@@ -43,7 +43,23 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ pro
       signal: req.signal,
     });
     return mirrorJsonResponse(upstream);
-  } catch {
-    return NextResponse.json({ error: "archive_processing_failed" }, { status: 422 });
+  } catch (caught) {
+    const message = caught instanceof Error ? caught.message : "";
+    if (message === "archive_entry_limit") {
+      return NextResponse.json(
+        {
+          error: "archive_too_large",
+          notice: "El ZIP tiene demasiados archivos. Exporta el chat de WhatsApp sin incluir la galería.",
+        },
+        { status: 422 },
+      );
+    }
+    return NextResponse.json(
+      {
+        error: "archive_processing_failed",
+        notice: "No se pudo leer el ZIP. Vuelve a exportar el chat desde WhatsApp.",
+      },
+      { status: 422 },
+    );
   }
 }

--- a/app/api/live/[projectId]/assets/token/route.ts
+++ b/app/api/live/[projectId]/assets/token/route.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { generateClientTokenFromReadWriteToken } from "@vercel/blob/client";
 import { NextResponse } from "next/server";
 import { loadVForgeLiveProject } from "@/lib/api/vforge-owned";
-import { isAcceptedZip, safeArchiveName } from "@/lib/live/review-context";
+import { ACCEPTED_ZIP_CONTENT_TYPES, isAcceptedZip, safeArchiveName } from "@/lib/live/review-context";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -27,7 +27,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ project
   const clientToken = await generateClientTokenFromReadWriteToken({
     token: storeToken,
     pathname,
-    allowedContentTypes: [contentType],
+    allowedContentTypes: [...ACCEPTED_ZIP_CONTENT_TYPES],
     maximumSizeInBytes: 50 * 1024 * 1024,
     validUntil: Date.now() + 10 * 60 * 1000,
     addRandomSuffix: false,

--- a/components/live/CommentsPanel.tsx
+++ b/components/live/CommentsPanel.tsx
@@ -315,7 +315,7 @@ export function CommentsPanel({
               void send();
             }
           }}
-          rows={3}
+          rows={workspace ? 2 : 3}
           maxLength={4000}
           placeholder="Deja una observación…"
           className="w-full resize-y rounded-md border border-[var(--border-1)] bg-white px-3 py-2.5 text-[12px] text-black placeholder:text-[var(--fg-muted)] focus:border-black"

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -145,21 +145,23 @@ const PANEL_LABELS: Record<WorkspacePanelId, string> = {
 };
 
 
+const FEEDBACK_PANELS = ["activity", "comments", "context"] as const;
+
 const DOCK_LAYOUTS: Record<WorkspacePreset, { root: DockLayout; previews: DockLayout; feedback: DockLayout }> = {
   balanced: {
-    root: { previews: 68, feedback: 32 },
+    root: { previews: 62, feedback: 38 },
     previews: { desktop: 52, mobile: 20, admin: 28 },
-    feedback: { activity: 24, comments: 42, context: 34 },
+    feedback: { activity: 18, comments: 44, context: 38 },
   },
   previews: {
-    root: { previews: 78, feedback: 22 },
+    root: { previews: 76, feedback: 24 },
     previews: { desktop: 60, mobile: 18, admin: 22 },
-    feedback: { activity: 28, comments: 40, context: 32 },
+    feedback: { activity: 18, comments: 44, context: 38 },
   },
   review: {
-    root: { previews: 58, feedback: 42 },
+    root: { previews: 48, feedback: 52 },
     previews: { desktop: 58, mobile: 22, admin: 20 },
-    feedback: { activity: 20, comments: 48, context: 32 },
+    feedback: { activity: 16, comments: 50, context: 34 },
   },
 };
 
@@ -446,6 +448,32 @@ function LiveWorkspace({
 
   function togglePanel(panel: WorkspacePanelId, handle: PanelImperativeHandle | null) {
     setFocusedPanel(null);
+    const feedbackHandles: Record<"activity" | "comments" | "context", PanelImperativeHandle | null> = {
+      activity: activityRef.current,
+      comments: commentsRef.current,
+      context: contextRef.current,
+    };
+    if (panel === "activity" || panel === "comments" || panel === "context") {
+      const othersOpen = FEEDBACK_PANELS.filter((id) => id !== panel && !collapsed[id]);
+      if (handle?.isCollapsed()) {
+        handle.expand();
+        for (const id of FEEDBACK_PANELS) {
+          if (id !== panel) feedbackHandles[id]?.collapse();
+        }
+        return;
+      }
+      if (othersOpen.length > 0) {
+        for (const id of FEEDBACK_PANELS) {
+          if (id !== panel) feedbackHandles[id]?.collapse();
+        }
+        handle?.expand();
+        return;
+      }
+      activityRef.current?.expand();
+      commentsRef.current?.expand();
+      contextRef.current?.expand();
+      return;
+    }
     if (handle?.isCollapsed()) handle.expand();
     else handle?.collapse();
   }
@@ -527,7 +555,7 @@ function LiveWorkspace({
           })}
         </div>
         <p className="ml-auto hidden shrink-0 px-2 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)] lg:block">
-          Arrastra cualquier divisor · doble clic restaura
+          Clic en un módulo para expandirlo · doble clic restaura
         </p>
       </div>
 
@@ -572,7 +600,7 @@ function LiveWorkspace({
               </Group>
             </Panel>
             <DockSeparator horizontal={false} />
-            <Panel id="feedback" minSize={150}>
+            <Panel id="feedback" minSize={220}>
               <Group
                 id={`feedback-${project.id}`}
                 orientation={isMobile ? "vertical" : "horizontal"}

--- a/components/live/ProjectContextPanel.tsx
+++ b/components/live/ProjectContextPanel.tsx
@@ -102,6 +102,7 @@ export function ProjectContextPanel({
   const [progress, setProgress] = useState<number | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -154,10 +155,10 @@ export function ProjectContextPanel({
   async function uploadArchive(file: File) {
     if (!data?.me.canWrite || busy) return;
     if (!file.name.toLowerCase().endsWith(".zip") || file.size < 1 || file.size > 50 * 1024 * 1024) {
-      setError("Selecciona un ZIP de hasta 50 MB.");
+      setError("Selecciona un ZIP de WhatsApp de hasta 50 MB.");
       return;
     }
-    const contentType = file.type || "application/zip";
+    const contentType = "application/zip";
     setBusy(true);
     setProgress(0);
     setNotice(null);
@@ -169,16 +170,20 @@ export function ProjectContextPanel({
         body: JSON.stringify({ filename: file.name, contentType, size: file.size }),
       });
       const tokenPayload = (await tokenResponse.json().catch(() => null)) as
-        | { pathname?: string; clientToken?: string }
+        | { pathname?: string; clientToken?: string; error?: string }
         | null;
-      if (!tokenResponse.ok || !tokenPayload?.pathname || !tokenPayload.clientToken) {
-        throw new Error("token");
+      if (!tokenResponse.ok || !tokenPayload?.pathname || !tokenPayload?.clientToken) {
+        throw new Error(
+          tokenPayload?.error === "storage_unavailable"
+            ? "El almacén de archivos no está disponible."
+            : "Ese archivo no se aceptó como ZIP.",
+        );
       }
       const blob = await put(tokenPayload.pathname, file, {
         access: "private",
         token: tokenPayload.clientToken,
         contentType,
-        multipart: true,
+        multipart: file.size > 4 * 1024 * 1024,
         onUploadProgress: ({ percentage }) => setProgress(Math.round(percentage)),
       });
       const finalize = await fetch(`/api/live/${encodedProjectId}/assets`, {
@@ -191,16 +196,26 @@ export function ProjectContextPanel({
           size: file.size,
         }),
       });
-      if (!finalize.ok) throw new Error("finalize");
-      setNotice("Conversación cargada y disponible para las IA");
+      const done = (await finalize.json().catch(() => null)) as
+        | { notice?: string; error?: string }
+        | null;
+      if (!finalize.ok) {
+        throw new Error(done?.notice || "No se pudo procesar el ZIP.");
+      }
+      setNotice("Conversación cargada. V ya puede leer el texto del chat.");
       if (inputRef.current) inputRef.current.value = "";
       await load();
-    } catch {
-      setError("No se pudo cargar o procesar el ZIP.");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "No se pudo cargar o procesar el ZIP.");
     } finally {
       setBusy(false);
       setProgress(null);
     }
+  }
+
+  function takeZip(files: FileList | File[] | null) {
+    const file = files && files[0] ? files[0] : null;
+    if (file) void uploadArchive(file);
   }
 
   return (
@@ -313,14 +328,36 @@ export function ProjectContextPanel({
           </div>
         ) : (
           <div>
-            <p className="text-[10px] leading-4 text-[var(--fg-muted)]">Sube la conversación completa de venta. VForge extrae texto seguro para las IA y conserva el ZIP privado para descarga.</p>
+            <p className="text-[10px] leading-4 text-[var(--fg-muted)]">
+              Exporta el chat de WhatsApp (sin incluir toda la galería si pesa más de 50 MB). VForge lee el texto y guarda el ZIP.
+            </p>
             {data.me.canWrite ? (
-              <button type="button" onClick={() => inputRef.current?.click()} disabled={busy} className="btn-primary mt-3 w-full disabled:opacity-40">
-                {busy ? <IconLoader size={12} className="animate-spin" /> : <IconUpload size={12} />}
-                {progress == null ? "Subir ZIP" : `Subiendo ${progress}%`}
-              </button>
+              <div
+                onDragOver={(event) => {
+                  event.preventDefault();
+                  setDragging(true);
+                }}
+                onDragLeave={() => setDragging(false)}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  setDragging(false);
+                  takeZip(event.dataTransfer.files);
+                }}
+                className={cn(
+                  "mt-3 rounded-md border border-dashed p-3",
+                  dragging ? "border-black bg-[#f7f7f5]" : "border-[var(--border-1)]",
+                )}
+              >
+                <button type="button" onClick={() => inputRef.current?.click()} disabled={busy} className="btn-primary w-full disabled:opacity-40">
+                  {busy ? <IconLoader size={12} className="animate-spin" /> : <IconUpload size={12} />}
+                  {progress == null ? "Subir ZIP de WhatsApp" : `Subiendo ${progress}%`}
+                </button>
+                <p className="mt-2 text-center font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">
+                  o suéltalo aquí
+                </p>
+              </div>
             ) : null}
-            <input ref={inputRef} type="file" accept=".zip,application/zip,application/x-zip-compressed" className="hidden" onChange={(event) => { const file = event.target.files?.[0]; if (file) void uploadArchive(file); }} />
+            <input ref={inputRef} type="file" accept=".zip,application/zip,application/x-zip-compressed" className="hidden" onChange={(event) => { takeZip(event.target.files); }} />
             <div className="mt-3 space-y-2">
               {data.assets.length ? data.assets.map((asset) => (
                 <div key={asset.id} className="flex items-center gap-2 rounded-md border border-[var(--border-1)] p-2.5">

--- a/lib/live/archive-text.ts
+++ b/lib/live/archive-text.ts
@@ -1,41 +1,55 @@
 import { unzipSync, type UnzipFileInfo } from "fflate";
 
 const MAX_EXTRACTED_BYTES = 2 * 1024 * 1024;
-const MAX_ARCHIVE_ENTRIES = 200;
+const MAX_TEXT_FILES = 80;
+const MAX_SCAN_ENTRIES = 50_000;
 const TEXT_EXTENSIONS = new Set(["txt", "md", "json", "csv", "html", "htm"]);
 
 function isTextEntry(info: UnzipFileInfo): boolean {
   const name = info.name.toLowerCase();
-  const extension = name.includes(".") ? name.split(".").pop() ?? "" : "";
-  return !name.endsWith("/") && TEXT_EXTENSIONS.has(extension);
+  const base = name.split("/").pop() ?? name;
+  if (name.endsWith("/") || info.originalSize < 0) return false;
+  if (base === "_chat.txt" || base.startsWith("whatsapp chat") || base.includes("chat de whatsapp")) {
+    return true;
+  }
+  const extension = base.includes(".") ? base.split(".").pop() ?? "" : "";
+  return TEXT_EXTENSIONS.has(extension);
+}
+
+function decodeText(data: Uint8Array): string {
+  if (data.length >= 2 && data[0] === 0xff && data[1] === 0xfe) {
+    return new TextDecoder("utf-16le").decode(data);
+  }
+  if (data.length >= 2 && data[0] === 0xfe && data[1] === 0xff) {
+    return new TextDecoder("utf-16be").decode(data);
+  }
+  const start = data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf ? 3 : 0;
+  return new TextDecoder("utf-8", { fatal: false }).decode(data.slice(start));
 }
 
 export function extractArchiveText(input: Uint8Array): string {
   let declaredBytes = 0;
-  let entryCount = 0;
-  let tooManyEntries = false;
+  let scanned = 0;
+  let textFiles = 0;
   const files = unzipSync(input, {
     filter(info) {
-      entryCount += 1;
-      if (entryCount > MAX_ARCHIVE_ENTRIES) {
-        tooManyEntries = true;
-        return false;
-      }
-      if (!isTextEntry(info) || info.originalSize < 0) return false;
+      scanned += 1;
+      if (scanned > MAX_SCAN_ENTRIES) return false;
+      if (!isTextEntry(info)) return false;
+      if (textFiles >= MAX_TEXT_FILES) return false;
       if (declaredBytes + info.originalSize > MAX_EXTRACTED_BYTES) return false;
+      textFiles += 1;
       declaredBytes += info.originalSize;
       return true;
     },
   });
-  if (tooManyEntries) throw new Error("archive_entry_limit");
 
-  const decoder = new TextDecoder("utf-8", { fatal: false });
-  const sections = Object.entries(files)
+  const decoderSections = Object.entries(files)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, data]) => `\n--- ${name.replace(/[\r\n]/g, " ")} ---\n${decoder.decode(data).replace(/\0/g, "")}`);
-  const joined = sections.join("\n").trim();
+    .map(([name, data]) => `\n--- ${name.replace(/[\r\n]/g, " ")} ---\n${decodeText(data).replace(/\0/g, "")}`);
+  const joined = decoderSections.join("\n").trim();
   if (!joined) return "";
   const encoded = new TextEncoder().encode(joined);
   if (encoded.byteLength <= MAX_EXTRACTED_BYTES) return joined;
-  return decoder.decode(encoded.slice(0, MAX_EXTRACTED_BYTES)).trim();
+  return new TextDecoder("utf-8", { fatal: false }).decode(encoded.slice(0, MAX_EXTRACTED_BYTES)).trim();
 }

--- a/lib/live/review-context.ts
+++ b/lib/live/review-context.ts
@@ -26,11 +26,15 @@ export interface AnchoredComment {
 }
 
 const VIEWPORTS = new Set<ReviewViewport>(["desktop", "mobile", "admin"]);
-const ZIP_TYPES = new Set([
+export const ACCEPTED_ZIP_CONTENT_TYPES = [
   "application/zip",
+  "application/x-zip",
   "application/x-zip-compressed",
   "application/octet-stream",
-]);
+  "multipart/x-zip",
+] as const;
+
+const ZIP_TYPES = new Set<string>(ACCEPTED_ZIP_CONTENT_TYPES);
 
 function cleanUrl(value: unknown): string | null {
   if (typeof value !== "string" || value.length > 2048) return null;
@@ -185,9 +189,10 @@ export function anchorViewportPosition(
 }
 
 export function isAcceptedZip(filename: string, contentType: string, size: number): boolean {
+  const type = contentType.trim().toLowerCase();
   return (
     filename.trim().toLowerCase().endsWith(".zip") &&
-    ZIP_TYPES.has(contentType.trim().toLowerCase()) &&
+    (!type || ZIP_TYPES.has(type)) &&
     Number.isInteger(size) &&
     size > 0 &&
     size <= 50 * 1024 * 1024

--- a/tests/archive-text.test.ts
+++ b/tests/archive-text.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { strToU8, zipSync } from "fflate";
 import { extractArchiveText } from "../lib/live/archive-text";
+import { isAcceptedZip } from "../lib/live/review-context";
 
 test("extractArchiveText reads textual WhatsApp exports and ignores media", () => {
   const archive = zipSync({
@@ -15,13 +16,22 @@ test("extractArchiveText reads textual WhatsApp exports and ignores media", () =
   assert.doesNotMatch(text, /IMG-001/);
 });
 
+test("extractArchiveText keeps the chat when the ZIP is full of photos", () => {
+  const entries: Record<string, Uint8Array> = {
+    "_chat.txt": strToU8("[10:00] Cliente: Quiero el paquete NET+"),
+  };
+  for (let index = 0; index < 250; index += 1) {
+    entries[`IMG-${index}.jpg`] = new Uint8Array([1, 2, 3, 4]);
+  }
+  const text = extractArchiveText(zipSync(entries));
+  assert.match(text, /paquete NET\+/);
+});
+
 test("extractArchiveText returns empty when the ZIP has no readable text", () => {
   assert.equal(extractArchiveText(zipSync({ "foto.jpg": new Uint8Array([1, 2]) })), "");
 });
 
-test("extractArchiveText rejects archives with excessive entries", () => {
-  const entries = Object.fromEntries(
-    Array.from({ length: 201 }, (_, index) => [`archivo-${index}.txt`, strToU8("x")]),
-  );
-  assert.throws(() => extractArchiveText(zipSync(entries)), /archive_entry_limit/);
+test("empty content-type still accepts a .zip name", () => {
+  assert.equal(isAcceptedZip("Chat de WhatsApp.zip", "", 2048), true);
+  assert.equal(isAcceptedZip("chat.zip", "application/x-zip", 2048), true);
 });

--- a/tests/review-context.test.ts
+++ b/tests/review-context.test.ts
@@ -79,6 +79,7 @@ test("scroll-aware anchors keep their document position", () => {
 
 test("ZIP validation rejects renamed or oversized files", () => {
   assert.equal(isAcceptedZip("chat.zip", "application/zip", 2048), true);
+  assert.equal(isAcceptedZip("chat.zip", "", 2048), true);
   assert.equal(isAcceptedZip("chat.pdf", "application/zip", 2048), false);
   assert.equal(isAcceptedZip("chat.zip", "application/zip", 51 * 1024 * 1024), false);
   assert.equal(safeArchiveName("Conversación cliente #1.zip"), "Conversaci_n_cliente_1.zip");


### PR DESCRIPTION
Actividad, Comentarios y Contexto se expanden a toda la fila. El ZIP de WhatsApp con fotos ya no se rechaza a las 200 entradas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cambios en extracción de ZIP (límites y escaneo de hasta 50k entradas) y en rutas de upload/assets; impacto acotado por tamaño máximo de ZIP y bytes extraídos, sin cambios en auth.
> 
> **Overview**
> Mejora la sala Live para **WhatsApp** y el **dock de feedback**.
> 
> **ZIP de conversación:** Los exports con muchas fotos ya no fallan por un límite global de entradas. `extractArchiveText` escanea hasta 50k entradas pero solo extrae texto de archivos relevantes (incl. `_chat.txt` y nombres típicos de WhatsApp), con decodificación UTF-16/UTF-8. La validación acepta más `content-types` y `.zip` sin tipo MIME; el token de Blob permite todos los tipos aceptados. La API de assets y el panel de contexto devuelven **avisos en español** en errores 422; el upload usa drag-and-drop, multipart solo si el archivo supera 4 MB y mensajes de error más claros.
> 
> **Dock:** Actividad, Comentarios y Contexto comparten una fila: al hacer clic en un módulo se expande y se colapsan los otros; si los tres están abiertos, otro clic los restaura. Se ajustan proporciones de presets, `minSize` del panel feedback (220) y el hint del toolbar. Comentarios usa 2 filas en workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a8ad93af8710bc3d2ba0c2d1ba2c73f5650993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->