### PR TITLE
feat(live): Vercel, integraciones, bóveda y MCP en la sala

### DIFF
--- a/app/api/live/[projectId]/tools/route.ts
+++ b/app/api/live/[projectId]/tools/route.ts
@@ -1,0 +1,226 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentVForgeIdentity, loadVForgeLiveProject } from "@/lib/api/vforge-owned";
+import { queryAll, queryOne, sql } from "@/lib/db/client";
+import { createMcpToken } from "@/lib/mcp/tokens";
+import {
+  buildIntegrationCatalog,
+  isSafeSecretName,
+  secretLooksLike,
+  type VaultSecretMeta,
+} from "@/lib/live/project-tools";
+import { encryptOperatorSecret } from "@/lib/vault/operator-crypto";
+import { invalidateSecretCache } from "@/lib/vault/get-secret";
+import {
+  listDeployments,
+  listProjectDomains,
+  listProjectEnvVars,
+} from "@/lib/vercel/client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const noStore = { "Cache-Control": "no-store" };
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  github_repo: string | null;
+  github_url: string | null;
+  vercel_project_id: string | null;
+  vercel_url: string | null;
+  domain: string | null;
+  status: string | null;
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const live = await loadVForgeLiveProject(projectId).catch(() => null);
+  if (!live) return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+
+  const project = await queryOne<ProjectRow>(
+    `SELECT id, name, github_repo, github_url, vercel_project_id, vercel_url, domain, status
+       FROM projects
+      WHERE id = $1
+      LIMIT 1`,
+    [projectId],
+  );
+  if (!project) return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+
+  const [integrationRows, secrets] = await Promise.all([
+    queryAll<{ kind: string; label: string; status: string }>(
+      `SELECT kind, label, status FROM project_integrations WHERE project_id = $1`,
+      [projectId],
+    ).catch(() => []),
+    queryAll<VaultSecretMeta>(
+      `SELECT id::text, name, provider, created_at::text, rotated_at::text, last_used_at::text
+         FROM project_secrets
+        WHERE project_id = $1
+        ORDER BY name`,
+      [projectId],
+    ).catch(() => []),
+  ]);
+
+  const secretNames = secrets.map((item) => item.name);
+  const integrations = buildIntegrationCatalog({
+    github: Boolean(project.github_repo || project.github_url),
+    vercel: Boolean(project.vercel_project_id || project.vercel_url),
+    neon: secretNames.some((name) => secretLooksLike(name, "NEON") || secretLooksLike(name, "DATABASE")),
+    clerk: secretNames.some((name) => secretLooksLike(name, "CLERK")),
+    stripe: secretNames.some((name) => secretLooksLike(name, "STRIPE")),
+    resend: secretNames.some((name) => secretLooksLike(name, "RESEND")),
+    blob: secretNames.some((name) => secretLooksLike(name, "BLOB")),
+    rows: integrationRows,
+  });
+
+  let vercel: Record<string, unknown> = {
+    connected: Boolean(project.vercel_project_id || project.vercel_url),
+    projectId: project.vercel_project_id,
+    url: project.vercel_url,
+    domain: project.domain,
+    deployments: [],
+    domains: [],
+    env: [],
+  };
+  if (project.vercel_project_id) {
+    try {
+      const [deployments, domains, env] = await Promise.all([
+        listDeployments(project.vercel_project_id, { limit: 8 }),
+        listProjectDomains(project.vercel_project_id),
+        listProjectEnvVars(project.vercel_project_id),
+      ]);
+      vercel = {
+        connected: true,
+        projectId: project.vercel_project_id,
+        url: project.vercel_url,
+        domain: project.domain,
+        deployments: deployments.map((item) => ({
+          uid: item.uid,
+          url: item.url,
+          state: item.readyState || item.state || "unknown",
+          target: item.target || "preview",
+          createdAt: item.createdAt,
+        })),
+        domains: domains.map((item) => ({
+          name: item.name,
+          verified: item.verified !== false,
+        })),
+        env: env.map((item) => ({
+          key: item.key,
+          type: item.type,
+          target: item.target,
+        })),
+      };
+    } catch (error) {
+      vercel = {
+        ...vercel,
+        error: error instanceof Error ? error.message : "No se pudo leer Vercel",
+      };
+    }
+  }
+
+  return NextResponse.json(
+    {
+      project: {
+        id: project.id,
+        name: project.name,
+        status: project.status,
+        github: project.github_repo || project.github_url,
+      },
+      vercel,
+      integrations,
+      vault: {
+        secrets: secrets.map((item) => ({
+          ...item,
+          preview: "••••••••",
+        })),
+      },
+      mcp: {
+        url: "https://vforge.site/api/mcp",
+        projectId,
+        hint: "Cada app tiene su MCP. Genéralo y pégalo en tu IA.",
+      },
+    },
+    { headers: noStore },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const identity = await getCurrentVForgeIdentity();
+  const live = await loadVForgeLiveProject(projectId).catch(() => null);
+  if (!identity || !live) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: noStore });
+  }
+  if (live.me.role === "observer") {
+    return NextResponse.json({ error: "forbidden" }, { status: 403, headers: noStore });
+  }
+
+  const payload = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const action = typeof payload?.action === "string" ? payload.action : "";
+
+  if (action === "mcp-token") {
+    const token = await createMcpToken(identity.userId, `VForge MCP · ${projectId}`);
+    return NextResponse.json(
+      {
+        token,
+        url: "https://vforge.site/api/mcp",
+        config: {
+          name: `VForge · ${live.project.name}`,
+          url: "https://vforge.site/api/mcp",
+          auth: "Bearer",
+          token,
+        },
+      },
+      { headers: noStore },
+    );
+  }
+
+  if (action === "secret") {
+    if (live.me.role !== "owner" && !live.me.isPlatformOwner) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403, headers: noStore });
+    }
+    const name = typeof payload?.name === "string" ? payload.name.trim() : "";
+    const value = typeof payload?.value === "string" ? payload.value : "";
+    const provider = typeof payload?.provider === "string" ? payload.provider.trim() : null;
+    if (!isSafeSecretName(name) || !value || value.length > 8192) {
+      return NextResponse.json({ error: "invalid_secret" }, { status: 400, headers: noStore });
+    }
+    try {
+      const enc = encryptOperatorSecret(value);
+      const ciphertextHex = enc.ciphertext.toString("hex");
+      const ivHex = enc.iv.toString("hex");
+      const authTagHex = enc.authTag.toString("hex");
+      await sql`
+        INSERT INTO project_secrets (
+          project_id, name, provider, ciphertext, iv, auth_tag
+        ) VALUES (
+          ${projectId}, ${name}, ${provider},
+          decode(${ciphertextHex}, 'hex'),
+          decode(${ivHex}, 'hex'),
+          decode(${authTagHex}, 'hex')
+        )
+        ON CONFLICT (project_id, name) DO UPDATE SET
+          provider = COALESCE(EXCLUDED.provider, project_secrets.provider),
+          ciphertext = EXCLUDED.ciphertext,
+          iv = EXCLUDED.iv,
+          auth_tag = EXCLUDED.auth_tag,
+          rotated_at = now()
+      `;
+      invalidateSecretCache(name, projectId);
+      return NextResponse.json({ ok: true, name, preview: "••••••••" }, { headers: noStore });
+    } catch {
+      return NextResponse.json(
+        { error: "vault_unavailable", notice: "La bóveda no pudo cifrar el secreto." },
+        { status: 503, headers: noStore },
+      );
+    }
+  }
+
+  return NextResponse.json({ error: "unknown_action" }, { status: 400, headers: noStore });
+}

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -59,6 +59,11 @@ const VControlPanel = dynamic(
   { ssr: false },
 );
 
