### PR TITLE
fix(live): una hebra de memoria por sala

### DIFF
--- a/lib/live/project-assistant.ts
+++ b/lib/live/project-assistant.ts
@@ -67,12 +67,10 @@ export async function listProjectAssistantMessages(
 
 export async function projectAssistantHistory(
   projectId: string,
-  mode: ProjectAssistantMode,
+  _mode?: ProjectAssistantMode,
 ): Promise<Array<{ role: "user" | "assistant"; content: string }>> {
-  const rows = (await listProjectAssistantMessages(projectId)).filter(
-    (row) => row.mode === mode,
-  );
-  return rows.slice(-20).map((row) => ({
+  const rows = await listProjectAssistantMessages(projectId);
+  return rows.slice(-24).map((row) => ({
     role: row.role,
     content: row.content,
   }));


### PR DESCRIPTION
Plática y planeación ya no son dos amnesias. V lee los últimos 24 turnos de la sala, da igual el modo.

Este chat de Grok sigue siendo otro cuerpo. La memoria de V es la sala + Brain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM context composition (cross-mode bleed and longer window), which can alter assistant behavior without touching auth or persistence schema.
> 
> **Overview**
> **Project assistant context is now one thread per room**, not separate histories for `talk` and `plan`.
> 
> `projectAssistantHistory` no longer filters `project_v_messages` by mode. It returns the last **24** turns (up from **20**) from all modes in chronological order. The `mode` argument is kept optional for callers but is unused (`_mode`).
> 
> New replies in either mode still persist with their mode via `saveProjectAssistantTurn`; only what gets sent to the model as prior context changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a37f09eb06dbcf9dba7ea5b8910901d6f92567a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->