### PR TITLE
feat(mcp): ojos de la sala — vforge_project_see

### DIFF
--- a/app/api/live/[projectId]/tools/route.ts
+++ b/app/api/live/[projectId]/tools/route.ts
@@ -178,7 +178,7 @@ export async function GET(
       mcp: {
         url: mcpUrl,
         projectId,
-        hint: "Toda app debe tener su MCP. Genéralo y pégalo en Claude, Cursor o Grok. No usamos n8n.",
+        hint: "Toda app debe tener su MCP. Claude, Cursor y Grok leen anotaciones, referencias y fotografían Escritorio/Móvil con vforge_project_see. No usamos n8n.",
         config: mcpClientConfig({ name: mcpName, url: mcpUrl }),
       },
     },

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -2,6 +2,7 @@ import { handleMcp } from "@/lib/mcp/handler";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+export const maxDuration = 120;
 
 /** VForge MCP Server — Streamable HTTP. Auth Bearer opcional: sin token operas
  *  como público (tools públicas); con token admin|client desbloqueas datos. */

--- a/components/live/ToolsPanel.tsx
+++ b/components/live/ToolsPanel.tsx
@@ -262,6 +262,11 @@ export function ToolsPanel({
           <div>
             <p className="text-[11px] leading-5">{data.mcp.hint}</p>
             <p className="mt-2 font-mono text-[10px] text-[var(--fg-muted)]">{data.mcp.url}</p>
+            <ul className="mt-3 space-y-1 font-mono text-[10px] leading-4 text-[var(--fg-muted)]">
+              <li>vforge_project_feedback — anotaciones y anclas</li>
+              <li>vforge_project_context — referencias y HTML leído</li>
+              <li>vforge_project_see — plugin de ojos: fotografía Escritorio y Móvil</li>
+            </ul>
             <button
               type="button"
               onClick={() => void postAction({ action: "mcp-token" }, "Token visible una sola vez. Cópialo ahora.")}

--- a/lib/forge/ask-v-policy.ts
+++ b/lib/forge/ask-v-policy.ts
@@ -52,7 +52,7 @@ export function modeSystemRules(mode: VConversationMode): string {
       "Parte de las observaciones, referencias y contenido de la sala; no pidas que te los reescriban.",
       "No escribas código, no crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios.",
       "El usuario podrá convertir después este plan en una tarea de Ejecución con «Usar como tarea».",
-      "Toda app debe tener su MCP. Sugiérelo. No propongas n8n.",
+      "Toda app debe tener su MCP. Sugiérelo. El plugin de ojos es vforge_project_see. No propongas n8n.",
     ].join(" ");
   }
   return [
@@ -62,6 +62,6 @@ export function modeSystemRules(mode: VConversationMode): string {
     "Lee observaciones, puntos marcados, URLs de referencia y CONTENIDO.md de la sala.",
     "Si el usuario habla de «puntos» o «lo que marqué», usa esas observaciones.",
     "No crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios.",
-    "Toda app debe tener su MCP. Sugiérelo. No propongas n8n.",
+    "Toda app debe tener su MCP. Sugiérelo. El plugin de ojos es vforge_project_see. No propongas n8n.",
   ].join(" ");
 }

--- a/lib/live/project-tools.ts
+++ b/lib/live/project-tools.ts
@@ -161,6 +161,6 @@ export function mcpClientConfig(input: { name: string; url: string }): {
 export function roomToolsBrief(): string {
   return [
     "HERRAMIENTAS DE LA SALA: Vercel (deploys, promover, redeploy, dominios, env sin valores), integraciones, bóveda cifrada y MCP por app.",
-    "MCP: toda app debe tener su MCP. Sugiérelo y explica cómo pegarlo en Claude, Cursor o Grok. No uses n8n.",
+    "MCP: toda app debe tener su MCP. Incluye vforge_project_see (plugin de ojos: fotografía Escritorio/Móvil). Sugiérelo y explica cómo pegarlo en Claude, Cursor o Grok. No uses n8n.",
   ].join(" ");
 }

--- a/lib/live/see-page.ts
+++ b/lib/live/see-page.ts
@@ -1,0 +1,278 @@
+/**
+ * Ojos de la sala: captura Escritorio / Móvil / Admin en un Chrome aislado
+ * (sin cookies del owner) y las devuelve como imagen MCP.
+ */
+const RELAY = (process.env.VULCANO_RELAY_URL || "http://178.105.135.26").replace(
+  /\/$/,
+  "",
+);
+const CONTAINER = "vulcano-browser";
+const CAPTURE_TIMEOUT_MS = 25_000;
+const MAX_BASE64_CHARS = 1_800_000;
+
+export const SEE_VIEWPORTS = {
+  desktop: { width: 1440, height: 900, label: "Escritorio", mobile: false },
+  mobile: { width: 390, height: 844, label: "Móvil", mobile: true },
+  admin: { width: 1280, height: 800, label: "Administración", mobile: false },
+} as const;
+
+export type SeeViewportId = keyof typeof SEE_VIEWPORTS;
+
+export interface SeeShot {
+  viewport: SeeViewportId;
+  label: string;
+  url: string;
+  mimeType: "image/png";
+  data: string;
+}
+
+export interface SeeFailure {
+  viewport: SeeViewportId;
+  label: string;
+  url: string | null;
+  error: string;
+}
+
+const MOBILE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+export function shSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function isSafeCaptureUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    if (parsed.username || parsed.password) return false;
+    if (!parsed.hostname) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseSeeViewports(raw: unknown): SeeViewportId[] {
+  if (raw === undefined || raw === null || raw === "") {
+    return ["desktop", "mobile"];
+  }
+  const values = Array.isArray(raw) ? raw : [raw];
+  const next: SeeViewportId[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const key = value.trim().toLowerCase();
+    if (key === "all") return ["desktop", "mobile", "admin"];
+    if (key === "desktop" || key === "mobile" || key === "admin") {
+      if (!next.includes(key)) next.push(key);
+    }
+  }
+  return next.length ? next : ["desktop", "mobile"];
+}
+
+export function isPngBase64(value: string): boolean {
+  const trimmed = value.trim().replace(/\s+/g, "");
+  if (trimmed.length < 80 || trimmed.length > MAX_BASE64_CHARS) return false;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(trimmed)) return false;
+  try {
+    const header = Buffer.from(trimmed.slice(0, 24), "base64");
+    return header[0] === 0x89 && header[1] === 0x50 && header[2] === 0x4e && header[3] === 0x47;
+  } catch {
+    return false;
+  }
+}
+
+/** El relay a veces mezcla logs; el PNG en base64 empieza por iVBORw0KGgo. */
+export function extractPngBase64(raw: string): string | null {
+  const compact = raw.replace(/\s+/g, "");
+  const idx = compact.indexOf("iVBORw0KGgo");
+  if (idx < 0) return isPngBase64(compact) ? compact : null;
+  const candidate = compact.slice(idx).replace(/[^A-Za-z0-9+/=]/g, "");
+  return isPngBase64(candidate) ? candidate : null;
+}
+
+const CAPTURE_SCRIPT = `set -euo pipefail
+URL="$1"
+W="$2"
+H="$3"
+MOBILE="$4"
+OUT="/tmp/vforge-see-$$.png"
+PROF="/tmp/vforge-see-profile-$$"
+BIN="$(command -v google-chrome-stable || command -v google-chrome || command -v chromium || command -v chromium-browser || true)"
+if [ -z "$BIN" ]; then
+  for c in /usr/bin/google-chrome /usr/bin/google-chrome-stable /opt/google/chrome/chrome /usr/lib/chromium/chromium; do
+    if [ -x "$c" ]; then BIN="$c"; break; fi
+  done
+fi
+if [ -z "$BIN" ]; then
+  echo "NO_CHROME" >&2
+  exit 2
+fi
+UA=()
+if [ "$MOBILE" = "1" ]; then
+  UA=(--user-agent=${JSON.stringify(MOBILE_UA)})
+fi
+"$BIN" --headless=new --no-sandbox --disable-gpu --disable-dev-shm-usage \\
+  --hide-scrollbars --force-device-scale-factor=1 \\
+  --user-data-dir="$PROF" --window-size="$W,$H" "\${UA[@]}" \\
+  --virtual-time-budget=12000 --screenshot="$OUT" "$URL" \\
+  >/tmp/vforge-see-chrome-$$.log 2>&1 || true
+if [ ! -s "$OUT" ]; then
+  echo "NO_SHOT" >&2
+  cat /tmp/vforge-see-chrome-$$.log >&2 || true
+  rm -rf "$PROF"
+  exit 3
+fi
+base64 -w0 "$OUT"
+rm -f "$OUT"
+rm -rf "$PROF"
+`;
+
+export function buildSeeHostCommand(input: {
+  url: string;
+  width: number;
+  height: number;
+  mobile: boolean;
+}): string {
+  if (!isSafeCaptureUrl(input.url)) {
+    throw new Error("url insegura");
+  }
+  const scriptB64 = Buffer.from(CAPTURE_SCRIPT, "utf8").toString("base64");
+  return [
+    `echo ${scriptB64} | base64 -d | docker exec -i ${CONTAINER} bash -s --`,
+    shSingleQuote(input.url),
+    String(input.width),
+    String(input.height),
+    input.mobile ? "1" : "0",
+  ].join(" ");
+}
+
+async function relayExec(cmd: string): Promise<string> {
+  const secret = process.env.BRAIN_SECRET ?? "";
+  if (!secret) throw new Error("ojos no disponibles: falta el relay");
+  const res = await fetch(`${RELAY}/brain/exec`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret, cmd }),
+    cache: "no-store",
+    signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`relay HTTP ${res.status}`);
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  const out = (data.stdout ?? data.output ?? data.result ?? data.data ?? "") as unknown;
+  return typeof out === "string" ? out : JSON.stringify(out);
+}
+
+export async function captureOneViewport(input: {
+  viewport: SeeViewportId;
+  url: string;
+}): Promise<SeeShot> {
+  const spec = SEE_VIEWPORTS[input.viewport];
+  const cmd = buildSeeHostCommand({
+    url: input.url,
+    width: spec.width,
+    height: spec.height,
+    mobile: spec.mobile,
+  });
+  const stdout = await relayExec(cmd);
+  const data = extractPngBase64(stdout);
+  if (!data) {
+    const hint = stdout.replace(/\s+/g, " ").trim().slice(0, 180) || "sin salida";
+    throw new Error(`no se pudo fotografiar ${spec.label}: ${hint}`);
+  }
+  return {
+    viewport: input.viewport,
+    label: spec.label,
+    url: input.url,
+    mimeType: "image/png",
+    data,
+  };
+}
+
+export async function captureSeeViewports(input: {
+  desktop_url: string | null;
+  mobile_url: string | null;
+  admin_url: string | null;
+  viewports: SeeViewportId[];
+}): Promise<{ shots: SeeShot[]; failures: SeeFailure[] }> {
+  const urls: Record<SeeViewportId, string | null> = {
+    desktop: input.desktop_url,
+    mobile: input.mobile_url,
+    admin: input.admin_url,
+  };
+  const results = await Promise.all(
+    input.viewports.map(async (viewport) => {
+      const url = urls[viewport];
+      const label = SEE_VIEWPORTS[viewport].label;
+      if (!url || !isSafeCaptureUrl(url)) {
+        return {
+          ok: false as const,
+          failure: {
+            viewport,
+            label,
+            url: url || null,
+            error: "Sin URL autorizada para esta vista",
+          },
+        };
+      }
+      try {
+        return { ok: true as const, shot: await captureOneViewport({ viewport, url }) };
+      } catch (error) {
+        return {
+          ok: false as const,
+          failure: {
+            viewport,
+            label,
+            url,
+            error: error instanceof Error ? error.message : "captura fallida",
+          },
+        };
+      }
+    }),
+  );
+  const shots: SeeShot[] = [];
+  const failures: SeeFailure[] = [];
+  for (const result of results) {
+    if (result.ok) shots.push(result.shot);
+    else failures.push(result.failure);
+  }
+  return { shots, failures };
+}
+
+export function mcpSeeResult(
+  projectName: string,
+  projectId: string,
+  result: { shots: SeeShot[]; failures: SeeFailure[] },
+): { content: Array<Record<string, unknown>>; isError?: boolean } {
+  if (result.shots.length === 0) {
+    const detail = result.failures
+      .map((item) => `- ${item.label}: ${item.error}`)
+      .join("\n");
+    return {
+      content: [
+        {
+          type: "text",
+          text: `No pude ver ${projectName} (${projectId}).\n${detail || "Sin vistas disponibles."}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+  const lines = [
+    `Ojos de la sala — ${projectName} (${projectId}).`,
+    ...result.shots.map(
+      (shot) =>
+        `• ${shot.label} ${SEE_VIEWPORTS[shot.viewport].width}×${SEE_VIEWPORTS[shot.viewport].height} — ${shot.url}`,
+    ),
+    ...result.failures.map((item) => `• ${item.label} no se vio: ${item.error}`),
+  ];
+  return {
+    content: [
+      { type: "text", text: lines.join("\n") },
+      ...result.shots.map((shot) => ({
+        type: "image",
+        data: shot.data,
+        mimeType: shot.mimeType,
+      })),
+    ],
+  };
+}

--- a/lib/mcp/rbac.ts
+++ b/lib/mcp/rbac.ts
@@ -60,6 +60,7 @@ export const TOOL_KIND: Record<string, ToolKind> = {
   vforge_project_feedback: "data",
   vforge_project_context: "data",
   vforge_project_file: "data",
+  vforge_project_see: "data",
   vforge_payments: "data",
   vforge_apps_health: "data",
   vforge_brain_search: "data",

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -120,6 +120,22 @@ export const MCP_TOOLS: McpToolDef[] = [
     },
   },
   {
+    name: "vforge_project_see",
+    description:
+      "OJOS (admin|client): fotografía Escritorio, Móvil y/o Admin de una sala y devuelve las imágenes. La IA ve el pixel, no sólo el texto. Usa project_id y viewport=desktop|mobile|admin|all.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: { type: "string", description: "ID exacto del proyecto (por ejemplo: netmas-distribuidores)" },
+        viewport: {
+          type: "string",
+          description: "desktop, mobile, admin o all. Default: desktop y mobile",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
     name: "vforge_payments",
     description: "DATOS (admin|client): pagos y avance financiero (total/pagado/pendiente) de los proyectos. Admin ve todo; client ve SOLO su org_id. Aislado por tenant.",
     inputSchema: { type: "object", properties: {} },
@@ -534,6 +550,7 @@ VForge es una fábrica de aplicaciones operada por un agente (V): construye, des
    • URL:  https://vforge.site/api/mcp
    • Auth: Bearer <tu-token>
 4. Llama \`help\` para ver las tools, o \`vforge_method\` para el método.
+5. Para ver una sala: \`vforge_project_see\` con el project_id. Recibes fotos de Escritorio y Móvil.
 
 ## Scopes
 • Tu token te aísla a TU forge: sólo ves tus propios proyectos, pagos y apps.
@@ -568,6 +585,7 @@ function helpText(principal: McpPrincipal): string {
   lines.push("• vforge_project_feedback — observaciones y anclas de una sala.");
   lines.push("• vforge_project_context — código, referencias (con contenido leído), CONTENIDO.md y archivos.");
   lines.push("• vforge_project_file — texto extraído de un ZIP privado, leído por fragmentos.");
+  lines.push("• vforge_project_see — ojos: fotografía Escritorio/Móvil/Admin y se las manda a la IA.");
   lines.push("• vforge_payments — avance financiero (total/pagado/pendiente).");
   lines.push("• vforge_apps_health — salud de despliegue de tus apps.");
   lines.push("• vforge_brain_search — memoria y método de VForge.");
@@ -985,7 +1003,7 @@ export async function runMcpTool(
         `## Contenido leído de las URLs\n${pagesText}\n\n` +
         `## CONTENIDO.md\n${document?.content?.trim() || project.description || "Sin contenido documentado todavía."}\n\n` +
         `## Archivos privados\n${assetsText}\n\n` +
-        `Usa vforge_project_file con project_id + asset_id para leer el texto extraído. Usa vforge_project_feedback para las anotaciones de la sala.`,
+        `Usa vforge_project_file con project_id + asset_id para leer el texto extraído. Usa vforge_project_feedback para las anotaciones. Usa vforge_project_see para fotografiar Escritorio/Móvil.`,
       );
     }
 
@@ -1013,6 +1031,27 @@ export async function runMcpTool(
         `Fragmento: ${offset}-${offset + chunk.length} de ${total}\n` +
         `Siguiente offset: ${nextOffset ?? "fin"}\n\n${chunk || "[El ZIP no contenía texto legible compatible.]"}`,
       );
+    }
+
+    case "vforge_project_see": {
+      const projectId = String(args.project_id ?? "").trim().slice(0, 160);
+      if (!projectId) return err("Falta 'project_id'.");
+      const allowed = await authorizeMcpProject(projectId, principal);
+      if (!allowed) return err("Proyecto no encontrado o sin acceso para este token MCP.");
+      const { getProjectViewports } = await import("@/lib/projects/live-portal");
+      const { captureSeeViewports, parseSeeViewports, mcpSeeResult } = await import(
+        "@/lib/live/see-page"
+      );
+      const project = await getProjectViewports(projectId);
+      if (!project) return err("Proyecto no encontrado.");
+      const viewports = parseSeeViewports(args.viewport ?? args.viewports);
+      const captured = await captureSeeViewports({
+        desktop_url: project.desktop_url,
+        mobile_url: project.mobile_url,
+        admin_url: project.admin_url,
+        viewports,
+      });
+      return mcpSeeResult(allowed.name, projectId, captured);
     }
 
     case "vforge_payments": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \".test-dist/tests/project-tools.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \".test-dist/tests/project-tools.test.js\" \".test-dist/tests/see-page.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/project-tools.test.ts
+++ b/tests/project-tools.test.ts
@@ -77,4 +77,5 @@ test("room brief tells V to suggest MCP and skip n8n", () => {
   assert.match(brief, /MCP/);
   assert.match(brief, /n8n/i);
   assert.match(brief, /Vercel/);
+  assert.match(brief, /vforge_project_see/);
 });

--- a/tests/see-page.test.ts
+++ b/tests/see-page.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildSeeHostCommand,
+  extractPngBase64,
+  isPngBase64,
+  isSafeCaptureUrl,
+  mcpSeeResult,
+  parseSeeViewports,
+  shSingleQuote,
+} from "../lib/live/see-page";
+
+test("default eyes are desktop and mobile, all includes admin", () => {
+  assert.deepEqual(parseSeeViewports(undefined), ["desktop", "mobile"]);
+  assert.deepEqual(parseSeeViewports("desktop"), ["desktop"]);
+  assert.deepEqual(parseSeeViewports("all"), ["desktop", "mobile", "admin"]);
+  assert.deepEqual(parseSeeViewports(["mobile", "desktop", "mobile"]), [
+    "mobile",
+    "desktop",
+  ]);
+});
+
+test("capture urls reject credentials and non-http", () => {
+  assert.equal(isSafeCaptureUrl("https://netmas.mx/app"), true);
+  assert.equal(isSafeCaptureUrl("http://localhost:3000"), true);
+  assert.equal(isSafeCaptureUrl("javascript:alert(1)"), false);
+  assert.equal(isSafeCaptureUrl("https://user:pass@evil.com"), false);
+});
+
+test("host command keeps the url quoted and never interpolates it raw", () => {
+  const url = "https://netmas.mx/app?x=1&y=2";
+  const cmd = buildSeeHostCommand({
+    url,
+    width: 1440,
+    height: 900,
+    mobile: false,
+  });
+  assert.match(cmd, /docker exec -i vulcano-browser bash -s --/);
+  assert.match(cmd, new RegExp(shSingleQuote(url).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.equal(cmd.includes(" user:pass"), false);
+  assert.equal(cmd.includes("$(rm"), false);
+});
+
+test("png header is required before calling it an image", () => {
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.alloc(80, 1),
+  ]).toString("base64");
+  assert.equal(isPngBase64(png), true);
+  assert.equal(isPngBase64("not-an-image"), false);
+  assert.equal(isPngBase64(""), false);
+});
+
+test("extracts PNG even if the relay prepends noise", () => {
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.alloc(80, 1),
+  ]).toString("base64");
+  assert.equal(extractPngBase64(`ok\n${png}\n`), png);
+  assert.equal(extractPngBase64("NO_SHOT"), null);
+});
+
+test("MCP result sends real image blocks, not a URL", () => {
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.alloc(80, 1),
+  ]).toString("base64");
+  const result = mcpSeeResult("NETMAS", "netmas-distribuidores", {
+    shots: [
+      {
+        viewport: "desktop",
+        label: "Escritorio",
+        url: "https://netmas.mx",
+        mimeType: "image/png",
+        data: png,
+      },
+    ],
+    failures: [],
+  });
+  const image = result.content.find((item) => item.type === "image");
+  assert.equal(image?.mimeType, "image/png");
+  assert.equal(image?.data, png);
+  assert.match(String(result.content[0]?.text), /Ojos de la sala/);
+});


