### PR TITLE
fix(live): fotografiar visores contra el Chrome que sí existe

### DIFF
--- a/app/api/navegador/control/route.ts
+++ b/app/api/navegador/control/route.ts
@@ -11,7 +11,7 @@ import { NextResponse } from "next/server";
 
 const RELAY = "http://178.105.135.26";
 const SECRET = process.env.BRAIN_SECRET ?? "";
-const CONTAINER = "vulcano-browser";
+const CONTAINER = process.env.VULCANO_BROWSER_CONTAINER?.trim() || "vulcano-browser-luis";
 const CDP = "http://localhost:9222";
 
 type Action = "navigate" | "tabs" | "close" | "eval" | "click" | "type" | "read" | "screenshot";

--- a/lib/live/project-eyes.ts
+++ b/lib/live/project-eyes.ts
@@ -20,21 +20,27 @@ let ensured = false;
 
 export async function ensureProjectEyesTable(): Promise<void> {
   if (ensured) return;
-  await sql`
-    CREATE TABLE IF NOT EXISTS project_eyes (
-      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-      project_id text NOT NULL,
-      source text NOT NULL DEFAULT 'plugin',
-      viewport text,
-      url text,
-      selector text,
-      note text,
-      mime_type text NOT NULL DEFAULT 'image/jpeg',
-      data_b64 text NOT NULL,
-      created_at timestamptz DEFAULT now()
-    )
-  `;
-  await sql`CREATE INDEX IF NOT EXISTS idx_project_eyes_project ON project_eyes (project_id, created_at DESC)`;
+  try {
+    await sql`
+      CREATE TABLE IF NOT EXISTS project_eyes (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        project_id text NOT NULL,
+        source text NOT NULL DEFAULT 'plugin',
+        viewport text,
+        url text,
+        selector text,
+        note text,
+        mime_type text NOT NULL DEFAULT 'image/jpeg',
+        data_b64 text NOT NULL,
+        created_at timestamptz DEFAULT now()
+      )
+    `;
+    await sql`CREATE INDEX IF NOT EXISTS idx_project_eyes_project ON project_eyes (project_id, created_at DESC)`;
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code) : "";
+    if (code !== "23505") throw error;
+  }
   ensured = true;
 }
 

--- a/lib/live/see-cdp.ts
+++ b/lib/live/see-cdp.ts
@@ -2,7 +2,8 @@
  * Ojos vía Navegador Pro (Chrome vivo en Hetzner, CDP :9222).
  * Abre pestaña nueva, fotografía, cierra. No usa el perfil aislado.
  */
-export const CDP_CONTAINER = "vulcano-browser";
+export const CDP_CONTAINER =
+  process.env.VULCANO_BROWSER_CONTAINER?.trim() || "vulcano-browser-luis";
 
 export function quoteArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;

--- a/lib/live/see-page.ts
+++ b/lib/live/see-page.ts
@@ -2,13 +2,13 @@
  * Ojos de la sala: Navegador Pro (CDP del Chrome vivo en Hetzner) primero.
  * Si CDP falla, Chrome aislado. El plugin de Chrome sube fotos aparte.
  */
-import { buildCdpCurrentCommand, buildCdpNavigateCommand } from "./see-cdp";
+import { buildCdpCurrentCommand, buildCdpNavigateCommand, CDP_CONTAINER } from "./see-cdp";
 
 const RELAY = (process.env.VULCANO_RELAY_URL || "http://178.105.135.26").replace(
   /\/$/,
   "",
 );
-const CONTAINER = "vulcano-browser";
+const CONTAINER = CDP_CONTAINER;
 const CAPTURE_TIMEOUT_MS = 25_000;
 const CDP_TIMEOUT_MS = 40_000;
 const MAX_BASE64_CHARS = 1_800_000;

--- a/tests/see-page.test.ts
+++ b/tests/see-page.test.ts
@@ -40,7 +40,7 @@ test("host command keeps the url quoted and never interpolates it raw", () => {
     height: 900,
     mobile: false,
   });
-  assert.match(cmd, /docker exec -i vulcano-browser bash -s --/);
+  assert.match(cmd, /docker exec -i vulcano-browser-luis bash -s --/);
   assert.match(cmd, new RegExp(shSingleQuote(url).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.equal(cmd.includes(" user:pass"), false);
   assert.equal(cmd.includes("$(rm"), false);
@@ -49,7 +49,7 @@ test("host command keeps the url quoted and never interpolates it raw", () => {
 test("Navegador Pro CDP opens a new tab, screenshots, and quotes the url", () => {
   const url = "https://netmas.mx/app?x=1&y=2";
   const cmd = buildCdpNavigateCommand({ url, width: 1440, height: 900, mobile: false });
-  assert.match(cmd, /docker exec -i vulcano-browser python3 -/);
+  assert.match(cmd, /docker exec -i vulcano-browser-luis python3 -/);
   const b64 = cmd.match(/echo ([A-Za-z0-9+/=]+) /)?.[1] || "";
   const py = Buffer.from(b64, "base64").toString("utf8");
   assert.match(py, /Page.captureScreenshot/);


### PR DESCRIPTION
## Por qué no funcionaba
1. Al abrir la sala, Herramientas y Contexto pegan dos GET /eyes. CREATE TABLE IF NOT EXISTS se pisa (23505).
2. El código hacía docker exec vulcano-browser. Ese contenedor no existe. El real es vulcano-browser-luis. CDP 9222 está vivo ahí (Chrome 138).

## Checks
tsc, eslint, npm test 77/77

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cambia el destino de `docker exec` y CDP en producción (mal configurado apunta al contenedor equivocado) y relaja errores al crear `project_eyes`, aunque solo para duplicados de DDL.
> 
> **Overview**
> Corrige por qué fallaban las capturas de visores y a veces el arranque de **project_eyes** al abrir la sala.
> 
> El nombre del contenedor Docker para **Navegador Pro** / CDP deja de ser `vulcano-browser` fijo: pasa a **`VULCANO_BROWSER_CONTAINER`** con fallback **`vulcano-browser-luis`**, centralizado en `see-cdp` y reutilizado en control del navegador, comandos `docker exec` de captura y tests.
> 
> **`ensureProjectEyesTable`** envuelve el `CREATE TABLE` / índice en `try/catch` y **ignora el error Postgres `23505`**, para que dos peticiones concurrentes (p. ej. doble GET `/eyes`) no revienten si chocan al crear el esquema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d718386e55fc5ecc6bcb8590801178cb388fe33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->