### PR TITLE
feat(live): aplicar a main sin preview

### DIFF
--- a/app/api/live/[projectId]/runs/[runId]/route.ts
+++ b/app/api/live/[projectId]/runs/[runId]/route.ts
@@ -61,47 +61,105 @@ export async function PATCH(
   if (!parsed) return json({ error: "invalid_repository" }, 409);
   const [owner, repo] = parsed;
 
-  if (action === "approve") {
-    if (
-      !run.preview_url ||
-      (run.status !== "preview_ready" && run.status !== "awaiting_approval")
-    ) {
-      return json({ error: "preview_required" }, 409);
-    }
+  if (action === "approve" || action === "apply") {
+    const ready =
+      run.status === "preview_ready" ||
+      run.status === "awaiting_approval" ||
+      run.status === "awaiting_preview" ||
+      run.status === "approved";
+    if (!ready) return json({ error: "not_ready" }, 409);
     try {
-      const pull = await withUserGithub(
+      let prNumber = run.pr_number;
+      let prUrl = run.pr_url;
+      if (!prNumber || !prUrl) {
+        const pull = await withUserGithub(
+          access.identity.userId,
+          async (github) => {
+            const created = await github.request(
+              "POST /repos/{owner}/{repo}/pulls",
+              {
+                owner,
+                repo,
+                title: `VForge: ${run.instruction.replace(/\s+/g, " ").slice(0, 90)}`,
+                head: run.work_branch,
+                base: run.base_branch,
+                body: `Run VForge ${run.id}\n\n${run.instruction}${run.preview_url ? `\n\nPreview: ${run.preview_url}` : ""}`,
+                draft: false,
+              },
+            );
+            return created.data;
+          },
+        );
+        if (!pull) return json({ error: "connect_github" }, 409);
+        prNumber = pull.number;
+        prUrl = pull.html_url;
+        await queryOne(
+          `UPDATE project_agent_runs
+              SET status = 'approved', pr_number = $1, pr_url = $2, approved_at = now(), updated_at = now()
+            WHERE id = $3`,
+          [prNumber, prUrl, runId],
+        );
+        await recordProjectDecision({
+          projectId,
+          kind: "approved",
+          summary: `Aprobado ${run.work_branch} → PR ${prUrl}`,
+          sourceId: runId,
+          email: access.identity.email,
+        }).catch(() => null);
+      }
+      if (action === "approve") {
+        const updated = await queryOne<AgentRunRow>(
+          `SELECT * FROM project_agent_runs WHERE id = $1 LIMIT 1`,
+          [runId],
+        );
+        return json({ run: updated });
+      }
+
+      const merged = await withUserGithub(
         access.identity.userId,
         async (github) => {
-          const created = await github.request(
-            "POST /repos/{owner}/{repo}/pulls",
+          const response = await github.request(
+            "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge",
             {
               owner,
               repo,
-              title: `VForge: ${run.instruction.replace(/\s+/g, " ").slice(0, 90)}`,
-              head: run.work_branch,
-              base: run.base_branch,
-              body: `Run VForge ${run.id}\n\n${run.instruction}\n\nPreview: ${run.preview_url}`,
-              draft: false,
+              pull_number: prNumber!,
+              merge_method: "squash",
+              commit_title: `VForge: ${run.instruction.replace(/\s+/g, " ").slice(0, 72)}`,
             },
           );
-          return created.data;
+          return response.data;
         },
       );
-      if (!pull) return json({ error: "connect_github" }, 409);
+      if (!merged) return json({ error: "connect_github" }, 409);
+      if (!merged.merged)
+        return json({ error: merged.message || "merge_blocked" }, 409);
       const updated = await queryOne<AgentRunRow>(
         `UPDATE project_agent_runs
-            SET status = 'approved', pr_number = $1, pr_url = $2, approved_at = now(), updated_at = now()
-          WHERE id = $3 RETURNING *`,
-        [pull.number, pull.html_url, runId],
+            SET status = 'published', phase = 'complete', published_at = now(), updated_at = now()
+          WHERE id = $1 RETURNING *`,
+        [runId],
       );
+      await queryOne(
+        `INSERT INTO project_events (project_id, event_type, details, severity)
+         VALUES ($1, 'agent.run.published', $2::jsonb, 'high')`,
+        [
+          projectId,
+          JSON.stringify({
+            message: `Run publicado: ${run.work_branch}`,
+            run_id: runId,
+            pr_url: prUrl,
+          }),
+        ],
+      ).catch(() => null);
       await recordProjectDecision({
         projectId,
-        kind: "approved",
-        summary: `Aprobado ${run.work_branch} → PR ${pull.html_url}`,
+        kind: "published",
+        summary: `Publicado ${run.work_branch}`,
         sourceId: runId,
         email: access.identity.email,
       }).catch(() => null);
-      return json({ run: updated });
+      return json({ run: updated, merged: true });
     } catch (caught) {
       return json(
         {

--- a/app/api/live/[projectId]/runs/route.ts
+++ b/app/api/live/[projectId]/runs/route.ts
@@ -202,7 +202,8 @@ async function advanceRun(
 
   await queryOne(
     `UPDATE project_agent_runs
-        SET phase = 'validation', status = CASE WHEN preview_url IS NULL THEN 'awaiting_preview' ELSE 'preview_ready' END,
+        SET phase = 'validation',
+            status = CASE WHEN preview_url IS NULL THEN 'awaiting_approval' ELSE 'preview_ready' END,
             summary = $1, updated_at = now()
       WHERE id = $2`,
     [result, run.id],

--- a/components/live/VControlPanel.tsx
+++ b/components/live/VControlPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { VConversationPanel } from "@/components/live/VConversationPanel";
 import { RunLiveConsole } from "@/components/live/RunLiveConsole";
+import { canApplyRun } from "@/lib/live/run-console";
 import { repositoryGroupLabel } from "@/lib/projects/repository-groups";
 import {
   IconBranch,
@@ -234,11 +235,11 @@ export function VControlPanel({
     await launchRun(instruction);
   }
 
-  async function runAction(action: "approve" | "publish" | "cancel") {
+  async function runAction(action: "approve" | "publish" | "cancel" | "apply") {
     if (!selected || busy) return;
     const message =
-      action === "publish"
-        ? "Esto fusionará el PR y activará producción. ¿Publicar ahora?"
+      action === "publish" || action === "apply"
+        ? "Esto fusionará a main. ¿Aplicar ahora?"
         : action === "cancel"
           ? "¿Cancelar este run? La rama se conservará para auditoría."
           : null;
@@ -679,11 +680,10 @@ export function VControlPanel({
                         <div>
                           <IconSparkles size={20} className="mx-auto" />
                           <p className="mt-3 text-[11px] font-medium">
-                            El preview aparecerá aquí
+                            El preview no es obligatorio
                           </p>
                           <p className="mt-2 max-w-xs text-[9px] leading-4 text-[var(--fg-muted)]">
-                            Cuando el agente haga push a la rama, Vercel enviará
-                            la URL a esta sala. Producción permanece intacta.
+                            Grok ya trabajó en la rama. Aplica a main sin esperar Vercel.
                           </p>
                         </div>
                       </div>
@@ -710,14 +710,24 @@ export function VControlPanel({
                           <IconExtLink size={11} /> PR
                         </a>
                       ) : null}
+                      {canWrite && canApplyRun(selected.status) ? (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => void runAction("apply")}
+                          className="btn-primary"
+                        >
+                          <IconRocket size={11} /> Aplicar
+                        </button>
+                      ) : null}
                       {canWrite && selected.status === "preview_ready" ? (
                         <button
                           type="button"
                           disabled={busy}
                           onClick={() => void runAction("approve")}
-                          className="btn-primary"
+                          className="btn-ghost"
                         >
-                          <IconCheck size={11} /> Aprobar y crear PR
+                          <IconCheck size={11} /> Sólo PR
                         </button>
                       ) : null}
                       {canWrite && selected.status === "approved" ? (

--- a/lib/live/run-console.ts
+++ b/lib/live/run-console.ts
@@ -14,6 +14,14 @@ export function formatElapsed(ms: number): string {
   return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
 }
 
+export function canApplyRun(status: string): boolean {
+  return (
+    status === "awaiting_preview" ||
+    status === "awaiting_approval" ||
+    status === "preview_ready"
+  );
+}
+
 export function isLiveRunStatus(status: string): boolean {
   return (
     status === "preparing" ||

--- a/tests/factory-spine.test.ts
+++ b/tests/factory-spine.test.ts
@@ -14,6 +14,7 @@ import {
 import { modeSystemRules, providersForMode } from "../lib/forge/ask-v-policy";
 import { repositoryGroupLabel } from "../lib/projects/repository-groups";
 import {
+  canApplyRun,
   formatElapsed,
   isLiveRunStatus,
   runnerWaitCopy,
@@ -99,4 +100,7 @@ test("live console wait copy is honest and timed", () => {
   assert.equal(formatElapsed(125_000), "2m 05s");
   assert.equal(isLiveRunStatus("running"), true);
   assert.equal(isLiveRunStatus("published"), false);
+  assert.equal(canApplyRun("awaiting_preview"), true);
+  assert.equal(canApplyRun("awaiting_approval"), true);
+  assert.equal(canApplyRun("running"), false);
 });


### PR DESCRIPTION
Grok DONE ya no se queda en Esperando preview. Botón Aplicar: PR + merge.

## Checks
tsc, eslint, npm test 79/79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a one-click path that squash-merges agent work into the default branch and marks runs published, directly affecting production Git history.
> 
> **Overview**
> **Live runs no longer block on a Vercel preview.** When Grok finishes without a `preview_url`, validation now lands in `awaiting_approval` instead of `awaiting_preview`.
> 
> **New `apply` PATCH action** (and shared PR logic with `approve`): eligible runs can open a GitHub PR if one does not exist, then **squash-merge** to the base branch, set status to `published`, and record project events/decisions. `approve` alone only creates or refreshes the PR and stops at `approved`; preview is no longer required for either path.
> 
> The control panel adds a primary **Aplicar** button (via `canApplyRun`), renames the old flow to **Sólo PR**, and updates empty-preview copy to say preview is optional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e750065130f07dc74e65720b8e53f99915bca786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->