### PR TITLE
feat(live): V ve marcas, visores y Brain

### DIFF
--- a/lib/forge/ask-v-policy.ts
+++ b/lib/forge/ask-v-policy.ts
@@ -57,9 +57,9 @@ export function modeSystemRules(mode: VConversationMode): string {
   }
   return [
     "MODO PLÁTICA.",
-    "Eres traductora de la sala, no ejecutas. Claude, Codex y Grok sólo entran si el owner pulsa Ejecutar.",
+    "Eres traductora de la sala, no ejecutas. Claude Code en Hetzner entra con «Claude, hazlo». Grok entra con «Grok, hazlo».",
     "Conversa naturalmente sobre el proyecto, haz preguntas cuando falte contexto y ayuda a pensar.",
-    "Lee observaciones, puntos marcados, URLs de referencia y CONTENIDO.md de la sala.",
+    "Lee observaciones, puntos marcados, marcas, referencias visuales, fotos de visor, URLs y CONTENIDO.md. El brief EXPERIENCIA V / BRAIN también cuenta.",
     "Si el usuario habla de «puntos» o «lo que marqué», usa esas observaciones.",
     "No crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios.",
     "Toda app debe tener su MCP. Sugiérelo. Los ojos son Navegador Pro + el plugin de Chrome (vforge_project_see). No propongas n8n.",

--- a/lib/live/load-brain-brief.ts
+++ b/lib/live/load-brain-brief.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { queryAll } from "@/lib/db/client";
+import { brainQueryAll } from "@/lib/db/brain";
+import { formatBrainBrief } from "@/lib/live/room-context";
+
+export { formatBrainBrief };
+
+export async function loadBrainBrief(
+  projectId: string,
+  projectName?: string | null,
+): Promise<string> {
+  const needle = (projectName?.trim() || projectId).slice(0, 80);
+  const like = `%${needle}%`;
+  const [files, lessons] = await Promise.all([
+    brainQueryAll<{ title: string; content: string }>(
+      `SELECT name AS title, content
+         FROM brain_files
+        WHERE name ILIKE $1 OR content ILIKE $1
+        ORDER BY updated_at DESC
+        LIMIT 6`,
+      [like],
+    ).catch(() => [] as Array<{ title: string; content: string }>),
+    queryAll<{ title: string; content: string }>(
+      `SELECT title, content
+         FROM knowledge_base
+        WHERE title ILIKE $1 OR content ILIKE $1
+        ORDER BY created_at DESC
+        LIMIT 5`,
+      [like],
+    ).catch(() => [] as Array<{ title: string; content: string }>),
+  ]);
+  return formatBrainBrief({ files, lessons });
+}

--- a/lib/live/load-room-context.ts
+++ b/lib/live/load-room-context.ts
@@ -15,6 +15,8 @@ import {
 import { parseReviewAnchor } from "@/lib/live/review-context";
 import { readPublicPages } from "@/lib/live/load-page-text";
 import { listProjectDecisionLog } from "@/lib/live/load-project-memory";
+import { loadBrainBrief } from "@/lib/live/load-brain-brief";
+import { listProjectEyes, listVisorEyes } from "@/lib/live/project-eyes";
 import { ensureProjectReferencesTable } from "@/lib/live/project-references";
 
 async function readJson(response: Response): Promise<Record<string, unknown> | null> {
@@ -100,14 +102,29 @@ export async function loadRoomContextBrief(
     }),
   ];
   const pages = await readPublicPages(pageUrls).catch(() => []);
+  const [visorEyes, pluginEyes, brain] = await Promise.all([
+    listVisorEyes(projectId).catch(() => []),
+    listProjectEyes(projectId, 6).catch(() => []),
+    loadBrainBrief(projectId, project?.name).catch(
+      () => "EXPERIENCIA V / BRAIN: no disponible en este turno.",
+    ),
+  ]);
+  const eyes = [...visorEyes, ...pluginEyes].map((eye) => ({
+    source: eye.source,
+    viewport: eye.viewport,
+    url: eye.url,
+    note: eye.note,
+    created_at: eye.created_at,
+  }));
   console.info("[room-context]", {
     projectId,
     comments: comments.length,
     references: references.length,
     pages: pages.length,
+    eyes: eyes.length,
   });
 
-  return formatRoomContext({
+  const room = formatRoomContext({
     projectId,
     project,
     comments,
@@ -121,5 +138,7 @@ export async function loadRoomContextBrief(
       filename: item.filename,
       text: item.extracted_text,
     })),
+    eyes,
   });
+  return `${room}\n\n${brain}`;
 }

