### PR TITLE
feat(live): consola en vivo para Grok

### DIFF
--- a/app/api/live/[projectId]/runs/[runId]/route.ts
+++ b/app/api/live/[projectId]/runs/[runId]/route.ts
@@ -2,11 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryOne } from "@/lib/db/client";
 import {
   authorizeAgentRunAccess,
+  buildAgentPrompt,
   ensureProjectAgentRunsTable,
+  type AgentQueueJob,
   type AgentRunRow,
 } from "@/lib/live/agent-runs";
+import { isLiveRunStatus } from "@/lib/live/run-console";
 import { parseRepoFullName, withUserGithub } from "@/lib/live/github-user";
 import { recordProjectDecision } from "@/lib/live/load-project-memory";
+import { dispatchJob } from "@/lib/vulcano/operator";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -38,6 +42,7 @@ export async function PATCH(
   if (!run) return json({ error: "not_found" }, 404);
   const payload = (await req.json().catch(() => null)) as {
     action?: string;
+    message?: string;
   } | null;
   const action = payload?.action;
 
@@ -166,6 +171,57 @@ export async function PATCH(
             caught instanceof Error
               ? caught.message.slice(0, 300)
               : "github_error",
+        },
+        502,
+      );
+    }
+  }
+
+  if (action === "nudge") {
+    const message =
+      typeof payload?.message === "string"
+        ? payload.message.trim().slice(0, 4000)
+        : "";
+    if (message.length < 2) return json({ error: "invalid_nudge" }, 400);
+    if (!isLiveRunStatus(run.status)) return json({ error: "run_idle" }, 409);
+    const agent =
+      run.resolved_executor === "claude" || run.resolved_executor === "codex"
+        ? run.resolved_executor
+        : "grok";
+    try {
+      const dispatched = await dispatchJob({
+        agent,
+        prompt: buildAgentPrompt({
+          runId,
+          projectId,
+          repo: run.repo_full_name,
+          baseBranch: run.base_branch,
+          workBranch: run.work_branch,
+          instruction: `CONTINUACIÓN EN VIVO. El owner te habla desde la sala:\n${message}`,
+          role: "builder",
+        }),
+        priority: 2,
+        source: `vforge:${projectId}:${runId}:${access.identity.userId}`,
+      });
+      const jobs = Array.isArray(run.queue_jobs) ? run.queue_jobs : [];
+      const nextJobs: AgentQueueJob[] = [
+        ...jobs,
+        { id: dispatched.id, agent, role: "builder" },
+      ];
+      const updated = await queryOne<AgentRunRow>(
+        `UPDATE project_agent_runs
+            SET queue_jobs = $1::jsonb, status = 'queued', phase = 'building', updated_at = now()
+          WHERE id = $2 RETURNING *`,
+        [JSON.stringify(nextJobs), runId],
+      );
+      return json({ run: updated });
+    } catch (caught) {
+      return json(
+        {
+          error:
+            caught instanceof Error
+              ? caught.message.slice(0, 300)
+              : "nudge_failed",
         },
         502,
       );

--- a/components/live/RunLiveConsole.tsx
+++ b/components/live/RunLiveConsole.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  formatElapsed,
+  isLiveRunStatus,
+  runnerWaitCopy,
+} from "@/lib/live/run-console";
+import { IconLoader, IconSend } from "@/components/brand/VFIcons";
+
+interface QueueJobRef {
+  id: number;
+  agent: string;
+  role: string;
+}
+
+interface QueueJob {
+  id: number;
+  agent: string | null;
+  status: string;
+  progress: number | null;
+  result: string | null;
+  logTail: string | null;
+}
+
+export function RunLiveConsole({
+  createdAt,
+  status,
+  jobs,
+  jobRefs,
+  canWrite,
+  busy,
+  onNudge,
+}: {
+  createdAt: string;
+  status: string;
+  jobs: Map<number, QueueJob>;
+  jobRefs: QueueJobRef[];
+  canWrite: boolean;
+  busy: boolean;
+  onNudge: (message: string) => Promise<void>;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+  const [nudge, setNudge] = useState("");
+  const scroller = useRef<HTMLDivElement>(null);
+  const live = isLiveRunStatus(status);
+  const started = new Date(createdAt).getTime();
+  const elapsed = Number.isFinite(started) ? now - started : 0;
+
+  const log = useMemo(() => {
+    const chunks = jobRefs.flatMap((ref) => {
+      const job = jobs.get(ref.id);
+      const body = (job?.logTail || job?.result || "").trim();
+      if (!body) return [];
+      return [`▸ ${ref.agent} · ${ref.role}\n${body}`];
+    });
+    return chunks.join("\n\n");
+  }, [jobRefs, jobs]);
+
+  const wait = runnerWaitCopy(elapsed, Boolean(log));
+  const progress = jobRefs.reduce((max, ref) => {
+    const value = jobs.get(ref.id)?.progress;
+    return value == null ? max : Math.max(max, value);
+  }, 0);
+
+  useEffect(() => {
+    if (!live) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [live]);
+
+  useEffect(() => {
+    scroller.current?.scrollTo({ top: scroller.current.scrollHeight });
+  }, [log, wait]);
+
+  async function sendNudge(event: React.FormEvent) {
+    event.preventDefault();
+    const text = nudge.trim();
+    if (!text || busy || !live) return;
+    await onNudge(text);
+    setNudge("");
+  }
+
+  return (
+    <section className="overflow-hidden rounded-[8px] border border-black bg-black text-white">
+      <header className="flex items-center justify-between gap-3 border-b border-white/15 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${live ? "animate-pulse bg-white" : "bg-white/40"}`}
+          />
+          <p className="font-mono text-[8px] uppercase tracking-[0.14em]">
+            Consola · {live ? "en vivo" : status}
+          </p>
+        </div>
+        <p className="font-mono text-[8px] uppercase tracking-[0.12em] text-white/55">
+          {formatElapsed(elapsed)}
+          {progress > 0 ? ` · ${Math.round(progress)}%` : ""}
+        </p>
+      </header>
+      <div
+        ref={scroller}
+        className="max-h-[280px] min-h-[180px] overflow-auto px-3 py-3 font-mono text-[11px] leading-5"
+      >
+        {log ? (
+          <pre className="whitespace-pre-wrap text-white/90">{log}</pre>
+        ) : (
+          <p className="text-white/55">{wait}</p>
+        )}
+        {live ? (
+          <span className="mt-2 inline-block h-3 w-1.5 animate-pulse bg-white" />
+        ) : null}
+      </div>
+      {canWrite && live ? (
+        <form
+          onSubmit={(event) => void sendNudge(event)}
+          className="flex items-center gap-2 border-t border-white/15 px-2 py-2"
+        >
+          <span className="pl-1 font-mono text-[11px] text-white/40">›</span>
+          <input
+            value={nudge}
+            onChange={(event) => setNudge(event.target.value)}
+            maxLength={4000}
+            placeholder="Háblale a Grok mientras trabaja…"
+            className="min-h-9 flex-1 bg-transparent text-[12px] text-white outline-none placeholder:text-white/35"
+          />
+          <button
+            type="submit"
+            disabled={busy || nudge.trim().length < 2}
+            className="grid h-8 w-8 place-items-center rounded-md border border-white/20 disabled:opacity-30"
+            aria-label="Enviar a Grok"
+          >
+            {busy ? (
+              <IconLoader size={12} className="animate-spin" />
+            ) : (
+              <IconSend size={12} />
+            )}
+          </button>
+        </form>
+      ) : null}
+    </section>
+  );
+}

--- a/components/live/VControlPanel.tsx
+++ b/components/live/VControlPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { VConversationPanel } from "@/components/live/VConversationPanel";
+import { RunLiveConsole } from "@/components/live/RunLiveConsole";
 import { repositoryGroupLabel } from "@/lib/projects/repository-groups";
 import {
   IconBranch,
@@ -175,7 +176,7 @@ export function VControlPanel({
 
   useEffect(() => {
     void load();
-    const timer = window.setInterval(() => void load(), 3000);
+    const timer = window.setInterval(() => void load(), 1500);
     return () => window.clearInterval(timer);
   }, [load]);
 
@@ -271,6 +272,36 @@ export function VControlPanel({
     }
   }
 
+  async function nudgeRun(message: string) {
+    if (!selected || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/live/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(selected.id)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "nudge", message }),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!response.ok)
+        throw new Error(payload?.error || "Grok no recibió el mensaje.");
+      await load();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Grok no recibió el mensaje.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-white">
       <header className="flex min-h-12 shrink-0 items-center justify-between gap-3 border-b border-[var(--border-1)] px-3">
@@ -289,7 +320,7 @@ export function VControlPanel({
         </div>
         <div className="flex items-center gap-2">
           <span className="hidden items-center gap-1.5 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)] sm:flex">
-            <span className="status-shape" data-active /> sincronización 3 s
+            <span className="status-shape" data-active /> sincronización 1.5 s
           </span>
           <button
             type="button"
@@ -544,6 +575,16 @@ export function VControlPanel({
                       </p>
                     </div>
                   </section>
+
+                  <RunLiveConsole
+                    createdAt={selected.created_at}
+                    status={selected.status}
+                    jobs={jobMap}
+                    jobRefs={selected.queue_jobs}
+                    canWrite={canWrite}
+                    busy={busy}
+                    onNudge={nudgeRun}
+                  />
 
                   <section className="rounded-[8px] border border-[var(--border-1)] bg-white">
                     <header className="border-b border-[var(--border-1)] px-3 py-2">

--- a/lib/live/run-console.ts
+++ b/lib/live/run-console.ts
@@ -1,0 +1,24 @@
+/** Copy honesta cuando el runner aún no escribe log. No finge voz de Grok. */
+export function runnerWaitCopy(elapsedMs: number, hasLog: boolean): string | null {
+  if (hasLog) return null;
+  if (elapsedMs < 8_000) return "En cola de Vulcano. Grok aún no escribe.";
+  if (elapsedMs < 25_000) return "Sigue en cola. El daemon no ha soltado log.";
+  return "El runner no ha escrito nada. Si pasa de un minuto, Grok no tomó el job.";
+}
+
+export function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  if (minutes <= 0) return `${seconds}s`;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+export function isLiveRunStatus(status: string): boolean {
+  return (
+    status === "preparing" ||
+    status === "queued" ||
+    status === "running" ||
+    status === "awaiting_preview"
+  );
+}

--- a/tests/factory-spine.test.ts
+++ b/tests/factory-spine.test.ts
@@ -13,6 +13,11 @@ import {
 } from "../lib/forge/cerebras-usage";
 import { modeSystemRules, providersForMode } from "../lib/forge/ask-v-policy";
 import { repositoryGroupLabel } from "../lib/projects/repository-groups";
+import {
+  formatElapsed,
+  isLiveRunStatus,
+  runnerWaitCopy,
+} from "../lib/live/run-console";
 
 test("V stays on Cerebras and names itself translator", () => {
   assert.equal(providersForMode("talk")[0].provider, "cerebras");
@@ -84,4 +89,14 @@ test("decision log and repo labels stay compact", () => {
     repositoryGroupLabel("turbillon50/apsus-web", "frontend", true),
     "Frontend · turbillon50/apsus-web · principal",
   );
+});
+
+test("live console wait copy is honest and timed", () => {
+  assert.equal(runnerWaitCopy(1000, true), null);
+  assert.match(runnerWaitCopy(1000, false) ?? "", /cola/);
+  assert.match(runnerWaitCopy(30_000, false) ?? "", /no tomó/);
+  assert.equal(formatElapsed(4500), "4s");
+  assert.equal(formatElapsed(125_000), "2m 05s");
+  assert.equal(isLiveRunStatus("running"), true);
+  assert.equal(isLiveRunStatus("published"), false);
 });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -30,6 +30,7 @@
     "lib/live/read-page.ts",
     "lib/live/project-tools.ts",
     "lib/live/see-page.ts",
-    "lib/live/see-cdp.ts"
+    "lib/live/see-cdp.ts",
+    "lib/live/run-console.ts"
   ]
 }


### PR DESCRIPTION
## Qué
Ejecución deja de ser un circuito muerto. Consola negra, log, tiempo, y un prompt para hablarle a Grok mientras trabaja.

## Checks
tsc, eslint, npm test 79/79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> El nudge encola trabajo real del agente en sandbox y muta estado del run; está acotado por auth de escritura y validación de estado, pero amplía la superficie de ejecución remota.
> 
> **Overview**
> Añade una **consola en vivo** en la cabina de ejecución (V): log agregado de jobs (`logTail`/`result`), tiempo transcurrido, progreso y mensajes de espera explícitos cuando el runner aún no escribe.
> 
> Los usuarios con permiso de escritura pueden **enviar un “nudge”** mientras el run está en estados activos (`preparing`, `queued`, `running`, `awaiting_preview`). El cliente llama `PATCH` con `action: "nudge"` y un mensaje (2–4000 caracteres); el servidor valida el estado, despacha un job nuevo vía Vulcano con un prompt de continuación en vivo, apila la referencia en `queue_jobs` y pone el run en `queued` / fase `building`.
> 
> La UI nueva (`RunLiveConsole`) se integra en `VControlPanel` y el polling de runs pasa de **3 s a 1.5 s** para refrescar la consola con más frecuencia. La lógica compartida vive en `lib/live/run-console.ts` con tests en `factory-spine`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d084bc6e0096914cbfad599eeac7b68efab62b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->