### PR TITLE
feat(live): chat de V con fotos y hilo de verdad

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -10,13 +10,20 @@ import {
   selectAgentRepository,
 } from "@/lib/live/agent-runs";
 import { loadRoomContextBrief } from "@/lib/live/load-room-context";
-import { listExpedienteEyes } from "@/lib/live/project-eyes";
+import { listExpedienteEyes, saveProjectEye } from "@/lib/live/project-eyes";
 import { pickExpedienteFrames } from "@/lib/live/expediente-vision";
+import { parseChatAttachments } from "@/lib/live/chat-attachments";
 import {
   factoryHandsBrief,
   persistRoomMemory,
 } from "@/lib/live/v-factory-hands";
 import { recordCerebrasPulse, todayCerebrasUsage } from "@/lib/forge/cerebras-pulse";
+import {
+  extractMemoryBlocks,
+  getUserMemories,
+  memoryPromptSection,
+  saveUserMemory,
+} from "@/lib/forge/user-memory";
 import {
   listProjectAssistantMessages,
   projectAssistantHistory,
@@ -76,16 +83,29 @@ export async function POST(
   > | null;
   const mode: ProjectAssistantMode | null =
     payload?.mode === "talk" || payload?.mode === "plan" ? payload.mode : null;
+  const attachments = parseChatAttachments(payload?.attachments);
   const message =
     typeof payload?.message === "string"
       ? payload.message.trim().slice(0, 6000)
       : "";
+  const spoken =
+    message || (attachments.length ? `Mira ${attachments.length} foto(s).` : "");
   const repository = selectAgentRepository(access, payload?.repository);
-  if (!mode || message.length < 1)
+  if (!mode || spoken.length < 1)
     return json({ error: "invalid_message" }, 400);
 
   try {
-    const history = await projectAssistantHistory(projectId, mode);
+    for (const file of attachments) {
+      await saveProjectEye({
+        projectId,
+        source: "attach",
+        note: file.name,
+        image: file.data,
+      }).catch((error) => {
+        console.error("[project assistant] attach failed", error);
+      });
+    }
+    const history = await projectAssistantHistory(projectId);
     const repoContext = repository
       ? `${repository.repo_full_name} (rama ${repository.default_branch || "main"})`
       : null;
@@ -97,30 +117,40 @@ export async function POST(
       console.error("[project assistant] room brief failed", { projectId, error });
       return null;
     });
-    const hands = await factoryHandsBrief(projectId, message).catch(() => "");
-    const brief = [roomContext, hands].filter(Boolean).join("\n\n");
+    const hands = await factoryHandsBrief(projectId, spoken).catch(() => "");
+    const memories = await getUserMemories(access.identity.userId).catch(() => []);
+    const brief = [roomContext, hands, memoryPromptSection(memories)]
+      .filter(Boolean)
+      .join("\n\n");
     const images = pickExpedienteFrames(
       await listExpedienteEyes(projectId).catch(() => []),
-      3,
+      4,
     );
     const result = await askV({
       mode,
       projectId,
       repository: repoContext,
-      message,
+      message: spoken,
       history,
       preferredModel: cerebrasTalkModel(images.length > 0),
       roomContext: brief || null,
       images,
     });
+    const extracted = extractMemoryBlocks(result.text);
+    for (const memory of extracted.memories) {
+      await saveUserMemory(access.identity.userId, memory.key, memory.value).catch(
+        () => null,
+      );
+    }
+    const reply = extracted.cleaned.slice(0, 12000);
 
     await saveProjectAssistantTurn({
       projectId,
       mode,
       userId: access.identity.userId,
       email: access.identity.email,
-      userText: message,
-      assistantText: result.text.slice(0, 12000),
+      userText: spoken,
+      assistantText: reply,
       provider: result.provider,
       model: result.model,
       status: result.status,
@@ -128,8 +158,8 @@ export async function POST(
     });
     await persistRoomMemory({
       projectId,
-      userText: message,
-      assistantText: result.text.slice(0, 2000),
+      userText: spoken,
+      assistantText: reply.slice(0, 2000),
     }).catch(() => null);
     await recordCerebrasPulse({
       projectId,
@@ -142,7 +172,7 @@ export async function POST(
     const messages = await listProjectAssistantMessages(projectId);
     return json({
       messages,
-      reply: result.text,
+      reply,
       provider: result.provider,
       model: result.model,
       status: result.status,

--- a/components/live/VConversationPanel.tsx
+++ b/components/live/VConversationPanel.tsx
@@ -2,11 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
-import {
-  IconLoader,
-  IconSend,
-  IconSparkles,
-} from "@/components/brand/VFIcons";
+import { IconLoader, IconSend } from "@/components/brand/VFIcons";
 
 type ConversationMode = "talk" | "plan";
 
@@ -16,6 +12,38 @@ interface AssistantMessage {
   role: "user" | "assistant";
   content: string;
   created_at: string;
+}
+
+interface PendingPhoto {
+  name: string;
+  mime: string;
+  data: string;
+  preview: string;
+}
+
+function fileToPhoto(file: File): Promise<PendingPhoto | null> {
+  return new Promise((resolve) => {
+    if (!/^image\/(png|jpeg|jpg)$/i.test(file.type)) {
+      resolve(null);
+      return;
+    }
+    if (file.size > 1_600_000) {
+      resolve(null);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const preview = String(reader.result || "");
+      resolve({
+        name: file.name.slice(0, 80),
+        mime: file.type === "image/png" ? "image/png" : "image/jpeg",
+        data: preview,
+        preview,
+      });
+    };
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(file);
+  });
 }
 
 export function VConversationPanel({
@@ -40,11 +68,13 @@ export function VConversationPanel({
 }) {
   const [messages, setMessages] = useState<AssistantMessage[]>([]);
   const [message, setMessage] = useState("");
+  const [photos, setPhotos] = useState<PendingPhoto[]>([]);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const pollingRef = useRef(false);
   const endRef = useRef<HTMLDivElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
     if (pollingRef.current) return;
@@ -70,19 +100,34 @@ export function VConversationPanel({
 
   useEffect(() => {
     void load();
-    const timer = window.setInterval(() => void load(), 5000);
+    const timer = window.setInterval(() => void load(), 8000);
     return () => window.clearInterval(timer);
   }, [load]);
 
-  const visibleMessages = useMemo(() => messages.slice(-80), [messages]);
+  const visibleMessages = useMemo(() => messages.slice(-120), [messages]);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ block: "end" });
   }, [visibleMessages.length, busy]);
 
+  async function addFiles(list: FileList | null) {
+    if (!list?.length) return;
+    const next: PendingPhoto[] = [];
+    for (const file of Array.from(list).slice(0, 4)) {
+      const photo = await fileToPhoto(file);
+      if (photo) next.push(photo);
+    }
+    if (!next.length) {
+      setError("Sólo PNG o JPG, máximo 1.5 MB.");
+      return;
+    }
+    setPhotos((current) => [...current, ...next].slice(0, 4));
+    setError(null);
+  }
+
   async function sendMessage(raw: string) {
     const trimmed = raw.trim();
-    if (!trimmed || busy || !canWrite) return;
+    if ((!trimmed && photos.length === 0) || busy || !canWrite) return;
     setBusy(true);
     setError(null);
     try {
@@ -91,7 +136,16 @@ export function VConversationPanel({
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ mode: "talk", message: trimmed, repository }),
+          body: JSON.stringify({
+            mode: "talk",
+            message: trimmed || (photos.length ? "Mira esta foto." : ""),
+            repository,
+            attachments: photos.map((photo) => ({
+              name: photo.name,
+              mime: photo.mime,
+              data: photo.data,
+            })),
+          }),
         },
       );
       const payload = (await response.json().catch(() => null)) as {
@@ -103,6 +157,7 @@ export function VConversationPanel({
         throw new Error(payload?.notice || payload?.error || "V no pudo responder.");
       setMessages(Array.isArray(payload?.messages) ? payload.messages : []);
       setMessage("");
+      setPhotos([]);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "V no pudo responder.");
     } finally {
@@ -114,23 +169,24 @@ export function VConversationPanel({
     [...visibleMessages].reverse().find((item) => item.role === "user")?.content ?? "";
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-[var(--color-background)]">
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--border-1)] bg-white px-3 py-2">
-        <div>
-          <p className="text-[11px] font-medium">V</p>
-          <p className="mt-0.5 text-[9px] text-[var(--fg-muted)]">
-            Tu hermana. Siempre aquí. Recuerda.
-          </p>
+    <div className="flex min-h-0 flex-1 flex-col bg-[#eceae4]">
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-1)] bg-white px-4 py-3">
+        <span className="grid h-9 w-9 place-items-center rounded-full bg-black text-[13px] font-semibold text-white">
+          V
+        </span>
+        <div className="min-w-0">
+          <p className="text-[14px] font-medium leading-none">V</p>
+          <p className="mt-1 text-[11px] text-[var(--fg-muted)]">Tu hermana · en línea</p>
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-4" aria-live="polite">
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-4 sm:px-4" aria-live="polite">
         {loading ? (
-          <div className="flex h-full items-center justify-center gap-2 text-[10px] text-[var(--fg-muted)]">
-            <IconLoader size={12} className="animate-spin" /> Cargando…
+          <div className="flex h-full items-center justify-center gap-2 text-[12px] text-[var(--fg-muted)]">
+            <IconLoader size={14} className="animate-spin" /> Cargando chat…
           </div>
         ) : visibleMessages.length ? (
-          <div className="flex flex-col gap-3">
+          <div className="mx-auto flex w-full max-w-[560px] flex-col gap-2">
             {visibleMessages.map((item) => (
               <div
                 key={item.id}
@@ -141,35 +197,36 @@ export function VConversationPanel({
               >
                 <article
                   className={cn(
-                    "min-w-[8rem] max-w-[92%] break-words rounded-[12px] px-4 py-3 text-[12px] leading-5",
+                    "max-w-[86%] rounded-[18px] px-3.5 py-2.5 text-[14px] leading-6 shadow-[0_1px_0_rgba(0,0,0,0.04)]",
                     item.role === "user"
-                      ? "bg-[var(--color-ink)] text-[var(--color-background)]"
-                      : "border border-[var(--border-1)] bg-white",
+                      ? "rounded-br-[6px] bg-black text-white"
+                      : "rounded-bl-[6px] bg-white text-black",
                   )}
                 >
-                  <p className="mb-1 font-mono text-[8px] uppercase tracking-[0.1em] text-[var(--fg-muted)]">
-                    {item.role === "user" ? "Tú" : "V"}
+                  <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                    {item.content}
                   </p>
-                  <p className="whitespace-pre-wrap break-words">{item.content}</p>
                 </article>
               </div>
             ))}
             {busy ? (
-              <div className="flex justify-start text-[10px] text-[var(--fg-muted)]">
-                <IconLoader size={12} className="mr-2 animate-spin" /> V está pensando…
+              <div className="flex justify-start">
+                <span className="inline-flex items-center gap-2 rounded-[18px] bg-white px-3.5 py-2 text-[13px] text-[var(--fg-muted)]">
+                  <IconLoader size={12} className="animate-spin" /> V está escribiendo
+                </span>
               </div>
             ) : null}
             <div ref={endRef} />
           </div>
         ) : (
           <div className="grid h-full place-items-center text-center">
-            <div className="max-w-xs">
-              <span className="mx-auto grid h-11 w-11 place-items-center rounded-full bg-black text-white">
-                <IconSparkles size={17} />
+            <div>
+              <span className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-black text-white">
+                V
               </span>
-              <p className="mt-3 text-[12px] font-medium">Ey hermano</p>
-              <p className="mt-2 text-[10px] leading-5 text-[var(--fg-muted)]">
-                Este chat no se va. Si hay que mandar a Grok, eso vive al centro.
+              <p className="mt-3 text-[15px] font-medium">Ey hermano</p>
+              <p className="mt-1 text-[12px] text-[var(--fg-muted)]">
+                Mándame texto o una foto. Aquí me quedo.
               </p>
             </div>
           </div>
@@ -177,7 +234,7 @@ export function VConversationPanel({
       </div>
 
       {error ? (
-        <p className="shrink-0 bg-white px-3 py-2 text-center text-[10px] text-[var(--color-danger)]">
+        <p className="shrink-0 bg-white px-4 py-2 text-center text-[12px] text-[var(--color-danger)]">
           {error}
         </p>
       ) : null}
@@ -188,9 +245,49 @@ export function VConversationPanel({
             event.preventDefault();
             void sendMessage(message);
           }}
-          className="shrink-0 bg-white px-3 pb-3 pt-1"
+          className="shrink-0 border-t border-[var(--border-1)] bg-white px-3 py-3"
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={(event) => {
+            event.preventDefault();
+            void addFiles(event.dataTransfer.files);
+          }}
         >
-          <div className="flex items-end gap-2 rounded-[12px] border border-[var(--border-1)] px-2 py-2">
+          {photos.length ? (
+            <div className="mb-2 flex gap-2 overflow-x-auto">
+              {photos.map((photo, index) => (
+                <button
+                  key={`${photo.name}-${index}`}
+                  type="button"
+                  className="relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-[var(--border-1)]"
+                  onClick={() => setPhotos((current) => current.filter((_, i) => i !== index))}
+                  aria-label="Quitar foto"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={photo.preview} alt="" className="h-full w-full object-cover" />
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <div className="flex items-end gap-2">
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/png,image/jpeg"
+              multiple
+              className="hidden"
+              onChange={(event) => {
+                void addFiles(event.target.files);
+                event.currentTarget.value = "";
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => fileRef.current?.click()}
+              className="grid h-11 w-11 shrink-0 place-items-center rounded-full border border-[var(--border-1)] text-[18px] hover:border-black"
+              aria-label="Adjuntar foto"
+            >
+              +
+            </button>
             <textarea
               value={message}
               onChange={(event) => setMessage(event.target.value)}
@@ -200,33 +297,33 @@ export function VConversationPanel({
                   event.currentTarget.form?.requestSubmit();
                 }
               }}
-              rows={2}
+              rows={1}
               maxLength={6000}
-              placeholder="Háblale a V…"
-              className="min-h-12 flex-1 resize-y border-0 bg-transparent px-2 py-1.5 text-[12px] leading-5 outline-none"
+              placeholder="Mensaje"
+              className="max-h-36 min-h-11 flex-1 resize-none rounded-[22px] border border-[var(--border-1)] bg-[#f7f6f2] px-4 py-2.5 text-[14px] leading-5 outline-none focus:border-black"
             />
             <button
               type="submit"
-              disabled={busy || !message.trim()}
-              className="btn-primary min-h-12 px-4 disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={busy || (!message.trim() && photos.length === 0)}
+              className="grid h-11 w-11 shrink-0 place-items-center rounded-full bg-black text-white disabled:opacity-30"
+              aria-label="Enviar"
             >
-              {busy ? <IconLoader size={12} className="animate-spin" /> : <IconSend size={12} />}
-              Enviar
+              {busy ? <IconLoader size={14} className="animate-spin" /> : <IconSend size={14} />}
             </button>
           </div>
           {onDispatchGrok ? (
             <button
               type="button"
-              className="mt-2 text-[9px] text-[var(--fg-muted)] underline-offset-2 hover:underline"
+              className="mt-2 text-[11px] text-[var(--fg-muted)] hover:text-black"
               onClick={() => onDispatchGrok((message.trim() || lastUser).slice(0, 12000))}
               disabled={busy || !(message.trim() || lastUser)}
             >
-              Mandar esto al centro → Grok
+              Mandar al centro → Grok
             </button>
           ) : null}
         </form>
       ) : (
-        <p className="shrink-0 bg-white px-3 py-3 text-[10px] text-[var(--fg-muted)]">
+        <p className="shrink-0 bg-white px-4 py-3 text-[12px] text-[var(--fg-muted)]">
           Sólo el owner habla con V.
         </p>
       )}

--- a/lib/live/chat-attachments.ts
+++ b/lib/live/chat-attachments.ts
@@ -1,0 +1,21 @@
+export interface ChatAttachment {
+  name: string;
+  mime: string;
+  data: string;
+}
+
+export function parseChatAttachments(raw: unknown): ChatAttachment[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ChatAttachment[] = [];
+  for (const item of raw.slice(0, 4)) {
+    if (!item || typeof item !== "object") continue;
+    const rec = item as Record<string, unknown>;
+    const name = typeof rec.name === "string" ? rec.name.slice(0, 80) : "foto";
+    const mime = typeof rec.mime === "string" ? rec.mime : "image/jpeg";
+    const data = typeof rec.data === "string" ? rec.data.trim() : "";
+    if (!data) continue;
+    if (!/^image\/(png|jpeg|jpg)$/i.test(mime) && !data.startsWith("data:image/")) continue;
+    out.push({ name, mime, data });
+  }
+  return out;
+}

--- a/lib/live/expediente-vision.ts
+++ b/lib/live/expediente-vision.ts
@@ -19,6 +19,7 @@ export function pickExpedienteFrames(
   limit = 3,
 ): VisionFrame[] {
   const cap = Math.min(4, Math.max(1, Math.floor(limit)));
+  const attach = eyes.filter((eye) => eye.source === "attach" && eye.data_b64?.trim());
   const visor = eyes
     .filter((eye) => eye.source === "visor" && eye.data_b64?.trim())
     .sort(
@@ -26,10 +27,13 @@ export function pickExpedienteFrames(
         VISOR_ORDER.indexOf(a.viewport || "") -
         VISOR_ORDER.indexOf(b.viewport || ""),
     );
-  const plugin = eyes.filter(
-    (eye) => eye.source !== "visor" && eye.data_b64?.trim(),
+  const rest = eyes.filter(
+    (eye) =>
+      eye.source !== "visor" &&
+      eye.source !== "attach" &&
+      eye.data_b64?.trim(),
   );
-  return [...visor, ...plugin].slice(0, cap).map((eye) => {
+  return [...attach, ...visor, ...rest].slice(0, cap).map((eye) => {
     const view = eye.viewport?.trim() || eye.source;
     const note = eye.note?.trim();
     return {
@@ -54,7 +58,7 @@ export function visionUserContent(
   > = [
     {
       type: "text",
-      text: `${message.trim()}\n\nFOTOS DEL EXPEDIENTE (${frames.length}): ${labels}. Ya las tienes. No pidas que te las reenvíen.`,
+      text: `${message.trim()}\n\nFOTOS (${frames.length}): ${labels}. Ya las viste. No pidas que te las reenvíen.`,
     },
   ];
   for (const frame of frames) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \".test-dist/tests/project-tools.test.js\" \".test-dist/tests/see-page.test.js\" \".test-dist/tests/v-factory-hands.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
+        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \".test-dist/tests/project-tools.test.js\" \".test-dist/tests/see-page.test.js\" \".test-dist/tests/v-factory-hands.test.js\" \".test-dist/tests/chat-attachments.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/chat-attachments.test.ts
+++ b/tests/chat-attachments.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseChatAttachments } from "../lib/live/chat-attachments";
+import { pickExpedienteFrames } from "../lib/live/expediente-vision";
+
+test("parses png attachments and ignores junk", () => {
+  const parsed = parseChatAttachments([
+    { name: "home.png", mime: "image/png", data: "data:image/png;base64,aaa" },
+    { name: "x.pdf", mime: "application/pdf", data: "xxx" },
+  ]);
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].name, "home.png");
+});
+
+test("attached photos beat visor frames", () => {
+  const frames = pickExpedienteFrames(
+    [
+      { source: "visor", viewport: "desktop", mime_type: "image/png", data_b64: "aaa" },
+      { source: "attach", note: "ejemplo", mime_type: "image/jpeg", data_b64: "bbb" },
+    ],
+    2,
+  );
+  assert.equal(frames[0].label.includes("attach"), true);
+});


### PR DESCRIPTION
Chat de V como hilo: burbujas, clip de fotos PNG/JPG, memoria de cuenta y fotos adjuntas primero en visión.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New user image upload path and automatic persistence of model-extracted user memory increase data-handling surface; limits are in place but content still flows to storage and the LLM.
> 
> **Overview**
> **V’s live assistant** now accepts **PNG/JPG attachments** (up to four) in addition to text: the panel adds pick/drag previews and posts `attachments` with the message, while the API validates via `parseChatAttachments`, persists images as project eyes (`source: "attach"`), and allows photo-only turns with a default prompt.
> 
> **Vision context** prefers user-attached frames over visor/plugin captures (`pickExpedienteFrames`), raises the frame cap to **4**, and slightly tightens the vision prompt copy.
> 
> **Per-user memory** is wired into the assistant turn: stored memories are injected into the room brief, the model’s `<memory key="…">` blocks are parsed out of replies before persistence/response, and key/value pairs are saved for the signed-in user.
> 
> The conversation UI is restyled toward a **thread-style chat** (bubbles, composer with `+` attach, slower polling, more visible history). Tests cover attachment parsing and attach-first frame ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0983908e2a20847e4718aef31aa6c69976653c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->