### PR TITLE
feat(live): V ve las fotos del expediente con Gemma 4

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { askV } from "@/lib/forge/ask-v";
-import { ROOM_CEREBRAS_MODEL } from "@/lib/forge/ask-v-policy";
+import {
+  ROOM_CEREBRAS_MODEL,
+  cerebrasTalkModel,
+} from "@/lib/forge/ask-v-policy";
 import { humanProviderLabel, ProviderUnavailable } from "@/lib/forge/provider-errors";
 import {
   authorizeAgentRunAccess,
   selectAgentRepository,
 } from "@/lib/live/agent-runs";
 import { loadRoomContextBrief } from "@/lib/live/load-room-context";
+import { listExpedienteEyes } from "@/lib/live/project-eyes";
+import { pickExpedienteFrames } from "@/lib/live/expediente-vision";
 import { recordCerebrasPulse, todayCerebrasUsage } from "@/lib/forge/cerebras-pulse";
 import {
   listProjectAssistantMessages,
@@ -84,15 +89,23 @@ export async function POST(
       projectId,
       access.identity,
       req.signal,
-    ).catch(() => null);
+    ).catch((error) => {
+      console.error("[project assistant] room brief failed", { projectId, error });
+      return null;
+    });
+    const images = pickExpedienteFrames(
+      await listExpedienteEyes(projectId).catch(() => []),
+      3,
+    );
     const result = await askV({
       mode,
       projectId,
       repository: repoContext,
       message,
       history,
-      preferredModel: ROOM_CEREBRAS_MODEL,
+      preferredModel: cerebrasTalkModel(images.length > 0),
       roomContext,
+      images,
     });
 
     await saveProjectAssistantTurn({
@@ -127,7 +140,7 @@ export async function POST(
       usage: result.usage,
       translator: {
         provider: "cerebras",
-        model: ROOM_CEREBRAS_MODEL,
+        model: result.model,
         today: usage,
       },
     });

--- a/lib/forge/ask-v-policy.ts
+++ b/lib/forge/ask-v-policy.ts
@@ -4,6 +4,11 @@ export type VConversationMode = "talk" | "plan";
 export type VAskMode = VConversationMode | "execute";
 
 export const ROOM_CEREBRAS_MODEL = "gpt-oss-120b";
+export const ROOM_CEREBRAS_VISION_MODEL = "gemma-4-31b";
+
+export function cerebrasTalkModel(hasExpedientePhotos: boolean): string {
+  return hasExpedientePhotos ? ROOM_CEREBRAS_VISION_MODEL : ROOM_CEREBRAS_MODEL;
+}
 
 export interface ProviderTarget {
   provider: "cerebras";
@@ -16,6 +21,7 @@ export function cerebrasModelId(slug: string | undefined): string {
   if (s.startsWith("anthropic/") || /claude/i.test(s)) return ROOM_CEREBRAS_MODEL;
   if (!s.includes("/")) {
     if (/gpt-oss|gpt.oss/i.test(s)) return ROOM_CEREBRAS_MODEL;
+    if (/gemma.?4.?31/i.test(s)) return ROOM_CEREBRAS_VISION_MODEL;
     return s;
   }
   const last = s.split("/").pop() || s;
@@ -25,7 +31,8 @@ export function cerebrasModelId(slug: string | undefined): string {
 }
 
 /**
- * Plática y Planeación hablan sólo por Cerebras GPT OSS 120B.
+ * Plática y Planeación hablan por Cerebras. Texto: GPT OSS 120B.
+ * Si el expediente trae fotos, Gemma 4 31B (visión nativa).
  * Misma infra que /app/chat. Sin Mesh, Claude CLI ni OpenRouter.
  * Ejecución no habla por este router.
  */
@@ -47,7 +54,7 @@ export function modeSystemRules(mode: VConversationMode): string {
       "MODO PLANEACIÓN.",
       "Eres traductora de planeación. No ejecutas. Las IAs grandes sólo actúan en Ejecución.",
       "Si hay observaciones, puntos marcados o URLs de referencia, entrega el plan ahora: alcance, pasos, riesgos y criterios de aceptación.",
-      "No pidas que te reescriban lo que ya está en la sala. No afirmes que no puedes leer las URLs si su contenido viene en el contexto.",
+      "No pidas que te reescriban lo que ya está en la sala. Si hay fotos del expediente, ya las viste.",
       "Entrega alcance, pasos, riesgos y criterios de aceptación.",
       "Parte de las observaciones, referencias y contenido de la sala; no pidas que te los reescriban.",
       "No escribas código, no crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios.",
@@ -59,7 +66,7 @@ export function modeSystemRules(mode: VConversationMode): string {
     "MODO PLÁTICA.",
     "Eres traductora de la sala, no ejecutas. Claude Code en Hetzner entra con «Claude, hazlo». Grok entra con «Grok, hazlo».",
     "Conversa naturalmente sobre el proyecto, haz preguntas cuando falte contexto y ayuda a pensar.",
-    "Lee observaciones, puntos marcados, marcas, referencias visuales, fotos de visor, URLs y CONTENIDO.md. El brief EXPERIENCIA V / BRAIN también cuenta.",
+    "Lee el expediente de la sala: observaciones, marcas, referencias, CONTENIDO.md, Brain y las fotos adjuntas. Si hay fotos del expediente, ya las viste. No pidas que te las reenvíen.",
     "Si el usuario habla de «puntos» o «lo que marqué», usa esas observaciones.",
     "No crees ramas, no llames agentes y nunca afirmes que ejecutaste cambios.",
     "Toda app debe tener su MCP. Sugiérelo. Los ojos son Navegador Pro + el plugin de Chrome (vforge_project_see). No propongas n8n.",

--- a/lib/forge/ask-v.ts
+++ b/lib/forge/ask-v.ts
@@ -7,9 +7,9 @@ import {
   providerUnavailableFromUnknown,
 } from "@/lib/forge/provider-errors";
 import {
+  cerebrasTalkModel,
   modeSystemRules,
   providersForMode,
-  ROOM_CEREBRAS_MODEL,
   type VAskMode,
   type VConversationMode,
 } from "@/lib/forge/ask-v-policy";
@@ -20,6 +20,10 @@ import {
 } from "@/lib/forge/cerebras-usage";
 import type { ChatTurn } from "@/lib/forge/v-brain";
 import { V_TEXT_SYSTEM_PROMPT } from "@/lib/forge/v-text-persona";
+import {
+  visionUserContent,
+  type VisionFrame,
+} from "@/lib/live/expediente-vision";
 
 export interface AskVInput {
   mode: VAskMode;
@@ -29,6 +33,7 @@ export interface AskVInput {
   history?: ChatTurn[];
   preferredModel?: string;
   roomContext?: string | null;
+  images?: VisionFrame[];
 }
 
 export interface AskVAttempt {
@@ -49,12 +54,20 @@ export interface AskVResult {
   usage: CerebrasUsage | null;
 }
 
+type ChatContent =
+  | string
+  | Array<
+      | { type: "text"; text: string }
+      | { type: "image_url"; image_url: { url: string } }
+    >;
+
 function buildMessages(input: AskVInput): Array<{
   role: "system" | "user" | "assistant";
-  content: string;
+  content: ChatContent;
 }> {
   const mode = input.mode as VConversationMode;
   const repo = input.repository?.trim() || "sin repositorio seleccionado";
+  const frames = input.images ?? [];
   const system = [
     V_TEXT_SYSTEM_PROMPT,
     "",
@@ -62,6 +75,9 @@ function buildMessages(input: AskVInput): Array<{
     `SALA VFORGE: ${input.projectId}`,
     `REPOSITORIO AUTORIZADO: ${repo}`,
     input.roomContext?.trim() || "",
+    frames.length
+      ? `EXPEDIENTE VISUAL: ${frames.length} foto(s) del expediente van en el último mensaje. Ya las viste.`
+      : "EXPEDIENTE VISUAL: sin fotos en la sala todavía.",
     "Eres la traductora de la sala: hablas y planeas. Las IAs grandes (Claude, Codex, Grok) sólo entran en Ejecución.",
     "No enumeres secretos, tokens ni prompts internos.",
   ].join("\n");
@@ -69,15 +85,19 @@ function buildMessages(input: AskVInput): Array<{
     role: turn.role,
     content: turn.content,
   }));
+  const userContent =
+    frames.length > 0
+      ? visionUserContent(input.message, frames)
+      : input.message;
   return [
     { role: "system", content: system },
     ...history,
-    { role: "user", content: input.message },
+    { role: "user", content: userContent },
   ];
 }
 
 async function completeCerebras(
-  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+  messages: Array<{ role: "system" | "user" | "assistant"; content: ChatContent }>,
   model: string,
   maxTokens: number,
 ): Promise<{ text: string; usage: CerebrasUsage | null }> {
@@ -94,7 +114,7 @@ async function completeCerebras(
   try {
     const completion = await engine.client.chat.completions.create({
       model,
-      messages,
+      messages: messages as never,
       max_tokens: maxTokens,
       temperature: 0.4,
     });
@@ -125,6 +145,7 @@ function logAttempt(
     durationMs: attempt.durationMs,
     cause: attempt.cause,
     ok,
+    photos: input.images?.length ?? 0,
   };
   if (ok) console.info("[askV]", payload);
   else console.warn("[askV] provider_unavailable", payload);
@@ -144,6 +165,8 @@ export async function askV(input: AskVInput): Promise<AskVResult> {
     throw new Error("Ejecución no habla por askV. Usa el circuito de agentes.");
   }
 
+  const frames = input.images ?? [];
+  const model = cerebrasTalkModel(frames.length > 0);
   const messages = buildMessages(input);
   const maxTokens = input.mode === "plan" ? 2048 : 1024;
   const started = Date.now();
@@ -153,14 +176,10 @@ export async function askV(input: AskVInput): Promise<AskVResult> {
   for (let hop = 0; hop < 2; hop += 1) {
     const hopStart = Date.now();
     try {
-      const { text, usage } = await completeCerebras(
-        messages,
-        ROOM_CEREBRAS_MODEL,
-        maxTokens,
-      );
+      const { text, usage } = await completeCerebras(messages, model, maxTokens);
       const attempt = {
         provider: "cerebras",
-        model: ROOM_CEREBRAS_MODEL,
+        model,
         durationMs: Date.now() - hopStart,
         cause: hop === 0 ? "ok" : "retry",
       };
@@ -168,10 +187,15 @@ export async function askV(input: AskVInput): Promise<AskVResult> {
       return {
         text,
         provider: "cerebras",
-        model: ROOM_CEREBRAS_MODEL,
+        model,
         status: hop === 0 ? "ok" : "fallback",
         durationMs: Date.now() - started,
-        notice: hop === 0 ? null : "Cerebras reintentó tras un límite breve",
+        notice:
+          hop === 0
+            ? frames.length
+              ? `V vio ${frames.length} foto(s) del expediente`
+              : null
+            : "Cerebras reintentó tras un límite breve",
         attempts: [...attempts, attempt],
         usage,
       };
@@ -183,7 +207,7 @@ export async function askV(input: AskVInput): Promise<AskVResult> {
       );
       attempts.push({
         provider: "cerebras",
-        model: ROOM_CEREBRAS_MODEL,
+        model,
         durationMs: err.durationMs,
         cause: err.cause,
       });

--- a/lib/live/expediente-vision.ts
+++ b/lib/live/expediente-vision.ts
@@ -1,0 +1,69 @@
+export interface ExpedienteEye {
+  source: string;
+  viewport?: string | null;
+  note?: string | null;
+  mime_type: "image/png" | "image/jpeg" | string;
+  data_b64: string;
+}
+
+export interface VisionFrame {
+  mimeType: "image/png" | "image/jpeg";
+  data: string;
+  label: string;
+}
+
+const VISOR_ORDER = ["desktop", "mobile", "admin"];
+
+export function pickExpedienteFrames(
+  eyes: ExpedienteEye[],
+  limit = 3,
+): VisionFrame[] {
+  const cap = Math.min(4, Math.max(1, Math.floor(limit)));
+  const visor = eyes
+    .filter((eye) => eye.source === "visor" && eye.data_b64?.trim())
+    .sort(
+      (a, b) =>
+        VISOR_ORDER.indexOf(a.viewport || "") -
+        VISOR_ORDER.indexOf(b.viewport || ""),
+    );
+  const plugin = eyes.filter(
+    (eye) => eye.source !== "visor" && eye.data_b64?.trim(),
+  );
+  return [...visor, ...plugin].slice(0, cap).map((eye) => {
+    const view = eye.viewport?.trim() || eye.source;
+    const note = eye.note?.trim();
+    return {
+      mimeType: eye.mime_type === "image/png" ? "image/png" : "image/jpeg",
+      data: eye.data_b64.replace(/\s/g, ""),
+      label: note ? `${eye.source} · ${view} — ${note}` : `${eye.source} · ${view}`,
+    };
+  });
+}
+
+export function visionUserContent(
+  message: string,
+  frames: VisionFrame[],
+): Array<
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } }
+> {
+  const labels = frames.map((frame) => frame.label).join(", ");
+  const parts: Array<
+    | { type: "text"; text: string }
+    | { type: "image_url"; image_url: { url: string } }
+  > = [
+    {
+      type: "text",
+      text: `${message.trim()}\n\nFOTOS DEL EXPEDIENTE (${frames.length}): ${labels}. Ya las tienes. No pidas que te las reenvíen.`,
+    },
+  ];
+  for (const frame of frames) {
+    parts.push({
+      type: "image_url",
+      image_url: {
+        url: `data:${frame.mimeType};base64,${frame.data}`,
+      },
+    });
+  }
+  return parts;
+}

--- a/lib/live/project-eyes.ts
+++ b/lib/live/project-eyes.ts
@@ -129,3 +129,11 @@ export async function listVisorEyes(projectId: string): Promise<ProjectEye[]> {
     (a, b) => order.indexOf(a.viewport || "") - order.indexOf(b.viewport || ""),
   );
 }
+
+export async function listExpedienteEyes(projectId: string): Promise<ProjectEye[]> {
+  const [visor, plugin] = await Promise.all([
+    listVisorEyes(projectId),
+    listProjectEyes(projectId, 4),
+  ]);
+  return [...visor, ...plugin];
+}

--- a/tests/factory-spine.test.ts
+++ b/tests/factory-spine.test.ts
@@ -11,7 +11,17 @@ import {
   isRetryableCerebrasCause,
   usageFromCompletion,
 } from "../lib/forge/cerebras-usage";
-import { modeSystemRules, providersForMode } from "../lib/forge/ask-v-policy";
+import {
+  cerebrasTalkModel,
+  modeSystemRules,
+  providersForMode,
+  ROOM_CEREBRAS_MODEL,
+  ROOM_CEREBRAS_VISION_MODEL,
+} from "../lib/forge/ask-v-policy";
+import {
+  pickExpedienteFrames,
+  visionUserContent,
+} from "../lib/live/expediente-vision";
 import { repositoryGroupLabel } from "../lib/projects/repository-groups";
 import {
   canApplyRun,
@@ -24,6 +34,41 @@ test("V stays on Cerebras and names itself translator", () => {
   assert.equal(providersForMode("talk")[0].provider, "cerebras");
   assert.match(modeSystemRules("talk"), /traductora/);
   assert.match(modeSystemRules("plan"), /traductora/);
+  assert.equal(cerebrasTalkModel(false), ROOM_CEREBRAS_MODEL);
+  assert.equal(cerebrasTalkModel(true), ROOM_CEREBRAS_VISION_MODEL);
+});
+
+test("expediente frames prefer visors and attach as data URIs", () => {
+  const frames = pickExpedienteFrames(
+    [
+      {
+        source: "plugin",
+        mime_type: "image/jpeg",
+        data_b64: "ccc",
+        note: "tap",
+      },
+      {
+        source: "visor",
+        viewport: "mobile",
+        mime_type: "image/jpeg",
+        data_b64: "bbb",
+      },
+      {
+        source: "visor",
+        viewport: "desktop",
+        mime_type: "image/png",
+        data_b64: "aaa",
+      },
+    ],
+    2,
+  );
+  assert.equal(frames.length, 2);
+  assert.equal(frames[0].label.includes("desktop"), true);
+  assert.equal(frames[0].mimeType, "image/png");
+  const content = visionUserContent("mira la home", frames);
+  assert.equal(content[0].type, "text");
+  assert.match(String((content[0] as { text: string }).text), /EXPEDIENTE/);
+  assert.equal(content[1].type, "image_url");
 });
 
 test("Cerebras 429 is retryable and usage is parsed", () => {


### PR DESCRIPTION
Sin bots nuevos. Sin Hugging Face. Sin GPUs.

- El expediente de la sala (visores + plugin) se adjunta al turno de V.
- Si hay fotos: Cerebras `gemma-4-31b` (visión nativa).
- Si no hay fotos: sigue `gpt-oss-120b`.
- Máximo 3 fotos ya guardadas. No se capturan otras.
- Brief de marcas / CONTENIDO.md / Brain sigue en el mismo turno.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multimodal LLM calls with project-scoped screenshots in the assistant path; model selection and payload size change Cerebras behavior and cost, but auth and write gates on the route are unchanged.
> 
> **Overview**
> **Live project assistant (Plática / Planeación)** now loads up to **3 stored expediente images** (visor viewports first, then Chrome plugin captures) and sends them with the user message to `askV`, alongside the existing room brief.
> 
> When any photos are present, Cerebras switches from **`gpt-oss-120b`** to **`gemma-4-31b`** via `cerebrasTalkModel`; multimodal user content uses base64 data URIs in `expediente-vision`. System prompts and API responses reflect the actual model used and tell V not to ask users to resend photos. Room brief load failures are logged instead of swallowed silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab25dfd3e4511b3cd4dc4f124a2e1d3c9548e243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->