### PR DESCRIPTION
## Qué
Plugin MCP `vforge_project_see`: fotografía Escritorio y Móvil (Admin si se pide) de una sala y se las manda a Claude, Cursor o Grok como imagen. No es extensión de Chrome; es una tool del MCP de la app.

## Cómo
- Chrome headless aislado (`--user-data-dir` temporal) en `vulcano-browser`. Sin cookies del owner.
- URLs salen del proyecto, no del caller. Default desktop+mobile.
- MCP `image` blocks (PNG), no un link.
- Visible en Herramientas → MCP.

## Tests
typecheck, eslint, 74 unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a tenant-gated path that runs remote shell/docker capture on operator infrastructure; mitigations include project-owned URLs, URL allowlisting, and quoting, but relay/exec availability and SSRF-style abuse if viewport URLs were misconfigured remain operational concerns.
> 
> **Overview**
> Adds the **`vforge_project_see`** MCP data tool so Claude, Cursor, and Grok can get **PNG screenshots** of a project’s configured **Escritorio / Móvil / Admin** views (default desktop+mobile), not just text context.
> 
> Captures run in **isolated headless Chrome** inside `vulcano-browser` via the Vulcano relay (`BRAIN_SECRET` + `/brain/exec`); URLs come from **`getProjectViewports`** on the project record, with **http(s) validation** and shell-safe quoting. Results are returned as MCP **image** blocks plus a short text summary. **`/api/mcp`** gets **`maxDuration = 120`** to tolerate slow captures.
> 
> Product copy and in-room guidance are updated (live tools API hint, **ToolsPanel** MCP tool list, `ask-v-policy`, `roomToolsBrief`, `getting_started` / `help` / `vforge_project_context`). RBAC registers the tool as tenant **data**. New **`see-page`** unit tests cover viewports, URL safety, PNG parsing, and MCP payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7a4a4b327119e4a5c20abb229770fffd8c70d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->