+const ToolsPanel = dynamic(
+  () => import("@/components/live/ToolsPanel").then((module) => module.ToolsPanel),
+  { ssr: false },
+);
+
 export interface LivePortalProject {
   id: string;
   name: string;
@@ -96,7 +101,8 @@ type WorkspacePanelId =
   | "context"
   | "code"
   | "references"
-  | "v";
+  | "v"
+  | "tools";
 type WorkspacePreset = "balanced" | "previews" | "review";
 type PreviewKind = "desktop" | "mobile" | "admin";
 
@@ -142,6 +148,7 @@ const PANEL_LABELS: Record<WorkspacePanelId, string> = {
   code: "Código",
   references: "Referencias",
   v: "V",
+  tools: "Herramientas",
 };
 
 
@@ -343,6 +350,7 @@ function LiveWorkspace({
       "context",
       "code",
       "references",
+      "tools",
     ],
     [canSeeAdmin],
   );
@@ -367,6 +375,7 @@ function LiveWorkspace({
     code: false,
     references: false,
     v: false,
+    tools: false,
   });
   const savedLayoutsRef = useRef(DOCK_LAYOUTS.balanced);
 
@@ -432,7 +441,7 @@ function LiveWorkspace({
       feedback: source.feedback,
     };
     setFocusedPanel(null);
-    setCollapsed({ desktop: false, mobile: false, admin: false, activity: false, comments: false, context: false, code: false, references: false, v: false });
+    setCollapsed({ desktop: false, mobile: false, admin: false, activity: false, comments: false, context: false, code: false, references: false, v: false, tools: false });
     desktopRef.current?.expand();
     mobileRef.current?.expand();
     adminRef.current?.expand();
@@ -491,6 +500,7 @@ function LiveWorkspace({
     code: null,
     references: null,
     v: null,
+    tools: null,
   };
 
   const updateCollapsed = (panel: WorkspacePanelId, pixels: number) => {
@@ -516,6 +526,8 @@ function LiveWorkspace({
     <ReferencesPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
   ) : focusedPanel === "v" ? (
     <VControlPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
+  ) : focusedPanel === "tools" ? (
+    <ToolsPanel projectId={project.id} onClose={() => setFocusedPanel(null)} />
   ) : null;
 
   return (
@@ -536,7 +548,7 @@ function LiveWorkspace({
         </div>
         <div className="flex shrink-0 items-center gap-1" aria-label="Paneles visibles">
           {availablePanels.map((panel) => {
-            const standalone = panel === "code" || panel === "references" || panel === "v";
+            const standalone = panel === "code" || panel === "references" || panel === "v" || panel === "tools";
             const visible = standalone ? focusedPanel === panel : !collapsed[panel];
             return (
               <button

--- a/components/live/ToolsPanel.tsx
+++ b/components/live/ToolsPanel.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  IconCheck,
+  IconCopy,
+  IconExtLink,
+  IconKey,
+  IconLoader,
+  IconShield,
+  IconX,
+} from "@/components/brand/VFIcons";
+
+type Tab = "vercel" | "integrations" | "vault" | "mcp";
+
+interface ToolsPayload {
+  project: { id: string; name: string; github?: string | null };
+  vercel: {
+    connected: boolean;
+    projectId?: string | null;
+    url?: string | null;
+    domain?: string | null;
+    error?: string;
+    deployments?: Array<{
+      uid: string;
+      url: string;
+      state: string;
+      target: string;
+      createdAt: number;
+    }>;
+    domains?: Array<{ name: string; verified: boolean }>;
+    env?: Array<{ key: string; type: string; target: string[] }>;
+  };
+  integrations: Array<{
+    kind: string;
+    label: string;
+    status: "connected" | "available" | "missing";
+    detail: string;
+  }>;
+  vault: {
+    secrets: Array<{
+      id: string;
+      name: string;
+      provider: string | null;
+      preview: string;
+      created_at: string | null;
+      last_used_at: string | null;
+    }>;
+  };
+  mcp: { url: string; projectId: string; hint: string };
+}
+
+export function ToolsPanel({
+  projectId,
+  onClose,
+}: {
+  projectId: string;
+  onClose: () => void;
+}) {
+  const [tab, setTab] = useState<Tab>("vercel");
+  const [data, setData] = useState<ToolsPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [mcpToken, setMcpToken] = useState<string | null>(null);
+  const [secretName, setSecretName] = useState("");
+  const [secretValue, setSecretValue] = useState("");
+
+  const load = useCallback(async () => {
+    const response = await fetch(`/api/live/${encodeURIComponent(projectId)}/tools`, {
+      cache: "no-store",
+    });
+    if (!response.ok) throw new Error("No se pudieron leer las herramientas.");
+    setData((await response.json()) as ToolsPayload);
+  }, [projectId]);
+
+  useEffect(() => {
+    void load().catch((caught) =>
+      setError(caught instanceof Error ? caught.message : "Sin herramientas."),
+    );
+  }, [load]);
+
+  async function mintMcp() {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/live/${encodeURIComponent(projectId)}/tools`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "mcp-token" }),
+      });
+      const payload = (await response.json().catch(() => null)) as { token?: string } | null;
+      if (!response.ok || !payload?.token) throw new Error("No se pudo emitir el MCP.");
+      setMcpToken(payload.token);
+      setNotice("Token visible una sola vez. Cópialo ahora.");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "No se pudo emitir el MCP.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function saveSecret() {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/live/${encodeURIComponent(projectId)}/tools`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "secret",
+          name: secretName.trim().toUpperCase(),
+          value: secretValue,
+        }),
+      });
+      if (!response.ok) throw new Error("No se pudo guardar el secreto.");
+      setSecretName("");
+      setSecretValue("");
+      setNotice("Secreto cifrado. El valor no se vuelve a mostrar.");
+      await load();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "No se pudo guardar.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-white">
+      <div className="flex h-10 shrink-0 items-center justify-between border-b border-[var(--border-1)] px-4">
+        <div className="flex items-center gap-2">
+          <IconShield size={13} />
+          <h2 className="text-[12px] font-medium">Herramientas de la sala</h2>
+        </div>
+        <button type="button" onClick={onClose} className="grid h-7 w-7 place-items-center rounded-md hover:bg-[#f2f2f0]" aria-label="Cerrar herramientas">
+          <IconX size={11} />
+        </button>
+      </div>
+      <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-[var(--border-1)] px-3 py-2">
+        {(["vercel", "integrations", "vault", "mcp"] as Tab[]).map((item) => (
+          <button
+            key={item}
+            type="button"
+            onClick={() => setTab(item)}
+            className={cn(
+              "shrink-0 rounded-md border px-2.5 py-1 font-mono text-[8px] uppercase tracking-[0.08em]",
+              tab === item ? "border-black bg-black text-white" : "border-[var(--border-1)]",
+            )}
+          >
+            {item === "vercel" ? "Vercel" : item === "integrations" ? "Integraciones" : item === "vault" ? "Bóveda" : "MCP"}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {!data ? (
+          <div className="grid min-h-40 place-items-center">
+            <IconLoader size={14} className="animate-spin" />
+          </div>
+        ) : tab === "vercel" ? (
+          <VercelTools vercel={data.vercel} />
+        ) : tab === "integrations" ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            {data.integrations.map((item) => (
+              <div key={item.kind} className="rounded-md border border-[var(--border-1)] p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-[12px] font-medium">{item.label}</p>
+                  <span className="flex items-center gap-1 font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">
+                    <span className="status-shape" data-active={item.status === "connected"} />
+                    {item.status === "connected" ? "conectado" : "disponible"}
+                  </span>
+                </div>
+                <p className="mt-1 text-[10px] leading-4 text-[var(--fg-muted)]">{item.detail}</p>
+              </div>
+            ))}
+          </div>
+        ) : tab === "vault" ? (
+          <div>
+            <p className="text-[10px] leading-4 text-[var(--fg-muted)]">
+              Nombres, alcance y estado. El valor nunca se muestra otra vez.
+            </p>
+            <div className="mt-3 grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+              <input value={secretName} onChange={(event) => setSecretName(event.target.value)} placeholder="STRIPE_SECRET_KEY" className="rounded-md border border-[var(--border-1)] px-3 py-2 font-mono text-[11px]" />
+              <input value={secretValue} onChange={(event) => setSecretValue(event.target.value)} placeholder="valor" type="password" className="rounded-md border border-[var(--border-1)] px-3 py-2 font-mono text-[11px]" />
+              <button type="button" onClick={() => void saveSecret()} disabled={busy || !secretName || !secretValue} className="btn-primary disabled:opacity-40">
+                {busy ? <IconLoader size={12} className="animate-spin" /> : <IconKey size={12} />} Guardar
+              </button>
+            </div>
+            <div className="mt-4 space-y-2">
+              {data.vault.secrets.length ? data.vault.secrets.map((secret) => (
+                <div key={secret.id} className="flex items-center justify-between gap-3 rounded-md border border-[var(--border-1)] px-3 py-2">
+                  <div className="min-w-0">
+                    <p className="truncate font-mono text-[11px]">{secret.name}</p>
+                    <p className="font-mono text-[8px] text-[var(--fg-muted)]">
+                      {secret.provider || "app"} · {secret.preview}
+                    </p>
+                  </div>
+                  <span className="font-mono text-[8px] uppercase tracking-[0.08em] text-[var(--fg-muted)]">cifrado</span>
+                </div>
+              )) : <p className="text-[11px] text-[var(--fg-muted)]">Bóveda vacía en esta sala.</p>}
+            </div>
+          </div>
+        ) : (
+          <div>
+            <p className="text-[11px] leading-5">{data.mcp.hint}</p>
+            <p className="mt-2 font-mono text-[10px] text-[var(--fg-muted)]">{data.mcp.url}</p>
+            <button type="button" onClick={() => void mintMcp()} disabled={busy} className="btn-primary mt-3 disabled:opacity-40">
+              {busy ? <IconLoader size={12} className="animate-spin" /> : <IconKey size={12} />} Emitir MCP de esta app
+            </button>
+            {mcpToken ? (
+              <div className="mt-3 rounded-md border border-black bg-[#f7f7f5] p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-[11px] font-medium">Bearer (una vez)</p>
+                  <button type="button" className="btn-ghost" onClick={() => void navigator.clipboard.writeText(mcpToken)}>
+                    <IconCopy size={11} /> Copiar
+                  </button>
+                </div>
+                <p className="mt-2 break-all font-mono text-[10px]">{mcpToken}</p>
+              </div>
+            ) : null}
+          </div>
+        )}
+        {notice ? <p className="mt-3 flex items-center gap-1 text-[10px]"><IconCheck size={11} /> {notice}</p> : null}
+        {error ? <p className="mt-3 text-[10px]">{error}</p> : null}
+      </div>
+    </section>
+  );
+}
+
+function VercelTools({ vercel }: { vercel: ToolsPayload["vercel"] }) {
+  if (!vercel.connected && !vercel.projectId) {
+    return <p className="text-[11px] text-[var(--fg-muted)]">Esta sala aún no tiene proyecto Vercel enlazado.</p>;
+  }
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-[var(--border-1)] p-3">
+        <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">Proyecto</p>
+        <p className="mt-1 font-mono text-[11px]">{vercel.projectId || "sin id"}</p>
+        {vercel.domain ? <p className="mt-1 text-[11px]">{vercel.domain}</p> : null}
+        {vercel.url ? (
+          <a href={vercel.url.startsWith("http") ? vercel.url : `https://${vercel.url}`} target="_blank" rel="noreferrer" className="mt-2 inline-flex items-center gap-1 text-[10px]">
+            Abrir <IconExtLink size={10} />
+          </a>
+        ) : null}
+        {vercel.error ? <p className="mt-2 text-[10px]">{vercel.error}</p> : null}
+      </div>
+      <div>
+        <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">Deploys</p>
+        <div className="mt-2 space-y-2">
+          {(vercel.deployments ?? []).length ? (vercel.deployments ?? []).map((item) => (
+            <a key={item.uid} href={`https://${item.url}`} target="_blank" rel="noreferrer" className="flex items-center justify-between gap-3 rounded-md border border-[var(--border-1)] px-3 py-2">
+              <span className="truncate font-mono text-[10px]">{item.target} · {item.state}</span>
+              <span className="font-mono text-[8px] text-[var(--fg-muted)]">{new Date(item.createdAt).toISOString().slice(5, 16).replace("T", " ")}</span>
+            </a>
+          )) : <p className="text-[11px] text-[var(--fg-muted)]">Sin deploys leídos.</p>}
+        </div>
+      </div>
+      <div>
+        <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">Dominios</p>
+        <div className="mt-2 space-y-1">
+          {(vercel.domains ?? []).map((item) => (
+            <p key={item.name} className="font-mono text-[11px]">{item.name} {item.verified ? "" : "· pendiente"}</p>
+          ))}
+        </div>
+      </div>
+      <div>
+        <p className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">Env · nombres, nunca valores</p>
+        <div className="mt-2 grid gap-1 sm:grid-cols-2">
+          {(vercel.env ?? []).map((item) => (
+            <p key={item.key} className="truncate rounded-md border border-[var(--border-1)] px-2 py-1.5 font-mono text-[10px]">
+              {item.key} <span className="text-[var(--fg-muted)]">· {item.target.join("/") || item.type}</span>
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/live/project-tools.ts
+++ b/lib/live/project-tools.ts
@@ -1,0 +1,86 @@
+export type ToolStatus = "connected" | "available" | "missing";
+
+export interface ToolIntegration {
+  kind: string;
+  label: string;
+  status: ToolStatus;
+  detail: string;
+}
+
+export interface VaultSecretMeta {
+  id: string;
+  name: string;
+  provider: string | null;
+  created_at: string | null;
+  rotated_at: string | null;
+  last_used_at: string | null;
+}
+
+const CATALOG: Array<{ kind: string; label: string }> = [
+  { kind: "github", label: "GitHub" },
+  { kind: "vercel", label: "Vercel" },
+  { kind: "neon", label: "Neon" },
+  { kind: "clerk", label: "Clerk" },
+  { kind: "stripe", label: "Stripe" },
+  { kind: "resend", label: "Resend" },
+  { kind: "blob", label: "Vercel Blob" },
+  { kind: "mcp", label: "MCP del proyecto" },
+];
+
+export function buildIntegrationCatalog(input: {
+  github?: boolean;
+  vercel?: boolean;
+  neon?: boolean;
+  clerk?: boolean;
+  stripe?: boolean;
+  resend?: boolean;
+  blob?: boolean;
+  rows?: Array<{ kind: string; label: string; status: string }>;
+}): ToolIntegration[] {
+  const extra = new Map(
+    (input.rows ?? []).map((row) => [row.kind.toLowerCase(), row]),
+  );
+  return CATALOG.map((item) => {
+    const flagged =
+      item.kind === "github"
+        ? input.github
+        : item.kind === "vercel"
+          ? input.vercel
+          : item.kind === "neon"
+            ? input.neon
+            : item.kind === "clerk"
+              ? input.clerk
+              : item.kind === "stripe"
+                ? input.stripe
+                : item.kind === "resend"
+                  ? input.resend
+                  : item.kind === "blob"
+                    ? input.blob
+                    : false;
+    const row = extra.get(item.kind);
+    const connected = Boolean(flagged) || row?.status === "connected";
+    return {
+      kind: item.kind,
+      label: row?.label || item.label,
+      status: connected ? "connected" : "available",
+      detail:
+        item.kind === "mcp"
+          ? "Cada app tiene su MCP. Pégalo en Claude, Cursor o Grok."
+          : connected
+            ? "Conectado a esta sala"
+            : "Listo para conectar",
+    };
+  });
+}
+
+export function secretLooksLike(name: string, needle: string): boolean {
+  return name.toUpperCase().includes(needle.toUpperCase());
+}
+
+export function maskSecretPreview(): string {
+  return "••••••••";
+}
+
+export function isSafeSecretName(name: string): boolean {
+  return /^[A-Z][A-Z0-9_]{0,63}$/.test(name.trim());
+}

--- a/lib/vercel/client.ts
+++ b/lib/vercel/client.ts
@@ -325,3 +325,35 @@ export function pickCustomDomain(domains: VercelDomain[]): string | null {
   const apex = prod.find((d) => d.apexName && d.name === d.apexName);
   return (apex?.name || prod[0]?.name || custom[0]?.name) ?? null;
 }
+
+export interface VercelEnvVar {
+  id: string;
+  key: string;
+  type: string;
+  target: string[];
+  updatedAt?: number;
+}
+
+/** Lista variables de entorno: nombres, destino y tipo. Nunca el valor. */
+export async function listProjectEnvVars(
+  idOrName: string,
+  options: { auditUserId?: string } = {},
+): Promise<VercelEnvVar[]> {
+  const { token } = await getCreds(options);
+  const team = await getDefaultTeam(options);
+  const data = await vercelJson<{ envs?: Array<Record<string, unknown>> }>(
+    `/v9/projects/${encodeURIComponent(idOrName)}/env?limit=100`,
+    { method: "GET", token, teamId: team.id },
+  );
+  return (data.envs ?? [])
+    .map((item) => ({
+      id: typeof item.id === "string" ? item.id : "",
+      key: typeof item.key === "string" ? item.key : "",
+      type: typeof item.type === "string" ? item.type : "encrypted",
+      target: Array.isArray(item.target)
+        ? item.target.filter((value): value is string => typeof value === "string")
+        : [],
+      updatedAt: typeof item.updatedAt === "number" ? item.updatedAt : undefined,
+    }))
+    .filter((item) => Boolean(item.key));
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \".test-dist/tests/project-tools.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/project-tools.test.ts
+++ b/tests/project-tools.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildIntegrationCatalog,
+  isSafeSecretName,
+  maskSecretPreview,
+  secretLooksLike,
+} from "../lib/live/project-tools";
+
+test("catalog marks github and vercel from the project, MCP always available", () => {
+  const catalog = buildIntegrationCatalog({
+    github: true,
+    vercel: true,
+    neon: false,
+  });
+  const github = catalog.find((item) => item.kind === "github");
+  const mcp = catalog.find((item) => item.kind === "mcp");
+  const neon = catalog.find((item) => item.kind === "neon");
+  assert.equal(github?.status, "connected");
+  assert.equal(mcp?.status, "available");
+  assert.equal(neon?.status, "available");
+});
+
+test("vault never pretends to show a value", () => {
+  assert.equal(maskSecretPreview(), "••••••••");
+  assert.equal(isSafeSecretName("STRIPE_SECRET_KEY"), true);
+  assert.equal(isSafeSecretName("stripe key"), false);
+  assert.equal(secretLooksLike("NEON_DATABASE_URL", "NEON"), true);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -27,6 +27,7 @@
     "lib/live/project-memory.ts",
     "lib/forge/cerebras-usage.ts",
     "lib/projects/repository-groups.ts",
-    "lib/live/read-page.ts"
+    "lib/live/read-page.ts",
+    "lib/live/project-tools.ts"
   ]
 }


### PR DESCRIPTION
Panel Herramientas en cada sala: deploys/dominios/env de Vercel (sin valores), catálogo de integraciones, bóveda cifrada y MCP por app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces live APIs that mint MCP bearer tokens and write encrypted project secrets; misconfigured auth or validation could expose credentials or allow unauthorized vault changes.
> 
> **Overview**
> Adds a **Herramientas** standalone panel in the live workspace so each project room can inspect ops and credentials from one place.
> 
> A new **`/api/live/[projectId]/tools`** route powers the panel: **GET** returns project summary, an integration catalog (GitHub/Vercel links plus heuristics from vault secret names), masked vault metadata, MCP endpoint hints, and—when a Vercel project is linked—recent deploys, domains, and **env var keys/targets only** (via new `listProjectEnvVars`). **POST** supports **`mcp-token`** (authenticated members except observers) and **`secret`** upserts (owners/platform owners only), encrypting values into `project_secrets` with name validation and cache invalidation.
> 
> **`ToolsPanel`** wires four tabs (Vercel, Integraciones, Bóveda, MCP) to that API, including one-time MCP bearer display and vault save without ever re-showing secret values. Shared helpers live in **`lib/live/project-tools.ts`**, with unit tests added to the test harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a994d8fb7fe765f944c0fc240cb6c7fe1ff6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->