--- a/lib/live/room-context.ts
+++ b/lib/live/room-context.ts
@@ -38,6 +38,14 @@ export interface RoomRepository {
   is_primary?: boolean;
 }
 
+export interface RoomEye {
+  source: string;
+  viewport?: string | null;
+  url?: string | null;
+  note?: string | null;
+  created_at?: string | null;
+}
+
 export interface RoomContextInput {
   projectId: string;
   project?: RoomProjectInfo | null;
@@ -49,6 +57,7 @@ export interface RoomContextInput {
   decisions?: string | null;
   pages?: RoomPage[];
   archives?: Array<{ filename: string; text: string }>;
+  eyes?: RoomEye[];
 }
 
 export function isSystemComment(comment: RoomComment): boolean {
@@ -142,12 +151,33 @@ export function formatRoomContext(input: RoomContextInput): string {
   const references = (input.references ?? [])
     .filter((item) => item.url?.trim())
     .slice(0, 20);
+  const visualKinds = new Set(["inspiration", "component", "marca", "brand", "visual"]);
+  const visualRefs = references.filter((item) =>
+    visualKinds.has((item.kind || "").toLowerCase()),
+  );
+  const pageRefs = references.filter(
+    (item) => !visualKinds.has((item.kind || "").toLowerCase()),
+  );
   lines.push("");
-  if (references.length === 0) {
-    lines.push("REFERENCIAS: ninguna todavía.");
+  if (visualRefs.length === 0) {
+    lines.push("MARCAS Y REFERENCIAS VISUALES: ninguna todavía.");
   } else {
-    lines.push(`URLS DE REFERENCIA (${references.length}):`);
-    for (const item of references) {
+    lines.push(
+      `MARCAS Y REFERENCIAS VISUALES (${visualRefs.length}). Están en la sala. No digas que no las ves.`,
+    );
+    for (const item of visualRefs) {
+      const kind = item.kind?.trim() ? `[${item.kind}] ` : "";
+      const label = item.label?.trim() || item.url;
+      const notes = item.notes?.trim() ? ` — ${clip(item.notes, 180)}` : "";
+      lines.push(`- ${kind}${label}: ${item.url}${notes}`);
+    }
+  }
+  lines.push("");
+  if (pageRefs.length === 0 && visualRefs.length === 0) {
+    lines.push("REFERENCIAS DE PÁGINA: ninguna todavía.");
+  } else if (pageRefs.length) {
+    lines.push(`URLS DE REFERENCIA (${pageRefs.length}):`);
+    for (const item of pageRefs) {
       const kind = item.kind?.trim() ? `[${item.kind}] ` : "";
       const label = item.label?.trim() || item.url;
       const notes = item.notes?.trim() ? ` — ${clip(item.notes, 180)}` : "";
@@ -189,12 +219,72 @@ export function formatRoomContext(input: RoomContextInput): string {
     .map((asset) => asset.filename?.trim())
     .filter(Boolean)
     .slice(0, 20);
-  if (assets.length) {
+  const imageAssets = assets.filter((name) =>
+    /\.(png|jpe?g|webp|gif|svg|avif)$/i.test(name),
+  );
+  const otherAssets = assets.filter((name) => !imageAssets.includes(name));
+  if (imageAssets.length) {
     lines.push("");
-    lines.push(`ARCHIVOS EN CONTEXTO: ${assets.join(", ")}`);
+    lines.push(
+      `ARCHIVOS VISUALES EN CONTEXTO (${imageAssets.length}): ${imageAssets.join(", ")}`,
+    );
+  }
+  if (otherAssets.length) {
+    lines.push("");
+    lines.push(`ARCHIVOS EN CONTEXTO: ${otherAssets.join(", ")}`);
+  }
+
+  const eyes = (input.eyes ?? []).slice(0, 12);
+  lines.push("");
+  if (eyes.length === 0) {
+    lines.push(
+      "OJOS DE LA SALA: sin fotos todavía. Pide fotografiar visores o usa el plugin.",
+    );
+  } else {
+    lines.push(
+      `OJOS DE LA SALA (${eyes.length}). Fotos reales de visores y plugin. No digas que la sala no tiene marca.`,
+    );
+    for (const eye of eyes) {
+      const when = eye.created_at
+        ? ` · ${eye.created_at.slice(0, 16).replace("T", " ")}`
+        : "";
+      const view = eye.viewport?.trim() || eye.source;
+      const note = eye.note?.trim() ? ` — ${clip(eye.note, 120)}` : "";
+      const url = eye.url?.trim() ? ` · ${eye.url}` : "";
+      lines.push(`- [${eye.source}] ${view}${when}${url}${note}`);
+    }
   }
 
   let text = lines.join("\n");
   if (text.length > 14000) text = `${text.slice(0, 13999)}…`;
+  return text;
+}
+
+export function formatBrainBrief(input: {
+  files: Array<{ title: string; content: string }>;
+  lessons: Array<{ title: string; content: string }>;
+}): string {
+  const lines = [
+    "EXPERIENCIA V / BRAIN. Esto no es la sala: es la memoria de la fábrica.",
+    "Úsalo. No pidas que te lo reescriban. No inventes proyectos que no estén aquí.",
+    "Doctrina: toda app tiene MCP. Código lo hace Claude Code en Hetzner. Grok investiga. Codex cubre si Claude no puede. Nunca n8n.",
+  ];
+  if (input.files.length) {
+    lines.push(`MEMORIA (${input.files.length}):`);
+    for (const file of input.files.slice(0, 6)) {
+      lines.push(`- ${clip(file.title, 80)}: ${clip(file.content, 280)}`);
+    }
+  }
+  if (input.lessons.length) {
+    lines.push(`LECCIONES (${input.lessons.length}):`);
+    for (const lesson of input.lessons.slice(0, 5)) {
+      lines.push(`- ${clip(lesson.title, 80)}: ${clip(lesson.content, 220)}`);
+    }
+  }
+  if (!input.files.length && !input.lessons.length) {
+    lines.push("Sin fichas del Brain para este proyecto todavía.");
+  }
+  let text = lines.join("\n");
+  if (text.length > 2200) text = `${text.slice(0, 2199)}…`;
   return text;
 }

--- a/lib/live/run-console.ts
+++ b/lib/live/run-console.ts
@@ -1,9 +1,9 @@
 /** Copy honesta cuando el runner aún no escribe log. No finge voz de Grok. */
 export function runnerWaitCopy(elapsedMs: number, hasLog: boolean): string | null {
   if (hasLog) return null;
-  if (elapsedMs < 8_000) return "En cola de Vulcano. Grok aún no escribe.";
+  if (elapsedMs < 8_000) return "En cola de Vulcano. Claude o Grok aún no escriben.";
   if (elapsedMs < 25_000) return "Sigue en cola. El daemon no ha soltado log.";
-  return "El runner no ha escrito nada. Si pasa de un minuto, Grok no tomó el job.";
+  return "El runner no ha escrito nada. Si pasa de un minuto, Claude o Grok no tomaron el job.";
 }
 
 export function formatElapsed(ms: number): string {

--- a/tests/factory-spine.test.ts
+++ b/tests/factory-spine.test.ts
@@ -5,7 +5,7 @@ import {
   parseReviewBridgeHit,
   sameReviewPage,
 } from "../lib/live/review-context";
-import { formatRoomContext } from "../lib/live/room-context";
+import { formatBrainBrief, formatRoomContext } from "../lib/live/room-context";
 import { formatDecisionLog } from "../lib/live/project-memory";
 import {
   isRetryableCerebrasCause,
@@ -81,6 +81,42 @@ test("room brief includes repo groups and decisions", () => {
   assert.match(brief, /plan_to_task/);
 });
 
+test("room brief surfaces marcas, visores and brain doctrine", () => {
+  const brief = formatRoomContext({
+    projectId: "lutor",
+    references: [
+      {
+        label: "Aman",
+        url: "https://www.aman.com",
+        kind: "inspiration",
+        notes: "luz cálida",
+      },
+    ],
+    assets: [{ filename: "logo-lutor.svg" }, { filename: "brief.pdf" }],
+    eyes: [
+      {
+        source: "visor",
+        viewport: "desktop",
+        url: "https://lutor.site",
+        note: "home",
+        created_at: "2026-08-30T17:00:00.000Z",
+      },
+    ],
+  });
+  assert.match(brief, /MARCAS Y REFERENCIAS VISUALES/);
+  assert.match(brief, /Aman/);
+  assert.match(brief, /ARCHIVOS VISUALES/);
+  assert.match(brief, /logo-lutor\.svg/);
+  assert.match(brief, /OJOS DE LA SALA/);
+  assert.match(brief, /desktop/);
+  const brain = formatBrainBrief({
+    files: [{ title: "lutor", content: "cobranza" }],
+    lessons: [],
+  });
+  assert.match(brain, /Claude Code en Hetzner/);
+  assert.match(brain, /lutor/);
+});
+
 test("decision log and repo labels stay compact", () => {
   assert.match(
     formatDecisionLog([{ kind: "talk_to_plan", summary: "puntos del CTA" }]),
@@ -95,7 +131,7 @@ test("decision log and repo labels stay compact", () => {
 test("live console wait copy is honest and timed", () => {
   assert.equal(runnerWaitCopy(1000, true), null);
   assert.match(runnerWaitCopy(1000, false) ?? "", /cola/);
-  assert.match(runnerWaitCopy(30_000, false) ?? "", /no tomó/);
+  assert.match(runnerWaitCopy(30_000, false) ?? "", /no tomaron/);
   assert.equal(formatElapsed(4500), "4s");
   assert.equal(formatElapsed(125_000), "2m 05s");
   assert.equal(isLiveRunStatus("running"), true);

--- a/tests/room-context.test.ts
+++ b/tests/room-context.test.ts
@@ -69,7 +69,8 @@ test("room brief surfaces observations, reference urls and content", () => {
 test("empty room still tells V there is nothing yet", () => {
   const brief = formatRoomContext({ projectId: "apsus" });
   assert.match(brief, /OBSERVACIONES: ninguna todavía/);
-  assert.match(brief, /REFERENCIAS: ninguna todavía/);
+  assert.match(brief, /MARCAS Y REFERENCIAS VISUALES: ninguna todavía/);
+  assert.match(brief, /OJOS DE LA SALA/);
   assert.match(brief, /MCP/);
 });
 


### PR DESCRIPTION
V deja de hablar ciega.

- Brief de sala nombra marcas, archivos visuales y fotos de visor/plugin.
- Cada plática inyecta Brain (brain_files + knowledge_base).
- Claude Code y Grok están logueados en Hetzner.

## Checks
tsc + tests en local 80/80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases prompt size and adds DB/API reads (Brain + eyes) on every room-context load; failures are mostly swallowed with fallbacks, but wrong ILIKE matches could inject unrelated Brain snippets.
> 
> **Overview**
> **V’s live context is richer** so talk/plan modes stop acting blind to visual and factory memory that already exists in the product.
> 
> The room brief now **splits references** into *marcas/referencias visuales* vs page URLs, **calls out image assets** separately, and adds an **“OJOS DE LA SALA”** block fed by visor + Chrome plugin captures loaded in `load-room-context`. Each turn **appends an EXPERIENCIA V / BRAIN** section via new `loadBrainBrief` (ILIKE search on `brain_files` and `knowledge_base`, formatted by `formatBrainBrief`).
> 
> **Policy and UX copy** align with that: talk-mode system rules tell V to use marcas, visor photos, and the Brain brief, and name **Claude Code on Hetzner** / **Grok** as execution entry points; live console wait messages mention Claude or Grok instead of Grok alone.
> 
> Tests cover the new brief sections and updated empty-room expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aed96c269c842f60e72a0794b22e4bcf6115572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->