### PR TITLE
feat(live): sin panel centro, V opera Hetzner

### DIFF
--- a/components/live/VControlPanel.tsx
+++ b/components/live/VControlPanel.tsx
@@ -5,14 +5,11 @@ import { cn } from "@/lib/utils";
 import { VConversationPanel } from "@/components/live/VConversationPanel";
 import { RunLiveConsole } from "@/components/live/RunLiveConsole";
 import { canApplyRun } from "@/lib/live/run-console";
-import { repositoryGroupLabel } from "@/lib/projects/repository-groups";
 import {
   IconBranch,
   IconCheck,
   IconExtLink,
-  IconLoader,
   IconRocket,
-  IconSend,
   IconStop,
   IconX,
 } from "@/components/brand/VFIcons";
@@ -47,10 +44,8 @@ interface QueueJob {
   id: number;
   agent: string | null;
   status: string;
-  progress: number | null;
   result: string | null;
   logTail: string | null;
-  verdict: string | null;
 }
 
 interface AgentRun {
@@ -69,14 +64,6 @@ interface AgentRun {
   error: string | null;
   created_at: string;
 }
-
-const EXECUTORS: Array<{ id: Executor; label: string }> = [
-  { id: "grok", label: "Grok" },
-  { id: "claude", label: "Claude" },
-  { id: "codex", label: "Codex" },
-  { id: "auto", label: "Auto" },
-  { id: "team", label: "Equipo" },
-];
 
 const STATUS_LABELS: Record<RunStatus, string> = {
   preparing: "Preparando",
@@ -105,8 +92,6 @@ export function VControlPanel({
   const [repositories, setRepositories] = useState<Repository[]>([]);
   const [canWrite, setCanWrite] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [instruction, setInstruction] = useState("");
-  const [executor, setExecutor] = useState<Executor>("grok");
   const [repository, setRepository] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -125,7 +110,7 @@ export function VControlPanel({
         repositories?: Repository[];
         canWrite?: boolean;
       } | null;
-      if (!response.ok) throw new Error("No se pudo leer la cabina.");
+      if (!response.ok) throw new Error("No se pudo leer Hetzner.");
       const nextRuns = Array.isArray(payload?.runs) ? payload.runs : [];
       const nextRepos = Array.isArray(payload?.repositories) ? payload.repositories : [];
       setRuns(nextRuns);
@@ -146,7 +131,7 @@ export function VControlPanel({
       );
       setError(null);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "No se pudo leer la cabina.");
+      setError(caught instanceof Error ? caught.message : "No se pudo leer Hetzner.");
     } finally {
       pollingRef.current = false;
     }
@@ -164,7 +149,7 @@ export function VControlPanel({
   );
   const jobMap = useMemo(() => new Map(jobs.map((job) => [job.id, job])), [jobs]);
 
-  async function launchRun(nextInstruction: string, nextExecutor: Executor = executor) {
+  async function launchRun(nextInstruction: string) {
     const text = nextInstruction.trim().slice(0, 12000);
     if (text.length < 3 || !repository || busy) return;
     setBusy(true);
@@ -173,20 +158,19 @@ export function VControlPanel({
       const response = await fetch(`/api/live/${encodeURIComponent(projectId)}/runs`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ instruction: text, executor: nextExecutor, repository }),
+        body: JSON.stringify({ instruction: text, executor: "grok", repository }),
       });
       const payload = (await response.json().catch(() => null)) as {
         run?: AgentRun;
         error?: string;
       } | null;
       if (!response.ok || !payload?.run)
-        throw new Error(payload?.error || "No se pudo iniciar el trabajo.");
-      setInstruction("");
+        throw new Error(payload?.error || "Hetzner no tomó el trabajo.");
       setRuns((current) => [payload.run!, ...current]);
       setSelectedId(payload.run.id);
       await load();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "No se pudo iniciar el trabajo.");
+      setError(caught instanceof Error ? caught.message : "Hetzner no tomó el trabajo.");
     } finally {
       setBusy(false);
     }
@@ -238,7 +222,7 @@ export function VControlPanel({
         <div className="min-w-0">
           <p className="font-mono text-[9px] uppercase tracking-[0.13em]">V · tu hermana</p>
           <p className="truncate text-[9px] text-[var(--fg-muted)]">
-            Chat a la izquierda · quien trabaja al centro · resultado a la derecha
+            Habla aquí. Hetzner trabaja. El resultado cae a la derecha.
           </p>
         </div>
         <button type="button" onClick={onClose} className="grid h-8 w-8 place-items-center rounded-md hover:bg-[var(--color-background)]" aria-label="Cerrar V">
@@ -247,141 +231,78 @@ export function VControlPanel({
       </header>
 
       {error ? (
-        <p className="shrink-0 border-b border-[var(--border-1)] px-3 py-2 text-[10px] text-[var(--color-danger)]">
+        <p className="shrink-0 border-b border-[var(--border-1)] px-3 py-2 text-[12px] text-[var(--color-danger)]">
           {error}
         </p>
       ) : null}
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-3">
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1.4fr)_minmax(280px,0.9fr)]">
         <section className="flex min-h-0 flex-col border-b border-[var(--border-1)] lg:border-b-0 lg:border-r">
           <VConversationPanel
             projectId={projectId}
             canWrite={canWrite}
             repository={repository}
             onDispatchGrok={(order) => {
-              setInstruction(order);
-              void launchRun(order, executor);
+              void launchRun(order);
             }}
           />
         </section>
 
-        <section className="flex min-h-0 flex-col overflow-y-auto border-b border-[var(--border-1)] lg:border-b-0 lg:border-r">
-          <header className="border-b border-[var(--border-1)] px-3 py-2">
-            <p className="text-[11px] font-medium">Mandar a alguien</p>
-            <p className="mt-0.5 text-[9px] text-[var(--fg-muted)]">Otra ventana. V se queda a tu izquierda.</p>
-          </header>
-          {canWrite ? (
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                void launchRun(instruction);
-              }}
-              className="shrink-0 space-y-2 border-b border-[var(--border-1)] p-3"
-            >
-              <select
-                value={repository}
-                onChange={(event) => setRepository(event.target.value)}
-                className="min-h-9 w-full rounded-md border border-[var(--border-1)] bg-white px-2 text-[11px]"
-              >
-                {repositories.map((repo) => (
-                  <option key={repo.repo_full_name} value={repo.repo_full_name}>
-                    {repositoryGroupLabel(repo.repo_full_name, repo.role, repo.is_primary)}
-                  </option>
-                ))}
-              </select>
-              <textarea
-                value={instruction}
-                onChange={(event) => setInstruction(event.target.value)}
-                rows={3}
-                placeholder="Qué tiene que hacer Grok o Claude…"
-                className="min-h-16 w-full resize-y rounded-md border border-[var(--border-1)] px-3 py-2 text-[12px] outline-none focus:border-black"
-              />
-              <div className="flex flex-wrap gap-1">
-                {EXECUTORS.map((item) => (
-                  <button
-                    key={item.id}
-                    type="button"
-                    onClick={() => setExecutor(item.id)}
-                    className={cn(
-                      "rounded-md border px-2 py-1 font-mono text-[8px] uppercase",
-                      executor === item.id ? "border-black bg-black text-white" : "border-[var(--border-1)]",
-                    )}
-                  >
-                    {item.label}
-                  </button>
-                ))}
-              </div>
-              <button type="submit" disabled={busy || !instruction.trim() || !repository} className="btn-primary w-full disabled:opacity-40">
-                {busy ? <IconLoader size={12} className="animate-spin" /> : <IconSend size={12} />}
-                Enviar al centro
-              </button>
-            </form>
-          ) : null}
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            {runs.length ? (
-              <div className="divide-y divide-[var(--border-1)]">
-                {runs.map((run) => (
-                  <button
-                    key={run.id}
-                    type="button"
-                    onClick={() => setSelectedId(run.id)}
-                    className={cn(
-                      "w-full p-3 text-left text-[11px] hover:bg-[var(--color-background)]",
-                      selected?.id === run.id && "bg-black text-white hover:bg-black",
-                    )}
-                  >
-                    <span className="line-clamp-2">{run.instruction}</span>
-                    <span className={cn("mt-1 block font-mono text-[8px] uppercase", selected?.id === run.id ? "text-white/65" : "text-[var(--fg-muted)]")}>
-                      {run.resolved_executor} · {STATUS_LABELS[run.status]}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <p className="p-4 text-[11px] text-[var(--fg-muted)]">Nadie trabaja todavía. Manda a Grok desde aquí.</p>
-            )}
-            {selected ? (
-              <div className="border-t border-[var(--border-1)] p-3">
-                <RunLiveConsole
-                  createdAt={selected.created_at}
-                  status={selected.status}
-                  jobs={jobMap}
-                  jobRefs={selected.queue_jobs}
-                  canWrite={canWrite}
-                  busy={busy}
-                  onNudge={nudgeRun}
-                />
-              </div>
-            ) : null}
-          </div>
-        </section>
-
         <section className="flex min-h-0 flex-col overflow-y-auto">
           <header className="border-b border-[var(--border-1)] px-3 py-2">
-            <p className="text-[11px] font-medium">Resultado</p>
-            <p className="mt-0.5 text-[9px] text-[var(--fg-muted)]">Cae aquí cuando alguien termina.</p>
+            <p className="text-[13px] font-medium">Hetzner</p>
+            <p className="mt-0.5 text-[11px] text-[var(--fg-muted)]">
+              Grok y Claude corren allá. Aquí sólo el resultado.
+            </p>
           </header>
+          {runs.length ? (
+            <div className="divide-y divide-[var(--border-1)]">
+              {runs.slice(0, 6).map((run) => (
+                <button
+                  key={run.id}
+                  type="button"
+                  onClick={() => setSelectedId(run.id)}
+                  className={cn(
+                    "w-full p-3 text-left text-[12px] hover:bg-[var(--color-background)]",
+                    selected?.id === run.id && "bg-black text-white hover:bg-black",
+                  )}
+                >
+                  <span className="line-clamp-2">{run.instruction}</span>
+                  <span className={cn("mt-1 block font-mono text-[8px] uppercase", selected?.id === run.id ? "text-white/65" : "text-[var(--fg-muted)]")}>
+                    {run.resolved_executor} · {STATUS_LABELS[run.status]}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="p-4 text-[12px] text-[var(--fg-muted)]">
+              Todavía no hay trabajo en Hetzner para esta sala.
+            </p>
+          )}
           {selected ? (
-            <div className="space-y-3 p-3">
+            <div className="space-y-3 border-t border-[var(--border-1)] p-3">
+              <RunLiveConsole
+                createdAt={selected.created_at}
+                status={selected.status}
+                jobs={jobMap}
+                jobRefs={selected.queue_jobs}
+                canWrite={canWrite}
+                busy={busy}
+                onNudge={nudgeRun}
+              />
               {selected.preview_url ? (
                 <iframe
                   src={selected.preview_url}
                   title="Preview"
-                  className="h-[280px] w-full rounded-[8px] border border-[var(--border-1)] bg-white"
+                  className="h-[220px] w-full rounded-[8px] border border-[var(--border-1)] bg-white"
                   sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
                 />
-              ) : (
-                <div className="grid h-40 place-items-center rounded-[8px] border border-[var(--border-1)] text-center text-[11px] text-[var(--fg-muted)]">
-                  {STATUS_LABELS[selected.status]}. El preview llega si Vercel lo publica.
-                </div>
-              )}
+              ) : null}
               {selected.summary ? (
-                <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-[8px] border border-[var(--border-1)] p-3 text-[10px] leading-5">
-                  {selected.summary}
-                </pre>
+                <pre className="max-h-36 overflow-auto whitespace-pre-wrap text-[11px] leading-5">{selected.summary}</pre>
               ) : null}
               {selected.error ? (
-                <p className="text-[10px] text-[var(--color-danger)]">{selected.error}</p>
+                <p className="text-[11px] text-[var(--color-danger)]">{selected.error}</p>
               ) : null}
               <div className="flex flex-wrap gap-2">
                 <a href={`https://github.com/${selected.repo_full_name}/tree/${selected.work_branch}`} target="_blank" rel="noreferrer" className="btn-ghost">
@@ -409,11 +330,7 @@ export function VControlPanel({
                 ) : null}
               </div>
             </div>
-          ) : (
-            <div className="grid flex-1 place-items-center p-6 text-center text-[11px] text-[var(--fg-muted)]">
-              Cuando Grok o Claude terminen, el resultado aparece aquí.
-            </div>
-          )}
+          ) : null}
         </section>
       </div>
     </section>

--- a/lib/forge/ask-v-policy.ts
+++ b/lib/forge/ask-v-policy.ts
@@ -45,10 +45,10 @@ export function fallbackNotice(from: string, to: string): string {
 export function modeSystemRules(mode: VConversationMode): string {
   const hands =
     "Eres V, la hermana de Luis. El chat de la sala es tuyo y está siempre abierto. Recuerdas. " +
-    "Tienes Brain, Vulcano y memoria semántica/vectorial (Mastra + pgvector) en el expediente. " +
+    "Operas desde Hetzner: Brain, Vulcano, v-server y memoria semántica/vectorial. " +
     "Lee las observaciones de la sala. Nunca pidas que el owner corra curl. " +
     "Nunca te presentes como traductora ni como asistente genérico. " +
-    "Si hay que mandar a Grok o Claude, eso ocurre en la ventana del centro, no aquí.";
+    "No hay panel del centro. Grok y Claude corren en Hetzner y el resultado cae a la derecha.";
   if (mode === "plan") {
     return [
       "MODO PLAN.",

--- a/lib/live/v-factory-hands.ts
+++ b/lib/live/v-factory-hands.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { queryAll } from "@/lib/db/client";
 import { brainQueryAll } from "@/lib/db/brain";
+import { callVServer } from "@/lib/forge/v-server";
 import {
   formatRecallSection,
   recall,
@@ -11,37 +12,58 @@ import {
 const BRAIN = (process.env.HETZNER_URL || "http://178.105.135.26").replace(/\/$/, "");
 const SECRET = process.env.BRAIN_SECRET || process.env.HETZNER_SECRET || "";
 
-const SAFE_LS = [
-  "ls -1 /brain/file/skills-vault/",
-  "ls -1 /brain/file/ | head -80",
-];
+const SAFE_CMD =
+  /^(ls|cat|head|tail|pwd|whoami|uname|df|free|ps|docker\s+ps|systemctl\s+status)\b/;
 
 export function wantsFactoryHands(message: string): boolean {
-  return /skill|vault|brain|mastra|memoria|vector|terminal|listar|cu[aá]ntas skill|\bls\b/i.test(
+  return /skill|vault|brain|mastra|memoria|vector|terminal|hetzner|hertzner|listar|cu[aá]ntas skill|\bls\b|salud|status/i.test(
     message,
   );
 }
 
-async function brainExec(cmd: string): Promise<string> {
+export async function brainExec(cmd: string): Promise<string> {
+  const trimmed = cmd.trim().slice(0, 400);
   if (!SECRET) return "relay sin secreto";
+  if (!SAFE_CMD.test(trimmed)) return `comando no permitido: ${trimmed.slice(0, 80)}`;
   const res = await fetch(`${BRAIN}/brain/exec`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ secret: SECRET, cmd }),
+    body: JSON.stringify({ secret: SECRET, cmd: trimmed }),
     cache: "no-store",
-    signal: AbortSignal.timeout(12_000),
+    signal: AbortSignal.timeout(20_000),
   });
-  if (!res.ok) return `relay HTTP ${res.status}`;
+  if (!res.ok) return `Hetzner /brain/exec HTTP ${res.status}`;
   const data = (await res.json().catch(() => null)) as {
     stdout?: string;
     stderr?: string;
+    output?: string;
   } | null;
-  const out = `${data?.stdout || ""}\n${data?.stderr || ""}`.trim();
-  return out.slice(0, 4000) || "sin salida";
+  const out = `${data?.stdout || data?.output || ""}\n${data?.stderr || ""}`.trim();
+  return out.slice(0, 6000) || "sin salida";
+}
+
+async function hetznerHealth(): Promise<string> {
+  const checks = await Promise.all([
+    fetch(`${BRAIN}/health`, { cache: "no-store", signal: AbortSignal.timeout(6000) })
+      .then((res) => `brain /health ${res.status}`)
+      .catch((error) => `brain /health ${error instanceof Error ? error.message : "down"}`),
+    callVServer("/health", {}).then((res) =>
+      res.ok ? `v-server ok ${res.status}` : `v-server ${res.status} ${res.error || ""}`,
+    ),
+    brainExec("ls -1 /brain/file/skills-vault/ | head -40"),
+  ]);
+  return [
+    "HETZNER VIVO. V opera aquí. No hay panel del centro.",
+    `relay: ${BRAIN}`,
+    checks[0],
+    checks[1],
+    "skills-vault:",
+    checks[2],
+  ].join("\n");
 }
 
 export async function loadFactoryCatalog(): Promise<string> {
-  const [dbSkills, brainSkills, vault] = await Promise.all([
+  const [dbSkills, brainSkills, health] = await Promise.all([
     queryAll<{ name: string; description: string | null }>(
       `SELECT name, description FROM skills WHERE active = true ORDER BY name LIMIT 80`,
     ).catch(() => [] as Array<{ name: string; description: string | null }>),
@@ -50,30 +72,25 @@ export async function loadFactoryCatalog(): Promise<string> {
         WHERE name ILIKE '%skill%' OR name ILIKE '%vault%' OR name ILIKE '%craft%'
         ORDER BY name LIMIT 80`,
     ).catch(() => [] as Array<{ name: string }>),
-    brainExec(SAFE_LS[0]).catch(() => "relay no contestó"),
+    hetznerHealth().catch(() => "Hetzner no contestó en este turno."),
   ]);
 
-  const lines = [
-    "MANOS DE FÁBRICA. Esto ya lo corrió el servidor. No pidas curl al owner.",
+  return [
+    health,
     `SKILLS TABLA (${dbSkills.length}):`,
     dbSkills.length
-      ? dbSkills.map((row) => `- ${row.name}${row.description ? ` — ${row.description.slice(0, 80)}` : ""}`).join("\n")
+      ? dbSkills.map((row) => `- ${row.name}`).join("\n")
       : "- vacía",
-    `BRAIN FILES skill/vault/craft (${brainSkills.length}):`,
-    brainSkills.length
-      ? brainSkills.map((row) => `- ${row.name}`).join("\n")
-      : "- ninguno",
-    "TERMINAL /brain/file/skills-vault/:",
-    vault,
-  ];
-  return lines.join("\n");
+    `BRAIN FILES (${brainSkills.length}):`,
+    brainSkills.length ? brainSkills.map((row) => `- ${row.name}`).join("\n") : "- ninguno",
+  ].join("\n");
 }
 
 export async function loadRoomMemory(projectId: string, message: string): Promise<string> {
   const hits = await recall(`${projectId} ${message}`, 6).catch(() => []);
   const block = formatRecallSection(hits, 0.18);
   if (block.trim()) return block.trim();
-  return "MEMORIA SEMÁNTICA/VECTORIAL: sin hits en este turno (Mastra + pgvector + embed Hetzner). Continúa con Brain y la sala.";
+  return "MEMORIA SEMÁNTICA/VECTORIAL: sin hits en este turno.";
 }
 
 export async function persistRoomMemory(input: {
@@ -99,9 +116,8 @@ export async function factoryHandsBrief(
   message: string,
 ): Promise<string> {
   const memory = await loadRoomMemory(projectId, message);
-  if (!wantsFactoryHands(message)) return memory;
   const catalog = await loadFactoryCatalog().catch(
-    () => "MANOS DE FÁBRICA: no respondieron en este turno.",
+    () => "HETZNER: no respondió en este turno.",
   );
   return `${memory}\n\n${catalog}`;
 }


### PR DESCRIPTION
Quita el panel del centro. Chat a la izquierda. Hetzner a la derecha. V lee Brain/v-server en cada turno.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cada turno del asistente live puede disparar varias llamadas a Hetzner (salud + exec), y la UI ya no permite elegir ejecutor ni mandar trabajos manualmente desde el panel eliminado.
> 
> **Overview**
> **Reorganiza la cabina live** de tres columnas a dos: chat con V a la izquierda y un panel **Hetzner** a la derecha con la lista de runs (máx. 6), consola en vivo, preview y acciones. Se elimina el panel central (selector de repo/ejecutor, formulario manual y lista de trabajos ahí).
> 
> Los lanzamientos desde el chat usan **`executor: "grok"` fijo**; ya no hay estado ni UI para Auto/Codex/Claude/Equipo en este panel. Los mensajes de error y copy pasan de “cabina” a **Hetzner**.
> 
> **Alinea el comportamiento de V** con ese modelo: las reglas de sistema en `ask-v-policy` dicen que no hay panel del centro y que Grok/Claude corren en Hetzner.
> 
> En **`v-factory-hands`**, el brief de fábrica **siempre** incluye catálogo + chequeo de salud (brain `/health`, v-server, listado de skills-vault), no solo cuando el mensaje pide “manos de fábrica”. `brainExec` queda exportado, con **lista blanca de comandos**, timeout mayor y salida ampliada; el catálogo enfatiza estado Hetzner frente al listado terminal anterior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74147312330dad9f4efe95a78802ae50a203a3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->