### PR TITLE
feat(live): invitación por WhatsApp sin correo

### DIFF
--- a/app/api/live/[projectId]/invitations/route.ts
+++ b/app/api/live/[projectId]/invitations/route.ts
@@ -6,7 +6,8 @@
  * 404 (no revela existencia).
  *
  *   GET  → lista invitaciones (sin token ni hash).
- *   POST → crea una invitación segura. Body { email, role?, ttlHours? }.
+ *   POST → crea una invitación. Body { email?, role?, ttlHours? }.
+ *          Sin correo = enlace abierto (WhatsApp). Con correo = un solo uso.
  *          Devuelve el token en claro UNA sola vez + el link de aceptación.
  */
 import { NextRequest, NextResponse } from "next/server";
@@ -59,8 +60,12 @@ export async function POST(
   }
   const { email, role, ttlHours } = body as Record<string, unknown>;
 
-  if (typeof email !== "string" || !EMAIL_RE.test(email.trim()) || email.length > 254) {
-    return NextResponse.json({ error: "invalid_email" }, { status: 400, headers: noStore });
+  let cleanEmail: string | null = null;
+  if (typeof email === "string" && email.trim()) {
+    if (!EMAIL_RE.test(email.trim()) || email.length > 254) {
+      return NextResponse.json({ error: "invalid_email" }, { status: 400, headers: noStore });
+    }
+    cleanEmail = email.trim();
   }
   // Solo se puede invitar como observer o reviewer. `owner` (u cualquier valor
   // inválido) se RECHAZA con 400 — nunca se degrada silenciosamente. Ausente ⇒
@@ -79,7 +84,7 @@ export async function POST(
   try {
     const { invitation, token } = await createInvitation({
       projectId,
-      email: email.trim(),
+      email: cleanEmail,
       role: cleanRole,
       invitedBy: access.email,
       ttlHours: cleanTtl,

--- a/components/live/InvitePanel.tsx
+++ b/components/live/InvitePanel.tsx
@@ -9,6 +9,7 @@ import {
   IconUsers,
 } from "@/components/brand/VFIcons";
 import type { LiveRole } from "@/lib/projects/roles";
+import { isOpenInviteEmail } from "@/lib/projects/roles";
 
 interface Invitation {
   id: string;
@@ -35,16 +36,27 @@ const ROLES: { value: LiveRole; label: string; description: string }[] = [
 
 function invitationState(invitation: Invitation) {
   if (invitation.revoked_at) return "Revocada";
-  if (invitation.accepted_at) return "Aceptada";
+  if (invitation.accepted_at && !isOpenInviteEmail(invitation.email)) return "Aceptada";
   if (new Date(invitation.expires_at).getTime() <= Date.now()) return "Expirada";
-  return "Pendiente";
+  return isOpenInviteEmail(invitation.email) ? "Activo" : "Pendiente";
+}
+
+function invitationLabel(invitation: Invitation) {
+  return isOpenInviteEmail(invitation.email) ? "Enlace WhatsApp" : invitation.email;
+}
+
+function whatsappShareUrl(link: string, projectName: string) {
+  const text = `Te invito a la sala de ${projectName} en VForge. Entra y, si no tienes cuenta, regístrate:\n${link}`;
+  return `https://wa.me/?text=${encodeURIComponent(text)}`;
 }
 
 export function InvitePanel({
   projectId,
+  projectName = "este proyecto",
   compact = false,
 }: {
   projectId: string;
+  projectName?: string;
   compact?: boolean;
 }) {
   const encodedProjectId = encodeURIComponent(projectId);
@@ -85,9 +97,10 @@ export function InvitePanel({
     void load();
   }, [load]);
 
-  async function createInvitation() {
+  async function createInvitation(openLink: boolean) {
+    if (busy) return;
     const trimmedEmail = email.trim();
-    if (!trimmedEmail || busy) return;
+    if (!openLink && !trimmedEmail) return;
     setBusy(true);
     setError(null);
     setLastLink(null);
@@ -97,7 +110,10 @@ export function InvitePanel({
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: trimmedEmail, role }),
+          body: JSON.stringify({
+            role,
+            ...(openLink ? {} : { email: trimmedEmail }),
+          }),
         },
       );
       const payload = (await response.json().catch(() => ({}))) as {
@@ -107,7 +123,7 @@ export function InvitePanel({
         setError("No se pudo crear la invitación.");
         return;
       }
-      setEmail("");
+      if (!openLink) setEmail("");
       setLastLink(payload.acceptUrl ?? null);
       await load();
     } catch {
@@ -138,7 +154,7 @@ export function InvitePanel({
           <div>
             <h2 className="text-[12px] font-medium">Invitar al proyecto</h2>
             <p className="mt-0.5 text-[10px] text-[var(--fg-muted)]">
-              El enlace se muestra una sola vez y respeta el alcance elegido.
+              Enlace para WhatsApp, sin correo. Al entrar se registran.
             </p>
           </div>
         </div>
@@ -147,18 +163,7 @@ export function InvitePanel({
         </span>
       </header>
 
-      <div className={compact ? "grid gap-3 px-4 py-4" : "grid gap-3 px-4 py-4 lg:grid-cols-[minmax(0,1fr)_190px_auto] lg:items-start"}>
-        <label>
-          <span className="mono-label">Correo del invitado</span>
-          <input
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            placeholder="cliente@empresa.com"
-            className="input-base mt-2"
-          />
-        </label>
-
+      <div className="grid gap-3 px-4 py-4">
         <label>
           <span className="mono-label">Alcance</span>
           <select
@@ -179,12 +184,32 @@ export function InvitePanel({
 
         <button
           type="button"
-          onClick={() => void createInvitation()}
-          disabled={busy || !email.trim()}
-          className={compact ? "btn-primary w-full disabled:opacity-40" : "btn-primary mt-[26px] disabled:opacity-40"}
+          onClick={() => void createInvitation(true)}
+          disabled={busy}
+          className="btn-primary w-full disabled:opacity-40"
         >
           {busy ? <IconLoader size={13} className="animate-spin" /> : <IconPlus size={13} />}
-          Crear invitación
+          Enlace para WhatsApp
+        </button>
+
+        <label>
+          <span className="mono-label">O un correo (un solo uso)</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="cliente@empresa.com"
+            className="input-base mt-2"
+          />
+        </label>
+
+        <button
+          type="button"
+          onClick={() => void createInvitation(false)}
+          disabled={busy || !email.trim()}
+          className="btn-ghost w-full disabled:opacity-40"
+        >
+          Invitar por correo
         </button>
       </div>
 
@@ -193,10 +218,20 @@ export function InvitePanel({
           <code className="min-w-0 flex-1 break-all font-mono text-[9px]">
             {lastLink}
           </code>
-          <button type="button" onClick={() => void copyLink()} className="btn-ghost shrink-0">
-            {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
-            {copied ? "Copiado" : "Copiar enlace"}
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button type="button" onClick={() => void copyLink()} className="btn-ghost shrink-0">
+              {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+              {copied ? "Copiado" : "Copiar"}
+            </button>
+            <a
+              href={whatsappShareUrl(lastLink, projectName)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-primary"
+            >
+              Abrir WhatsApp
+            </a>
+          </div>
         </div>
       ) : null}
 
@@ -227,14 +262,14 @@ export function InvitePanel({
                 key={invitation.id}
                 className={compact ? "grid grid-cols-[minmax(0,1fr)_70px_72px] items-center px-4 py-3 text-[10px]" : "grid grid-cols-[minmax(0,1fr)_90px_90px] items-center px-4 py-3 text-[10px]"}
               >
-                <span className="truncate">{invitation.email}</span>
+                <span className="truncate">{invitationLabel(invitation)}</span>
                 <span className="font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
                   {ROLE_LABEL(invitation.role)}
                 </span>
                 <span className="flex items-center justify-end gap-1.5 font-mono text-[8px] uppercase tracking-[0.08em]">
                   <span
                     className="status-shape"
-                    data-active={invitationState(invitation) === "Aceptada"}
+                    data-active={invitationState(invitation) === "Aceptada" || invitationState(invitation) === "Activo"}
                   />
                   {invitationState(invitation)}
                 </span>

--- a/components/live/LiveGate.tsx
+++ b/components/live/LiveGate.tsx
@@ -31,6 +31,11 @@ export function LiveGate({ projectId }: { projectId: string }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ token: t }),
         });
+        if (res.status === 401) {
+          const next = `${window.location.pathname}${window.location.search}`;
+          window.location.assign(`/sign-in?redirect_url=${encodeURIComponent(next)}`);
+          return;
+        }
         if (res.ok) {
           setState("accepted");
           // Limpia el token de la URL y recarga con acceso ya concedido.

--- a/components/live/LivePortal.tsx
+++ b/components/live/LivePortal.tsx
@@ -273,7 +273,7 @@ export function LivePortal({
             >
               <IconX size={12} />
             </button>
-            <InvitePanel projectId={project.id} compact />
+            <InvitePanel projectId={project.id} projectName={project.name} compact />
           </aside>
         </div>
       ) : null}

--- a/components/live/LivePortalMobileEntry.tsx
+++ b/components/live/LivePortalMobileEntry.tsx
@@ -100,7 +100,7 @@ export function LivePortalMobileEntry({
               </Link>
               {canInvite ? (
                 <div id="invite">
-                  <InvitePanel projectId={project.id} compact />
+                  <InvitePanel projectId={project.id} projectName={project.name} compact />
                 </div>
               ) : null}
             </div>

--- a/lib/projects/live-portal.ts
+++ b/lib/projects/live-portal.ts
@@ -11,6 +11,7 @@ import { queryOne, queryAll } from "@/lib/db/client";
 import {
   type LiveRole,
   isLiveRole,
+  OPEN_INVITE_EMAIL,
 } from "@/lib/projects/roles";
 import {
   generateInviteToken,
@@ -87,7 +88,7 @@ export interface CreatedInvitation {
  */
 export async function createInvitation(args: {
   projectId: string;
-  email: string;
+  email?: string | null;
   role: LiveRole;
   invitedBy: string | null;
   ttlHours?: number;
@@ -97,7 +98,8 @@ export async function createInvitation(args: {
     Math.max(1, Math.floor(args.ttlHours ?? INVITE_DEFAULT_TTL_HOURS)),
   );
   const { token, tokenHash } = generateInviteToken();
-  const email = args.email.trim().toLowerCase();
+  const trimmed = (args.email ?? "").trim().toLowerCase();
+  const email = trimmed || OPEN_INVITE_EMAIL;
 
   const invitation = await queryOne<InvitationSummary>(
     `INSERT INTO project_live_invitations
@@ -138,12 +140,15 @@ export async function acceptInvitation(args: {
   const row = await queryOne<{ project_id: string; role: string }>(
     `WITH claimed AS (
         UPDATE project_live_invitations
-           SET accepted_at = now(), accepted_by = $3
+           SET accepted_at = CASE WHEN email = '*' THEN accepted_at ELSE now() END,
+               accepted_by = CASE WHEN email = '*' THEN COALESCE(accepted_by, $3) ELSE $3 END
          WHERE token_hash = $1
-           AND accepted_at IS NULL
            AND revoked_at IS NULL
            AND expires_at > now()
-           AND lower(email) = $2
+           AND (
+             email = '*'
+             OR (accepted_at IS NULL AND lower(email) = $2)
+           )
         RETURNING project_id, role, invited_by
      ),
      membership AS (

--- a/lib/projects/roles.ts
+++ b/lib/projects/roles.ts
@@ -95,6 +95,13 @@ export interface InvitationRow {
   revoked_at?: string | Date | null;
 }
 
+export const OPEN_INVITE_EMAIL = "*";
+
+export function isOpenInviteEmail(email: string | null | undefined): boolean {
+  const value = (email ?? "").trim().toLowerCase();
+  return value === OPEN_INVITE_EMAIL || value === "open";
+}
+
 export type InvitationCheck =
   | { ok: true; role: LiveRole }
   | { ok: false; reason: "expired" | "used" | "revoked" | "email_mismatch" | "invalid" };
@@ -110,7 +117,8 @@ export function checkInvitation(
 ): InvitationCheck {
   if (!row || !isLiveRole(row.role)) return { ok: false, reason: "invalid" };
   if (row.revoked_at != null) return { ok: false, reason: "revoked" };
-  if (row.accepted_at != null) return { ok: false, reason: "used" };
+  const open = isOpenInviteEmail(row.email);
+  if (row.accepted_at != null && !open) return { ok: false, reason: "used" };
 
   const exp = row.expires_at instanceof Date
     ? row.expires_at
@@ -119,10 +127,13 @@ export function checkInvitation(
     return { ok: false, reason: "expired" };
   }
 
-  const invited = (row.email ?? "").trim().toLowerCase();
   const session = (sessionEmail ?? "").trim().toLowerCase();
-  if (!invited || !session || invited !== session) {
-    return { ok: false, reason: "email_mismatch" };
+  if (!session) return { ok: false, reason: "invalid" };
+  if (!open) {
+    const invited = (row.email ?? "").trim().toLowerCase();
+    if (!invited || invited !== session) {
+      return { ok: false, reason: "email_mismatch" };
+    }
   }
 
   return { ok: true, role: row.role };

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -93,6 +93,21 @@ test("checkInvitation: happy path", () => {
   assert.deepEqual(r, { ok: true, role: "reviewer" });
 });
 
+test("checkInvitation: open WhatsApp link binds to whoever registers", () => {
+  const r = checkInvitation(
+    { role: "observer", email: "*", expires_at: future, accepted_at: null },
+    "nuevo@cliente.com",
+    NOW,
+  );
+  assert.deepEqual(r, { ok: true, role: "observer" });
+  const stillOpen = checkInvitation(
+    { role: "observer", email: "*", expires_at: future, accepted_at: future },
+    "otro@cliente.com",
+    NOW,
+  );
+  assert.deepEqual(stillOpen, { ok: true, role: "observer" });
+});
+
 test("checkInvitation: email mismatch", () => {
   const r = checkInvitation(
     { role: "reviewer", email: "a@test.com", expires_at: future, accepted_at: null },


### PR DESCRIPTION
## Qué
Enlace con token para pegar en WhatsApp. No pide el correo del invitado.

Al abrir el link: si no hay cuenta, Clerk pide registro. Luego entra a la sala.

El enlace abierto dura 7 días y lo pueden usar varios. El correo específico sigue siendo de un solo uso.

## Checks
tsc, eslint, npm test 78/78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes project access provisioning (invite create/accept SQL and validation); open links are shareable until expiry, which widens who can join if the token leaks.
> 
> **Overview**
> Adds **open invite links** for the live portal so owners can share a token URL (e.g. via WhatsApp) without collecting the guest’s email first. **POST** `/api/live/[projectId]/invitations` now treats `email` as optional: omitting it creates a multi-use link stored with sentinel `*`; a valid email still creates a single-use invite.
> 
> **Acceptance** logic distinguishes the two modes: `checkInvitation` skips email match and “already used” for open invites; `acceptInvitation` no longer marks `accepted_at` on `*` rows so the same link can onboard multiple sign-ups until expiry. Unauthenticated visitors hitting an invite link are sent to **sign-in** with `redirect_url` preserving `?invite=`.
> 
> **InvitePanel** prioritizes “Enlace para WhatsApp” (copy + `wa.me` share with project name), keeps email invites as a secondary path, and lists open invites as “Enlace WhatsApp” / **Activo** instead of one-shot pending/accepted states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 450700e3e09972b39439ff243f8a8212b197e085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->