### PR TITLE
feat(live): fotografiar cada visor y guardarlo para el MCP

### DIFF
--- a/app/api/live/[projectId]/eyes/route.ts
+++ b/app/api/live/[projectId]/eyes/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { loadVForgeLiveProject } from "@/lib/api/vforge-owned";
 import { resolveMcpToken } from "@/lib/mcp/tokens";
 import { authorizeMcpProject } from "@/lib/mcp/tools";
-import { listProjectEyes, saveProjectEye } from "@/lib/live/project-eyes";
+import { listProjectEyes, listVisorEyes, saveProjectEye } from "@/lib/live/project-eyes";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -38,17 +38,31 @@ export async function GET(
   if (!(await canWrite(req, projectId))) {
     return NextResponse.json({ error: "no auth" }, { status: 401, headers: noStore });
   }
-  const rows = await listProjectEyes(projectId, 8);
+  const [plugin, visors] = await Promise.all([
+    listProjectEyes(projectId, 8),
+    listVisorEyes(projectId),
+  ]);
   return NextResponse.json(
     {
-      eyes: rows.map((row) => ({
+      eyes: plugin.map((row) => ({
         id: row.id,
         source: row.source,
+        viewport: row.viewport,
         url: row.url,
         selector: row.selector,
         note: row.note,
         mimeType: row.mime_type,
         createdAt: row.created_at,
+      })),
+      visors: visors.map((row) => ({
+        id: row.id,
+        source: row.source,
+        viewport: row.viewport,
+        url: row.url,
+        note: row.note,
+        mimeType: row.mime_type,
+        createdAt: row.created_at,
+        data: row.data_b64,
       })),
     },
     { headers: noStore },

--- a/app/api/live/[projectId]/tools/route.ts
+++ b/app/api/live/[projectId]/tools/route.ts
@@ -29,6 +29,7 @@ import {
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+export const maxDuration = 120;
 
 const noStore = { "Cache-Control": "no-store" };
 
@@ -178,7 +179,7 @@ export async function GET(
       mcp: {
         url: mcpUrl,
         projectId,
-        hint: "Toda app debe tener su MCP. Claude, Cursor y Grok ven la sala con Navegador Pro y el plugin de Chrome (vforge_project_see). No usamos n8n.",
+        hint: "Toda app debe tener su MCP. vforge_project_see fotografía cada visor y lo guarda en documentos. No usamos n8n.",
         config: mcpClientConfig({ name: mcpName, url: mcpUrl }),
       },
     },
@@ -216,6 +217,34 @@ export async function POST(
       },
       { headers: noStore },
     );
+  }
+
+  if (action === "photograph-viewports") {
+    try {
+      const { photographAndStoreVisors } = await import("@/lib/live/photograph-visors");
+      const result = await photographAndStoreVisors({
+        projectId,
+        preferCdp: live.me.isPlatformOwner,
+      });
+      return NextResponse.json(
+        {
+          ok: result.shots.length > 0,
+          shots: result.shots.map((shot) => ({
+            viewport: shot.viewport,
+            label: shot.label,
+            url: shot.url,
+            engine: shot.engine,
+          })),
+          failures: result.failures,
+        },
+        { headers: noStore },
+      );
+    } catch (error) {
+      return jsonError(
+        error instanceof Error ? error.message : "No se pudieron fotografiar los visores",
+        502,
+      );
+    }
   }
 
   if (action === "secret") {

--- a/components/live/ProjectContextPanel.tsx
+++ b/components/live/ProjectContextPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { extractArchiveText } from "@/lib/live/archive-text";
 import {
+  IconCamera,
   IconCheck,
   IconCode,
   IconDownload,
@@ -14,7 +15,7 @@ import {
   IconX,
 } from "@/components/brand/VFIcons";
 
-type ContextTab = "status" | "content" | "archive";
+type ContextTab = "status" | "content" | "visors" | "archive";
 
 interface ContextPayload {
   project: {
@@ -103,6 +104,15 @@ export function ProjectContextPanel({
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [dragging, setDragging] = useState(false);
+  const [visors, setVisors] = useState<Array<{
+    viewport: string | null;
+    note: string | null;
+    mimeType: string;
+    data: string;
+    url: string | null;
+    createdAt: string;
+  }>>([]);
+  const [visorBusy, setVisorBusy] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -124,9 +134,17 @@ export function ProjectContextPanel({
     }
   }, [encodedProjectId]);
 
+  const loadVisors = useCallback(async () => {
+    const response = await fetch(`/api/live/${encodedProjectId}/eyes`, { cache: "no-store" });
+    if (!response.ok) return;
+    const payload = (await response.json()) as { visors?: typeof visors };
+    setVisors(payload.visors ?? []);
+  }, [encodedProjectId]);
+
   useEffect(() => {
     void load();
-  }, [load]);
+    void loadVisors();
+  }, [load, loadVisors]);
 
   async function saveContent() {
     if (!data?.me.canWrite || busy) return;
@@ -233,7 +251,7 @@ export function ProjectContextPanel({
       </div>
 
       <div className="mt-3 flex gap-1 overflow-x-auto">
-        {(["status", "content", "archive"] as ContextTab[]).map((item) => (
+        {(["status", "content", "visors", "archive"] as ContextTab[]).map((item) => (
           <button
             key={item}
             type="button"
@@ -243,7 +261,7 @@ export function ProjectContextPanel({
               tab === item ? "border-black bg-black text-white" : "border-[var(--border-1)]",
             )}
           >
-            {item === "status" ? "Estado real" : item === "content" ? "CONTENIDO.md" : "Conversación.zip"}
+            {item === "status" ? "Estado real" : item === "content" ? "CONTENIDO.md" : item === "visors" ? "Visores" : "Conversación.zip"}
           </button>
         ))}
       </div>
@@ -315,6 +333,61 @@ export function ProjectContextPanel({
               </button>
             ) : <p className="mt-2 text-[10px] text-[var(--fg-muted)]">Disponible en modo lectura para tu rol.</p>}
             {data.document.updated_at ? <p className="mt-2 text-[9px] text-[var(--fg-muted)]">Última edición: {data.document.updated_by || "miembro del proyecto"}</p> : null}
+          </div>
+        ) : tab === "visors" ? (
+          <div>
+            <p className="text-[10px] leading-4 text-[var(--fg-muted)]">
+              Escritorio, Móvil y Admin. Quedan como documentos. El MCP las ve con vforge_project_context.
+            </p>
+            {data.me.canWrite ? (
+              <button
+                type="button"
+                disabled={visorBusy}
+                onClick={() => {
+                  setVisorBusy(true);
+                  setError(null);
+                  void fetch(`/api/live/${encodedProjectId}/tools`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ action: "photograph-viewports" }),
+                  })
+                    .then(async (response) => {
+                      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+                      if (!response.ok) throw new Error(payload?.error || "No se pudieron fotografiar.");
+                      setNotice("Visores guardados para el MCP.");
+                      await loadVisors();
+                    })
+                    .catch((caught) => {
+                      setError(caught instanceof Error ? caught.message : "No se pudieron fotografiar.");
+                    })
+                    .finally(() => setVisorBusy(false));
+                }}
+                className="btn-primary mt-3 disabled:opacity-40"
+              >
+                {visorBusy ? <IconLoader size={12} className="animate-spin" /> : <IconCamera size={12} />} Fotografiar visores
+              </button>
+            ) : null}
+            {visors.length ? (
+              <div className="mt-3 space-y-3">
+                {visors.map((visor) => (
+                  <figure key={`${visor.viewport}-${visor.createdAt}`} className="overflow-hidden rounded-md border border-[var(--border-1)]">
+                    {/* data: URLs from the sala — next/image cannot optimize them */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={`data:${visor.mimeType};base64,${visor.data}`}
+                      alt={visor.note || visor.viewport || "visor"}
+                      className="w-full object-contain object-top"
+                    />
+                    <figcaption className="flex items-center justify-between gap-2 px-2 py-1.5 font-mono text-[8px] uppercase tracking-[0.08em]">
+                      <span>{visor.viewport || visor.note}</span>
+                      <span className="truncate text-[var(--fg-muted)]">{visor.url}</span>
+                    </figcaption>
+                  </figure>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-[10px] text-[var(--fg-muted)]">Aún no hay fotos de visor.</p>
+            )}
           </div>
         ) : (
           <div>

--- a/components/live/ToolsPanel.tsx
+++ b/components/live/ToolsPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import {
+  IconCamera,
   IconCheck,
   IconCopy,
   IconExtLink,
@@ -81,6 +82,13 @@ export function ToolsPanel({
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [mcpToken, setMcpToken] = useState<string | null>(null);
+  const [visors, setVisors] = useState<Array<{
+    viewport: string | null;
+    note: string | null;
+    mimeType: string;
+    data: string;
+    url: string | null;
+  }>>([]);
   const [secretName, setSecretName] = useState("");
   const [secretValue, setSecretValue] = useState("");
   const [domain, setDomain] = useState("");
@@ -95,11 +103,19 @@ export function ToolsPanel({
     setData((await response.json()) as ToolsPayload);
   }, [projectId]);
 
+  const loadVisors = useCallback(async () => {
+    const response = await fetch(`/api/live/${encodeURIComponent(projectId)}/eyes`, { cache: "no-store" });
+    if (!response.ok) return;
+    const payload = (await response.json()) as { visors?: typeof visors };
+    setVisors(payload.visors ?? []);
+  }, [projectId]);
+
   useEffect(() => {
     void load().catch((caught) =>
       setError(caught instanceof Error ? caught.message : "Sin herramientas."),
     );
-  }, [load]);
+    void loadVisors();
+  }, [load, loadVisors]);
 
   async function postAction(body: Record<string, unknown>, okMessage: string) {
     setBusy(true);
@@ -118,7 +134,8 @@ export function ToolsPanel({
       }
       if (payload?.token) setMcpToken(payload.token);
       setNotice(okMessage);
-      if (body.action !== "mcp-token") await load();
+      if (body.action === "photograph-viewports") await loadVisors();
+      else if (body.action !== "mcp-token") await load();
       return payload;
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "No se pudo completar.");
@@ -264,10 +281,45 @@ export function ToolsPanel({
             <p className="mt-2 font-mono text-[10px] text-[var(--fg-muted)]">{data.mcp.url}</p>
             <ul className="mt-3 space-y-1 font-mono text-[10px] leading-4 text-[var(--fg-muted)]">
               <li>vforge_project_feedback — anotaciones y anclas</li>
-              <li>vforge_project_context — referencias y HTML leído</li>
-              <li>vforge_project_see — Navegador Pro fotografía Escritorio/Móvil</li>
+              <li>vforge_project_context — referencias, HTML y fotos de visores</li>
+              <li>vforge_project_see — fotografía cada visor y lo guarda en documentos</li>
               <li>vforge_navegador_see — pestaña abierta del Chrome en Hetzner</li>
             </ul>
+            {write ? (
+              <button
+                type="button"
+                onClick={() =>
+                  void postAction(
+                    { action: "photograph-viewports" },
+                    "Fotos de visor guardadas. El MCP las ve en documentos.",
+                  )
+                }
+                disabled={busy}
+                className="btn-primary mt-3 disabled:opacity-40"
+              >
+                {busy ? <IconLoader size={12} className="animate-spin" /> : <IconCamera size={12} />} Fotografiar visores
+              </button>
+            ) : null}
+            {visors.length ? (
+              <div className="mt-3 grid grid-cols-3 gap-2">
+                {visors.map((visor) => (
+                  <figure key={`${visor.viewport}-${visor.note}`} className="overflow-hidden rounded-md border border-[var(--border-1)]">
+                    {/* data: URLs from the sala — next/image cannot optimize them */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={`data:${visor.mimeType};base64,${visor.data}`}
+                      alt={visor.note || visor.viewport || "visor"}
+                      className="h-20 w-full object-cover object-top"
+                    />
+                    <figcaption className="truncate px-1.5 py-1 font-mono text-[8px] uppercase tracking-[0.08em]">
+                      {visor.viewport || visor.note}
+                    </figcaption>
+                  </figure>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-[10px] text-[var(--fg-muted)]">Aún no hay fotos de Escritorio, Móvil o Admin.</p>
+            )}
             <a
               href="/api/inspector/zip"
               className="btn-ghost mt-3 inline-flex"

--- a/lib/live/photograph-visors.ts
+++ b/lib/live/photograph-visors.ts
@@ -1,0 +1,38 @@
+import { getProjectViewports } from "@/lib/projects/live-portal";
+import { saveProjectEye } from "./project-eyes";
+import {
+  captureSeeViewports,
+  visorDocumentName,
+  type SeeFailure,
+  type SeeShot,
+} from "./see-page";
+
+export async function persistVisorShots(projectId: string, shots: SeeShot[]): Promise<void> {
+  for (const shot of shots) {
+    await saveProjectEye({
+      projectId,
+      source: "visor",
+      viewport: shot.viewport,
+      url: shot.url,
+      note: visorDocumentName(shot.viewport),
+      image: `data:${shot.mimeType};base64,${shot.data}`,
+    }).catch(() => null);
+  }
+}
+
+export async function photographAndStoreVisors(input: {
+  projectId: string;
+  preferCdp: boolean;
+}): Promise<{ shots: SeeShot[]; failures: SeeFailure[] }> {
+  const project = await getProjectViewports(input.projectId);
+  if (!project) throw new Error("Proyecto no encontrado");
+  const result = await captureSeeViewports({
+    desktop_url: project.desktop_url,
+    mobile_url: project.mobile_url,
+    admin_url: project.admin_url,
+    viewports: ["desktop", "mobile", "admin"],
+    preferCdp: input.preferCdp,
+  });
+  await persistVisorShots(input.projectId, result.shots);
+  return result;
+}

--- a/lib/live/project-eyes.ts
+++ b/lib/live/project-eyes.ts
@@ -1,7 +1,7 @@
 import { queryAll, queryOne, sql } from "@/lib/db/client";
 import { parseEyeImage } from "./see-page";
 
-const KEEP = 8;
+const KEEP_PLUGIN = 8;
 
 export interface ProjectEye {
   id: string;
@@ -50,14 +50,16 @@ export async function saveProjectEye(input: {
   await ensureProjectEyesTable();
   const parsed = parseEyeImage(input.image);
   if (!parsed) throw new Error("imagen inválida");
+  const source = (input.source || "plugin").slice(0, 40);
+  const viewport = input.viewport?.slice(0, 40) || null;
   const row = await queryOne<ProjectEye>(
     `INSERT INTO project_eyes (project_id, source, viewport, url, selector, note, mime_type, data_b64)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
      RETURNING id::text, project_id, source, viewport, url, selector, note, mime_type, data_b64, created_at::text`,
     [
       input.projectId,
-      (input.source || "plugin").slice(0, 40),
-      input.viewport?.slice(0, 40) || null,
+      source,
+      viewport,
       input.url?.slice(0, 500) || null,
       input.selector?.slice(0, 300) || null,
       input.note?.slice(0, 500) || null,
@@ -66,26 +68,58 @@ export async function saveProjectEye(input: {
     ],
   );
   if (!row) throw new Error("no se guardó la foto");
-  await sql`
-    DELETE FROM project_eyes
-     WHERE project_id = ${input.projectId}
-       AND id NOT IN (
-         SELECT id FROM project_eyes WHERE project_id = ${input.projectId}
-         ORDER BY created_at DESC LIMIT ${KEEP}
-       )
-  `;
+  if (source === "visor" && viewport) {
+    await sql`
+      DELETE FROM project_eyes
+       WHERE project_id = ${input.projectId}
+         AND source = 'visor'
+         AND viewport = ${viewport}
+         AND id <> ${row.id}::uuid
+    `;
+  } else if (source !== "visor") {
+    await sql`
+      DELETE FROM project_eyes
+       WHERE project_id = ${input.projectId}
+         AND source <> 'visor'
+         AND id NOT IN (
+           SELECT id FROM project_eyes
+            WHERE project_id = ${input.projectId}
+              AND source <> 'visor'
+            ORDER BY created_at DESC
+            LIMIT ${KEEP_PLUGIN}
+         )
+    `;
+  }
   return row;
 }
 
 export async function listProjectEyes(projectId: string, limit = 4): Promise<ProjectEye[]> {
   await ensureProjectEyesTable();
-  const cap = Math.min(KEEP, Math.max(1, Math.floor(limit)));
+  const cap = Math.min(KEEP_PLUGIN, Math.max(1, Math.floor(limit)));
   return queryAll<ProjectEye>(
     `SELECT id::text, project_id, source, viewport, url, selector, note, mime_type, data_b64, created_at::text
        FROM project_eyes
       WHERE project_id = $1
+        AND source <> 'visor'
       ORDER BY created_at DESC
       LIMIT $2`,
     [projectId, cap],
   ).catch(() => []);
+}
+
+export async function listVisorEyes(projectId: string): Promise<ProjectEye[]> {
+  await ensureProjectEyesTable();
+  const rows = await queryAll<ProjectEye>(
+    `SELECT DISTINCT ON (viewport)
+            id::text, project_id, source, viewport, url, selector, note, mime_type, data_b64, created_at::text
+       FROM project_eyes
+      WHERE project_id = $1
+        AND source = 'visor'
+      ORDER BY viewport, created_at DESC`,
+    [projectId],
+  ).catch(() => []);
+  const order = ["desktop", "mobile", "admin"];
+  return [...rows].sort(
+    (a, b) => order.indexOf(a.viewport || "") - order.indexOf(b.viewport || ""),
+  );
 }

--- a/lib/live/project-tools.ts
+++ b/lib/live/project-tools.ts
@@ -161,6 +161,6 @@ export function mcpClientConfig(input: { name: string; url: string }): {
 export function roomToolsBrief(): string {
   return [
     "HERRAMIENTAS DE LA SALA: Vercel (deploys, promover, redeploy, dominios, env sin valores), integraciones, bóveda cifrada y MCP por app.",
-    "MCP: toda app debe tener su MCP. Incluye vforge_project_see (Navegador Pro + plugin Chrome que sí manda la foto). Sugiérelo y explica cómo pegarlo en Claude, Cursor o Grok. No uses n8n.",
+    "MCP: toda app debe tener su MCP. Incluye vforge_project_see (fotografía cada visor y lo guarda en documentos). Sugiérelo. No uses n8n.",
   ].join(" ");
 }

--- a/lib/live/see-page.ts
+++ b/lib/live/see-page.ts
@@ -21,6 +21,10 @@ export const SEE_VIEWPORTS = {
 
 export type SeeViewportId = keyof typeof SEE_VIEWPORTS;
 
+export function visorDocumentName(viewport: SeeViewportId): string {
+  return `visor-${viewport}.jpg`;
+}
+
 export interface SeeShot {
   viewport: SeeViewportId;
   label: string;
@@ -349,6 +353,7 @@ export function mcpSeeResult(
       return `• ${shot.label} ${size.width}×${size.height} (${engineLabel(shot.engine)}) — ${shot.url}`;
     }),
     ...result.failures.map((item) => `• ${item.label} no se vio: ${item.error}`),
+    "Las fotos quedan en documentos de la sala. vforge_project_context las lee.",
   ];
   return {
     content: [

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -122,7 +122,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   {
     name: "vforge_project_see",
     description:
-      "OJOS (admin|client): fotografía Escritorio/Móvil vía Navegador Pro (Chrome de Hetzner) y devuelve las imágenes. También incluye fotos del plugin de Chrome. Usa project_id y viewport=desktop|mobile|admin|all.",
+      "OJOS (admin|client): fotografía Escritorio/Móvil/Admin, guarda cada foto como documento de la sala y las devuelve. También incluye fotos del plugin de Chrome. Usa project_id y viewport=desktop|mobile|admin|all.",
     inputSchema: {
       type: "object",
       properties: {
@@ -556,7 +556,7 @@ VForge es una fábrica de aplicaciones operada por un agente (V): construye, des
    • URL:  https://vforge.site/api/mcp
    • Auth: Bearer <tu-token>
 4. Llama \`help\` para ver las tools, o \`vforge_method\` para el método.
-5. Para ver una sala: \`vforge_project_see\` con el project_id. Fotografía con Navegador Pro. Si hay plugin de Chrome, también manda esas fotos.
+5. Para ver una sala: \`vforge_project_see\` con el project_id. Fotografía cada visor y lo guarda en documentos. \`vforge_project_context\` las vuelve a leer.
 
 ## Scopes
 • Tu token te aísla a TU forge: sólo ves tus propios proyectos, pagos y apps.
@@ -589,9 +589,9 @@ function helpText(principal: McpPrincipal): string {
   lines.push("## De datos (requieren token admin|client; aisladas por tenant)");
   lines.push("• vforge_project_status — estado de tus proyectos.");
   lines.push("• vforge_project_feedback — observaciones y anclas de una sala.");
-  lines.push("• vforge_project_context — código, referencias (con contenido leído), CONTENIDO.md y archivos.");
+  lines.push("• vforge_project_context — código, referencias, CONTENIDO.md, archivos y fotos de los visores.");
   lines.push("• vforge_project_file — texto extraído de un ZIP privado, leído por fragmentos.");
-  lines.push("• vforge_project_see — ojos: Navegador Pro fotografía Escritorio/Móvil/Admin. Incluye fotos del plugin de Chrome.");
+  lines.push("• vforge_project_see — fotografía cada visor, lo guarda en documentos y lo devuelve. Incluye plugin Chrome.");
   lines.push("• vforge_navegador_see — ojos admin: fotografía la pestaña abierta del Chrome en Hetzner.");
   lines.push("• vforge_payments — avance financiero (total/pagado/pendiente).");
   lines.push("• vforge_apps_health — salud de despliegue de tus apps.");
@@ -926,7 +926,7 @@ export async function runMcpTool(
       const allowed = await authorizeMcpProject(projectId, principal);
       if (!allowed) return err("Proyecto no encontrado o sin acceso para este token MCP.");
 
-      const [project, integrations, repositories, document, assets, references] = await Promise.all([
+      const [project, integrations, repositories, document, assets, references, visors] = await Promise.all([
         queryOne<{
           id: string; name: string; description: string | null; github_repo: string | null;
           github_default_branch: string | null; github_url: string | null; vercel_url: string | null;
@@ -965,6 +965,7 @@ export async function runMcpTool(
             LIMIT 20`,
           [projectId],
         ).catch(() => []),
+        import("@/lib/live/project-eyes").then((mod) => mod.listVisorEyes(projectId)).catch(() => []),
       ]);
       if (!project) return err("Proyecto no encontrado.");
       const { readPublicPages } = await import("@/lib/live/load-page-text");
@@ -990,6 +991,11 @@ export async function runMcpTool(
             })
             .join("\n")
         : "• Sin URLs de referencia.";
+      const visorsText = visors.length
+        ? visors
+            .map((item) => `• ${item.note || item.viewport} · ${item.url || "sin url"} · ${item.created_at}`)
+            .join("\n")
+        : "• Sin fotos de visor todavía. Usa vforge_project_see o el botón Fotografiar visores.";
       const pagesText = !references.length
         ? "• No hay URLs que leer."
         : pages.length
@@ -1001,17 +1007,29 @@ export async function runMcpTool(
               })
               .join("\n\n")
           : "• No se pudo leer el HTML público de las referencias.";
-      return text(
-        `# Contexto — ${project.name} (${project.id})\n\n` +
-        `## Código y publicación\nEstado: ${project.status}\nRepo principal: ${project.github_repo ?? "sin repo"}\nRama principal: ${project.github_default_branch ?? "sin rama"}\nGitHub: ${project.github_url ?? "sin URL"}\nVercel: ${project.vercel_url ?? "sin URL"}\nDominio: ${project.domain ?? "sin dominio"}\nAuditoría: ${project.last_audit_score ?? "sin score"} · ${project.last_audit_at ?? "sin fecha"}\n\n` +
-        `## Grupo de repositorios\n${repositoriesText}\n\n` +
-        `## Integraciones\n${integrationsText}\n\n` +
-        `## URLs de referencia\n${referencesText}\n\n` +
-        `## Contenido leído de las URLs\n${pagesText}\n\n` +
-        `## CONTENIDO.md\n${document?.content?.trim() || project.description || "Sin contenido documentado todavía."}\n\n` +
-        `## Archivos privados\n${assetsText}\n\n` +
-        `Usa vforge_project_file con project_id + asset_id para leer el texto extraído. Usa vforge_project_feedback para las anotaciones. Usa vforge_project_see para fotografiar Escritorio/Móvil con Navegador Pro.`,
-      );
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `# Contexto — ${project.name} (${project.id})\n\n` +
+              `## Código y publicación\nEstado: ${project.status}\nRepo principal: ${project.github_repo ?? "sin repo"}\nRama principal: ${project.github_default_branch ?? "sin rama"}\nGitHub: ${project.github_url ?? "sin URL"}\nVercel: ${project.vercel_url ?? "sin URL"}\nDominio: ${project.domain ?? "sin dominio"}\nAuditoría: ${project.last_audit_score ?? "sin score"} · ${project.last_audit_at ?? "sin fecha"}\n\n` +
+              `## Grupo de repositorios\n${repositoriesText}\n\n` +
+              `## Integraciones\n${integrationsText}\n\n` +
+              `## URLs de referencia\n${referencesText}\n\n` +
+              `## Contenido leído de las URLs\n${pagesText}\n\n` +
+              `## CONTENIDO.md\n${document?.content?.trim() || project.description || "Sin contenido documentado todavía."}\n\n` +
+              `## Archivos privados\n${assetsText}\n\n` +
+              `## Visores (documentos)\n${visorsText}\n\n` +
+              `Usa vforge_project_file con project_id + asset_id para leer el texto extraído. Usa vforge_project_feedback para las anotaciones. Usa vforge_project_see para fotografiar los visores y guardarlos en documentos.`,
+          },
+          ...visors.map((item) => ({
+            type: "image",
+            data: item.data_b64,
+            mimeType: item.mime_type,
+          })),
+        ],
+      };
     }
 
     case "vforge_project_file": {
@@ -1046,14 +1064,15 @@ export async function runMcpTool(
       const allowed = await authorizeMcpProject(projectId, principal);
       if (!allowed) return err("Proyecto no encontrado o sin acceso para este token MCP.");
       const { getProjectViewports } = await import("@/lib/projects/live-portal");
-      const { captureSeeViewports, parseSeeViewports, mcpSeeResult } = await import(
+      const { captureSeeViewports, parseSeeViewports, mcpSeeResult, SEE_VIEWPORTS } = await import(
         "@/lib/live/see-page"
       );
-      const { listProjectEyes } = await import("@/lib/live/project-eyes");
+      const { listProjectEyes, listVisorEyes } = await import("@/lib/live/project-eyes");
+      const { persistVisorShots } = await import("@/lib/live/photograph-visors");
       const project = await getProjectViewports(projectId);
       if (!project) return err("Proyecto no encontrado.");
       const viewports = parseSeeViewports(args.viewport ?? args.viewports);
-      const [captured, pluginEyes] = await Promise.all([
+      const [captured, pluginEyes, storedVisors] = await Promise.all([
         captureSeeViewports({
           desktop_url: project.desktop_url,
           mobile_url: project.mobile_url,
@@ -1062,7 +1081,22 @@ export async function runMcpTool(
           preferCdp: isAdminScope,
         }),
         listProjectEyes(projectId, 4),
+        listVisorEyes(projectId),
       ]);
+      await persistVisorShots(projectId, captured.shots);
+      const seen = new Set(captured.shots.map((shot) => shot.viewport));
+      for (const eye of storedVisors) {
+        const viewport = eye.viewport === "mobile" || eye.viewport === "admin" ? eye.viewport : "desktop";
+        if (seen.has(viewport) || !viewports.includes(viewport)) continue;
+        captured.shots.push({
+          viewport,
+          label: SEE_VIEWPORTS[viewport].label,
+          url: eye.url || "",
+          mimeType: eye.mime_type,
+          data: eye.data_b64,
+        });
+        seen.add(viewport);
+      }
       for (const eye of pluginEyes) {
         captured.shots.push({
           viewport: "desktop",

--- a/tests/see-page.test.ts
+++ b/tests/see-page.test.ts
@@ -11,6 +11,7 @@ import {
   parseSeeViewports,
   parseEyeImage,
   shSingleQuote,
+  visorDocumentName,
 } from "../lib/live/see-page";
 import { buildCdpCurrentCommand, buildCdpNavigateCommand } from "../lib/live/see-cdp";
 
@@ -115,4 +116,11 @@ test("MCP result sends real image blocks, not a URL", () => {
   assert.equal(image?.data, png);
   assert.match(String(result.content[0]?.text), /Ojos de la sala/);
   assert.match(String(result.content[0]?.text), /Navegador Pro/);
+  assert.match(String(result.content[0]?.text), /documentos/);
+});
+
+test("visor documents are named per viewport", () => {
+  assert.equal(visorDocumentName("desktop"), "visor-desktop.jpg");
+  assert.equal(visorDocumentName("mobile"), "visor-mobile.jpg");
+  assert.equal(visorDocumentName("admin"), "visor-admin.jpg");
 });


### PR DESCRIPTION
## Qué
Una foto de Escritorio, Móvil y Admin se guarda como documento de la sala. El MCP las ve.

## Cómo
- Botón **Fotografiar visores** en Herramientas → MCP y en Contexto → Visores
- `vforge_project_see` persiste cada captura (source `visor`, una por viewport)
- `vforge_project_context` devuelve esas fotos como bloques imagen, no texto
- El plugin sigue aparte; no se borra al guardar visores

## Checks
- `tsc --noEmit`
- eslint 0
- `npm test` 77/77

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds long-running server-side URL capture, stores large base64 images in the DB, and expands MCP context responses with embedded screenshots—auth is gated but payload size and infra dependency (relay/browser) increase blast radius.
> 
> **Overview**
> **Adds persisted viewport screenshots** (Escritorio, Móvil, Admin) as sala documents so MCP clients can reuse them, not only get ephemeral captures from `vforge_project_see`.
> 
> **Storage and API:** Visor shots save to `project_eyes` with `source: visor` (one row per viewport; plugin captures stay separate with their own retention). New `photographAndStoreVisors` drives capture + persist. `GET /api/live/.../eyes` now returns `eyes` plus `visors` (including base64 `data`). Live tools POST adds **`photograph-viewports`** (120s `maxDuration`); platform owners can prefer CDP for capture.
> 
> **UI:** **Fotografiar visores** in Herramientas → MCP and a new **Visores** tab under context; both load previews from `/eyes`.
> 
> **MCP:** `vforge_project_see` persists new shots and can fill gaps from stored visors; **`vforge_project_context`** lists visor documents and attaches **image** content blocks alongside the text summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d910fa3ecd9ee05818d8bd86cd03aea411a4f3ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->