### PR TITLE
fix(live): el ZIP de WhatsApp ya no se queda en 0%

### DIFF
--- a/app/api/live/[projectId]/assets/[assetId]/download/route.ts
+++ b/app/api/live/[projectId]/assets/[assetId]/download/route.ts
@@ -5,6 +5,7 @@ import {
   getCurrentVForgeIdentity,
   projectAssetApiPath,
 } from "@/lib/api/vforge-owned";
+import { queryOne } from "@/lib/db/client";
 import { isSafeProjectBlobPath, safeArchiveName } from "@/lib/live/review-context";
 
 export const runtime = "nodejs";
@@ -19,6 +20,25 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ proj
     if (!upstream.ok) return NextResponse.json({ error: "not_found" }, { status: upstream.status });
     const payload = (await upstream.json()) as { asset?: { filename?: string; blob_pathname?: string } };
     const pathname = payload.asset?.blob_pathname;
+    const filename = safeArchiveName(payload.asset?.filename || "conversacion.zip");
+    if (pathname?.includes("/inline-")) {
+      const row = await queryOne<{ extracted_text: string }>(
+        `SELECT extracted_text
+           FROM project_context_assets
+          WHERE id = $1 AND project_id = $2
+          LIMIT 1`,
+        [assetId, projectId],
+      );
+      if (!row?.extracted_text) return NextResponse.json({ error: "not_found" }, { status: 404 });
+      return new Response(row.extracted_text, {
+        headers: {
+          "Cache-Control": "private, no-store",
+          "Content-Type": "text/plain; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename.replace(/\.zip$/i, ".txt")}"`,
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    }
     if (!pathname || !isSafeProjectBlobPath(projectId, pathname)) {
       return NextResponse.json({ error: "not_found" }, { status: 404 });
     }
@@ -30,7 +50,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ proj
       headers: {
         "Cache-Control": "private, no-store",
         "Content-Type": "application/zip",
-        "Content-Disposition": `attachment; filename="${safeArchiveName(payload.asset?.filename || "conversacion.zip")}"`,
+        "Content-Disposition": `attachment; filename="${filename}"`,
         "X-Content-Type-Options": "nosniff",
       },
     });

--- a/app/api/live/[projectId]/assets/route.ts
+++ b/app/api/live/[projectId]/assets/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { get, head } from "@vercel/blob";
 import { NextRequest, NextResponse } from "next/server";
 import {
@@ -12,6 +13,8 @@ import { isAcceptedZip, isSafeProjectBlobPath, safeArchiveName } from "@/lib/liv
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const MAX_EXTRACTED_CHARS = 2_097_152;
+
 export async function POST(req: NextRequest, { params }: { params: Promise<{ projectId: string }> }) {
   const { projectId } = await params;
   const identity = await getCurrentVForgeIdentity();
@@ -19,8 +22,31 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ pro
   const payload = (await req.json().catch(() => null)) as Record<string, unknown> | null;
   const filename = typeof payload?.filename === "string" ? safeArchiveName(payload.filename) : "";
   const blobPathname = typeof payload?.blobPathname === "string" ? payload.blobPathname.trim() : "";
-  const contentType = typeof payload?.contentType === "string" ? payload.contentType.trim().toLowerCase() : "";
+  const contentType = typeof payload?.contentType === "string" ? payload.contentType.trim().toLowerCase() : "application/zip";
   const size = Number(payload?.size);
+  const extractedFromClient =
+    typeof payload?.extractedText === "string" ? payload.extractedText.replace(/\0/g, "") : "";
+
+  if (extractedFromClient.trim()) {
+    if (!isAcceptedZip(filename, contentType, size) || extractedFromClient.length > MAX_EXTRACTED_CHARS) {
+      return NextResponse.json({ error: "invalid_asset" }, { status: 400 });
+    }
+    const inlinePath = `context/${projectId}/inline-${randomUUID()}-${filename}`;
+    const upstream = await fetchVForgeApi(projectApiPath(projectId, "assets"), identity, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        filename,
+        blobPathname: inlinePath,
+        contentType: "application/zip",
+        size,
+        extractedText: extractedFromClient.slice(0, MAX_EXTRACTED_CHARS),
+      }),
+      signal: req.signal,
+    });
+    return mirrorJsonResponse(upstream);
+  }
+
   if (!isSafeProjectBlobPath(projectId, blobPathname) || !isAcceptedZip(filename, contentType, size)) {
     return NextResponse.json({ error: "invalid_asset" }, { status: 400 });
   }

--- a/components/live/ProjectContextPanel.tsx
+++ b/components/live/ProjectContextPanel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { put } from "@vercel/blob/client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
+import { extractArchiveText } from "@/lib/live/archive-text";
 import {
   IconCheck,
   IconCode,
@@ -158,41 +158,30 @@ export function ProjectContextPanel({
       setError("Selecciona un ZIP de WhatsApp de hasta 50 MB.");
       return;
     }
-    const contentType = "application/zip";
     setBusy(true);
-    setProgress(0);
-    setNotice(null);
+    setProgress(1);
+    setNotice("Leyendo el ZIP en tu dispositivo…");
     setError(null);
     try {
-      const tokenResponse = await fetch(`/api/live/${encodedProjectId}/assets/token`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ filename: file.name, contentType, size: file.size }),
+      const bytes = await readFileBytes(file, (loaded) => {
+        setProgress(Math.max(1, Math.round((loaded / file.size) * 55)));
       });
-      const tokenPayload = (await tokenResponse.json().catch(() => null)) as
-        | { pathname?: string; clientToken?: string; error?: string }
-        | null;
-      if (!tokenResponse.ok || !tokenPayload?.pathname || !tokenPayload?.clientToken) {
-        throw new Error(
-          tokenPayload?.error === "storage_unavailable"
-            ? "El almacén de archivos no está disponible."
-            : "Ese archivo no se aceptó como ZIP.",
-        );
+      setProgress(60);
+      setNotice("Extrayendo el texto del chat…");
+      const extractedText = extractArchiveText(bytes);
+      if (!extractedText.trim()) {
+        throw new Error("No encontré _chat.txt. Exporta el chat de WhatsApp; las fotos se ignoran.");
       }
-      const blob = await put(tokenPayload.pathname, file, {
-        access: "private",
-        token: tokenPayload.clientToken,
-        contentType,
-        multipart: file.size > 4 * 1024 * 1024,
-        onUploadProgress: ({ percentage }) => setProgress(Math.round(percentage)),
-      });
+      const text = extractedText.slice(0, 1_800_000);
+      setProgress(78);
+      setNotice("Guardando la conversación…");
       const finalize = await fetch(`/api/live/${encodedProjectId}/assets`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           filename: file.name,
-          blobPathname: blob.pathname,
-          contentType,
+          extractedText: text,
+          contentType: "application/zip",
           size: file.size,
         }),
       });
@@ -200,13 +189,14 @@ export function ProjectContextPanel({
         | { notice?: string; error?: string }
         | null;
       if (!finalize.ok) {
-        throw new Error(done?.notice || "No se pudo procesar el ZIP.");
+        throw new Error(done?.notice || "No se pudo guardar la conversación.");
       }
-      setNotice("Conversación cargada. V ya puede leer el texto del chat.");
+      setProgress(100);
+      setNotice("Conversación cargada. V ya puede leer el chat.");
       if (inputRef.current) inputRef.current.value = "";
       await load();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "No se pudo cargar o procesar el ZIP.");
+      setError(caught instanceof Error ? caught.message : "No se pudo leer el ZIP.");
     } finally {
       setBusy(false);
       setProgress(null);
@@ -350,7 +340,7 @@ export function ProjectContextPanel({
               >
                 <button type="button" onClick={() => inputRef.current?.click()} disabled={busy} className="btn-primary w-full disabled:opacity-40">
                   {busy ? <IconLoader size={12} className="animate-spin" /> : <IconUpload size={12} />}
-                  {progress == null ? "Subir ZIP de WhatsApp" : `Subiendo ${progress}%`}
+                  {progress == null ? "Subir ZIP de WhatsApp" : `${progress}%`}
                 </button>
                 <p className="mt-2 text-center font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">
                   o suéltalo aquí
@@ -378,4 +368,22 @@ export function ProjectContextPanel({
       {error ? <p className="mt-2 text-[10px] text-black">{error}</p> : null}
     </section>
   );
+}
+
+function readFileBytes(file: File, onProgress: (loaded: number) => void): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onprogress = (event) => {
+      if (event.lengthComputable) onProgress(event.loaded);
+    };
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) {
+        resolve(new Uint8Array(reader.result));
+        return;
+      }
+      reject(new Error("No se pudo leer el ZIP."));
+    };
+    reader.onerror = () => reject(new Error("No se pudo leer el ZIP."));
+    reader.readAsArrayBuffer(file);
+  });
 }

--- a/lib/live/load-room-context.ts
+++ b/lib/live/load-room-context.ts
@@ -82,6 +82,16 @@ export async function loadRoomContextBrief(
         }))
     : [];
 
+  const archives = await queryAll<{ filename: string; extracted_text: string }>(
+    `SELECT filename, extracted_text
+       FROM project_context_assets
+      WHERE project_id = $1
+        AND char_length(extracted_text) > 20
+      ORDER BY created_at DESC
+      LIMIT 3`,
+    [projectId],
+  ).catch(() => [] as Array<{ filename: string; extracted_text: string }>);
+
   const pageUrls = [
     ...references.map((item) => item.url),
     ...comments.flatMap((comment) => {
@@ -107,5 +117,9 @@ export async function loadRoomContextBrief(
     repositories,
     decisions,
     pages,
+    archives: archives.map((item) => ({
+      filename: item.filename,
+      text: item.extracted_text,
+    })),
   });
 }

--- a/lib/live/room-context.ts
+++ b/lib/live/room-context.ts
@@ -47,6 +47,7 @@ export interface RoomContextInput {
   repositories?: RoomRepository[];
   decisions?: string | null;
   pages?: RoomPage[];
+  archives?: Array<{ filename: string; text: string }>;
 }
 
 export function isSystemComment(comment: RoomComment): boolean {
@@ -160,6 +161,16 @@ export function formatRoomContext(input: RoomContextInput): string {
       const title = page.title?.trim() ? ` — ${page.title.trim()}` : "";
       lines.push(`### ${page.url}${title}`);
       lines.push(clip(page.text, 1600));
+    }
+  }
+
+  const archives = (input.archives ?? []).filter((item) => item.text?.trim()).slice(0, 3);
+  if (archives.length) {
+    lines.push("");
+    lines.push(`CONVERSACIONES CARGADAS (${archives.length}):`);
+    for (const archive of archives) {
+      lines.push(`### ${archive.filename.trim() || "chat.zip"}`);
+      lines.push(clip(archive.text, 3500));
     }
   }
 

--- a/tests/room-context.test.ts
+++ b/tests/room-context.test.ts
@@ -74,3 +74,17 @@ test("talk and plan must read the room", () => {
   assert.match(modeSystemRules("talk"), /observaciones/);
   assert.match(modeSystemRules("plan"), /observaciones/);
 });
+
+test("room brief includes WhatsApp conversation text", () => {
+  const brief = formatRoomContext({
+    projectId: "netmas-distribuidores",
+    archives: [
+      {
+        filename: "Chat de WhatsApp.zip",
+        text: "[10:00] Cliente: Quiero el paquete NET+",
+      },
+    ],
+  });
+  assert.match(brief, /CONVERSACIONES CARGADAS/);
+  assert.match(brief, /paquete NET\+/);
+});


### PR DESCRIPTION
El chat se extrae en el dispositivo. No depende de Vercel Blob. V lee el texto en Planeación.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the asset ingestion and download paths and trusts client-supplied extracted text within size checks, which affects stored project context and what the assistant sees in planning.
> 
> **Overview**
> WhatsApp ZIP uploads no longer go through Vercel Blob on the client. **ProjectContextPanel** reads the file locally, extracts `_chat.txt` with `extractArchiveText`, shows staged progress, and POSTs **`extractedText`** (capped) to finalize the asset.
> 
> The **assets POST** route adds an early path for that payload: it validates ZIP metadata and size limits, registers the asset with a synthetic `context/.../inline-...` pathname, and mirrors the upstream VForge response—without requiring blob storage for the common case. The legacy blob **head/get + server extract** flow remains for uploads that still send `blobPathname`.
> 
> **Downloads** for inline assets serve **`extracted_text` from the database** as a `.txt` attachment instead of streaming a ZIP from Blob.
> 
> **Room planning context** now loads up to three recent archives from `project_context_assets` and adds a **CONVERSACIONES CARGADAS** section (clipped text) so V can read WhatsApp content in talk/plan modes; a test covers this formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454611e5f7c3ab69f6a0da1176553fccc8e81e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->