### PR TITLE
feat(live): V lee comentarios y URLs de referencia

### DIFF
--- a/lib/live/load-page-text.ts
+++ b/lib/live/load-page-text.ts
@@ -9,9 +9,9 @@ export interface ReadPageResult {
   text: string;
 }
 
-const MAX_PAGES = 5;
-const MAX_BYTES = 80_000;
-const TIMEOUT_MS = 4_000;
+const MAX_PAGES = 10;
+const MAX_BYTES = 100_000;
+const TIMEOUT_MS = 6_000;
 
 async function readOne(url: string): Promise<ReadPageResult | null> {
   const safe = normalizeReferenceUrl(url);
@@ -42,7 +42,7 @@ async function readOne(url: string): Promise<ReadPageResult | null> {
     const html = new TextDecoder("utf-8", { fatal: false }).decode(slice);
     const extracted = extractReadableText(html);
     if (!extracted.text) return null;
-    return { url: safe, title: extracted.title, text: extracted.text.slice(0, 1800) };
+    return { url: safe, title: extracted.title, text: extracted.text.slice(0, 2500) };
   } catch {
     return null;
   }

--- a/lib/live/load-room-context.ts
+++ b/lib/live/load-room-context.ts
@@ -33,13 +33,21 @@ export async function loadRoomContextBrief(
   identity: VForgeIdentity,
   signal: AbortSignal,
 ): Promise<string> {
-  const [commentsRes, contextRes, references, decisions] = await Promise.all([
+  const [commentsRes, contextRes, dbComments, references, decisions] = await Promise.all([
     fetchVForgeApi(`${projectApiPath(projectId, "comments")}?limit=80`, identity, {
       signal,
     }).then(readJson).catch(() => null),
     fetchVForgeApi(projectApiPath(projectId, "context"), identity, {
       signal,
     }).then(readJson).catch(() => null),
+    queryAll<RoomComment>(
+      `SELECT id::text, author_email, author_name, body, anchor, created_at::text
+         FROM project_comments
+        WHERE project_id = $1
+        ORDER BY created_at DESC
+        LIMIT 80`,
+      [projectId],
+    ).catch(() => [] as RoomComment[]),
     (async () => {
       await ensureProjectReferencesTable();
       return queryAll<RoomReference>(
@@ -47,16 +55,17 @@ export async function loadRoomContextBrief(
            FROM project_references
           WHERE project_id = $1
           ORDER BY created_at DESC
-          LIMIT 20`,
+          LIMIT 30`,
         [projectId],
       );
     })().catch(() => [] as RoomReference[]),
     listProjectDecisionLog(projectId).catch(() => "DECISIONES: ninguna todavía."),
   ]);
 
-  const comments = Array.isArray(commentsRes?.comments)
+  const apiComments = Array.isArray(commentsRes?.comments)
     ? (commentsRes.comments as RoomComment[])
     : [];
+  const comments = dbComments.length ? dbComments : apiComments;
   const project = (contextRes?.project ?? null) as RoomProjectInfo | null;
   const document =
     contextRes?.document &&

--- a/lib/live/room-context.ts
+++ b/lib/live/room-context.ts
@@ -77,6 +77,10 @@ function clip(value: string, max: number): string {
   return `${trimmed.slice(0, max - 1)}…`;
 }
 
+function urlKey(url: string): string {
+  return url.trim().replace(/\/$/, "");
+}
+
 function formatAnchor(raw: unknown): string {
   const anchor: ReviewAnchor | null = parseReviewAnchor(raw);
   if (!anchor) return "";
@@ -89,6 +93,7 @@ export function formatRoomContext(input: RoomContextInput): string {
   const lines: string[] = [
     "CONTEXTO DE LA SALA. Léelo completo. Cuando el usuario dice «puntos», «observaciones», «lo que marqué» o «lo de ahí», se refiere a esto.",
     "No afirmes que no lo ves. No pidas que te lo reescriba si ya está aquí.",
+    "Lee comentarios, URLs de referencia y el HTML extraído. Si una URL no trajo HTML, dílo; no inventes la página.",
   ];
 
   const project = input.project ?? {};
@@ -125,7 +130,7 @@ export function formatRoomContext(input: RoomContextInput): string {
 
   const observations = (input.comments ?? [])
     .filter((comment) => comment.body?.trim() && !isSystemComment(comment))
-    .slice(0, 30);
+    .slice(0, 50);
   lines.push("");
   if (observations.length === 0) {
     lines.push("OBSERVACIONES: ninguna todavía.");
@@ -144,13 +149,16 @@ export function formatRoomContext(input: RoomContextInput): string {
       lines.push(
         `${index + 1}. ${author}${when}${formatAnchor(comment.anchor)}`,
       );
-      lines.push(`   ${clip(comment.body, 500)}`);
+      lines.push(`   ${clip(comment.body, 800)}`);
     });
   }
 
   const references = (input.references ?? [])
     .filter((item) => item.url?.trim())
-    .slice(0, 20);
+    .slice(0, 30);
+  const readKeys = new Set(
+    (input.pages ?? []).map((page) => urlKey(page.url)),
+  );
   const visualKinds = new Set(["inspiration", "component", "marca", "brand", "visual"]);
   const visualRefs = references.filter((item) =>
     visualKinds.has((item.kind || "").toLowerCase()),
@@ -158,6 +166,15 @@ export function formatRoomContext(input: RoomContextInput): string {
   const pageRefs = references.filter(
     (item) => !visualKinds.has((item.kind || "").toLowerCase()),
   );
+
+  const formatRef = (item: RoomReference): string => {
+    const kind = item.kind?.trim() ? `[${item.kind}] ` : "";
+    const label = item.label?.trim() || item.url;
+    const notes = item.notes?.trim() ? ` — ${clip(item.notes, 180)}` : "";
+    const read = readKeys.has(urlKey(item.url)) ? " · HTML leído" : " · sin HTML leído aún";
+    return `- ${kind}${label}: ${item.url}${notes}${read}`;
+  };
+
   lines.push("");
   if (visualRefs.length === 0) {
     lines.push("MARCAS Y REFERENCIAS VISUALES: ninguna todavía.");
@@ -165,34 +182,24 @@ export function formatRoomContext(input: RoomContextInput): string {
     lines.push(
       `MARCAS Y REFERENCIAS VISUALES (${visualRefs.length}). Están en la sala. No digas que no las ves.`,
     );
-    for (const item of visualRefs) {
-      const kind = item.kind?.trim() ? `[${item.kind}] ` : "";
-      const label = item.label?.trim() || item.url;
-      const notes = item.notes?.trim() ? ` — ${clip(item.notes, 180)}` : "";
-      lines.push(`- ${kind}${label}: ${item.url}${notes}`);
-    }
+    for (const item of visualRefs) lines.push(formatRef(item));
   }
   lines.push("");
   if (pageRefs.length === 0 && visualRefs.length === 0) {
     lines.push("REFERENCIAS DE PÁGINA: ninguna todavía.");
   } else if (pageRefs.length) {
     lines.push(`URLS DE REFERENCIA (${pageRefs.length}):`);
-    for (const item of pageRefs) {
-      const kind = item.kind?.trim() ? `[${item.kind}] ` : "";
-      const label = item.label?.trim() || item.url;
-      const notes = item.notes?.trim() ? ` — ${clip(item.notes, 180)}` : "";
-      lines.push(`- ${kind}${label}: ${item.url}${notes}`);
-    }
+    for (const item of pageRefs) lines.push(formatRef(item));
   }
 
-  const pages = (input.pages ?? []).filter((page) => page.text?.trim()).slice(0, 5);
+  const pages = (input.pages ?? []).filter((page) => page.text?.trim()).slice(0, 10);
   if (pages.length) {
     lines.push("");
     lines.push(`CONTENIDO LEÍDO DE LAS URLS (${pages.length}):`);
     for (const page of pages) {
       const title = page.title?.trim() ? ` — ${page.title.trim()}` : "";
       lines.push(`### ${page.url}${title}`);
-      lines.push(clip(page.text, 1600));
+      lines.push(clip(page.text, 2200));
     }
   }
 
@@ -210,7 +217,7 @@ export function formatRoomContext(input: RoomContextInput): string {
   lines.push("");
   if (document) {
     lines.push("CONTENIDO.md DE LA SALA:");
-    lines.push(clip(document, 4000));
+    lines.push(clip(document, 5000));
   } else {
     lines.push("CONTENIDO.md: vacío.");
   }
@@ -256,7 +263,7 @@ export function formatRoomContext(input: RoomContextInput): string {
   }
 
   let text = lines.join("\n");
-  if (text.length > 14000) text = `${text.slice(0, 13999)}…`;
+  if (text.length > 22000) text = `${text.slice(0, 21999)}…`;
   return text;
 }
 

--- a/tests/room-context.test.ts
+++ b/tests/room-context.test.ts
@@ -48,6 +48,19 @@ test("room brief surfaces observations, reference urls and content", () => {
         url: "https://apsus.site/onboarding",
         notes: "flujo que duele",
       },
+      {
+        kind: "inspiration",
+        label: "Aman",
+        url: "https://www.aman.com",
+        notes: "luz",
+      },
+    ],
+    pages: [
+      {
+        url: "https://apsus.site/onboarding",
+        title: "Onboarding",
+        text: "Paso 1: datos. Paso 2: KYC.",
+      },
     ],
     document: "Prioridad: contrastes y onboarding APSUS.",
     assets: [{ filename: "brief.pdf" }],
@@ -58,6 +71,10 @@ test("room brief surfaces observations, reference urls and content", () => {
   assert.match(brief, /https:\/\/apsus\.site\/app/);
   assert.doesNotMatch(brief, /Tarea aceptada/);
   assert.match(brief, /Onboarding: https:\/\/apsus\.site\/onboarding/);
+  assert.match(brief, /HTML leído/);
+  assert.match(brief, /sin HTML leído aún/);
+  assert.match(brief, /CONTENIDO LEÍDO DE LAS URLS/);
+  assert.match(brief, /Paso 1: datos/);
   assert.match(brief, /CONTENIDO\.md DE LA SALA/);
   assert.match(brief, /contrastes y onboarding/);
   assert.match(brief, /brief\.pdf/);


### PR DESCRIPTION
V lee el expediente completo de la sala en cada turno:
- comentarios / puntos marcados directo de `project_comments`
- URLs de referencia + HTML público cuando se puede bajar
- si una URL no trajo HTML, el brief lo dice
- fotos del expediente siguen aparte (Gemma)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds outbound fetches and direct DB reads on every assistant turn, increasing latency, token use, and exposure to untrusted URL content in prompts.
> 
> **Overview**
> Expands what **V** gets in the per-turn room brief so it can rely on marked comments, reference URLs, and extracted public HTML instead of asking users to repeat context.
> 
> **Comment sourcing:** `loadRoomContextBrief` now loads up to 80 rows from `project_comments` in parallel with the API and **prefers the DB** when rows exist, with API comments as fallback.
> 
> **Reference pages:** Public URL fetching limits rise (10 pages, 100KB, 6s timeout, 2500 chars per page). The brief labels each reference with **«HTML leído»** vs **«sin HTML leído aún»**, includes a **CONTENIDO LEÍDO DE LAS URLS** section, and instructs V not to invent page content when fetch failed.
> 
> **Larger brief caps:** More observations (50), longer comment bodies (800), more references (30), longer page/document clips, and overall brief cap **22k** chars (was ~14k).
> 
> Tests assert the new HTML status strings and fetched URL content in `formatRoomContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7353dd738610d28d4320c1198c29fd9d9c4b748a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->