### PR TITLE
feat(live): Grok / Cursor / Claude Code / Codex — uno o dos

### DIFF
--- a/app/api/live/[projectId]/runs/route.ts
+++ b/app/api/live/[projectId]/runs/route.ts
@@ -17,6 +17,8 @@ import {
   type AgentQueueJob,
   type AgentRunRow,
 } from "@/lib/live/agent-runs";
+import { parseRequestedExecutors } from "@/lib/live/executors";
+import { loosenExecutorConstraint } from "@/lib/live/loosen-executors";
 import { parseRepoFullName, withUserGithub } from "@/lib/live/github-user";
 
 export const runtime = "nodejs";
@@ -255,11 +257,11 @@ export async function POST(
     typeof payload?.instruction === "string"
       ? payload.instruction.trim().slice(0, 12000)
       : "";
-  const requested =
-    typeof payload?.executor === "string" &&
-    executors.has(payload.executor as AgentExecutor)
-      ? (payload.executor as AgentExecutor)
-      : "auto";
+  const team = payload?.executor === "team";
+  const picked = team
+    ? (["claude"] as const)
+    : parseRequestedExecutors(payload?.executors ?? payload?.executor);
+  const requested = team ? "team" : picked.join("+");
   const repository = selectAgentRepository(access, payload?.repository);
   if (instruction.length < 3 || !repository)
     return json({ error: "invalid_run" }, 400);
@@ -267,12 +269,12 @@ export async function POST(
   if (!parsed) return json({ error: "invalid_repository" }, 400);
 
   await ensureProjectAgentRunsTable();
+  await loosenExecutorConstraint();
   const runId = randomUUID();
   const baseBranch = repository.default_branch || "main";
   const workBranch = `vforge/run-${runId.slice(0, 8)}`;
-  const resolved =
-    requested === "team" ? "team" : resolveExecutor(requested, instruction);
-  const phase = requested === "team" ? "planning" : "building";
+  const resolved = team ? "team" : picked.join("+");
+  const phase = team ? "planning" : "building";
   await queryOne(
     `INSERT INTO project_agent_runs
       (id, project_id, instruction, requested_executor, resolved_executor, phase, status,
@@ -311,9 +313,8 @@ export async function POST(
       },
     );
     if (!branch) throw new Error("Conecta GitHub para crear la rama aislada.");
-    const firstAgent: "codex" | "claude" | "grok" =
-      requested === "team" ? "claude" : resolveExecutor(requested, instruction);
-    const role = requested === "team" ? "planner" : "builder";
+    const agents = team ? (["claude"] as const) : picked;
+    const role = team ? "planner" : "builder";
     const prompt = buildAgentPrompt({
       runId,
       projectId,
@@ -323,15 +324,20 @@ export async function POST(
       instruction,
       role,
     });
-    const dispatched = await dispatchJob({
-      agent: firstAgent,
-      prompt,
-      priority: 3,
-      source: `vforge:${projectId}:${runId}:${access.identity.userId}`,
-    });
-    const jobs: AgentQueueJob[] = [
-      { id: dispatched.id, agent: firstAgent, role },
-    ];
+    const jobs: AgentQueueJob[] = [];
+    for (const agent of agents) {
+      const dispatched = await dispatchJob({
+        agent,
+        prompt,
+        priority: 3,
+        source: `vforge:${projectId}:${runId}:${access.identity.userId}:${agent}`,
+      });
+      jobs.push({
+        id: dispatched.id,
+        agent: agent === "cursor" ? ("claude" as const) : (agent as "codex" | "claude" | "grok"),
+        role,
+      });
+    }
     const run = await queryOne<AgentRunRow>(
       `UPDATE project_agent_runs SET queue_jobs = $1::jsonb, status = 'queued', updated_at = now()
         WHERE id = $2 RETURNING *`,

--- a/components/live/VControlPanel.tsx
+++ b/components/live/VControlPanel.tsx
@@ -6,6 +6,11 @@ import { VConversationPanel } from "@/components/live/VConversationPanel";
 import { RunLiveConsole } from "@/components/live/RunLiveConsole";
 import { canApplyRun } from "@/lib/live/run-console";
 import {
+  EXECUTOR_LABEL,
+  FACTORY_EXECUTORS,
+  type FactoryExecutor,
+} from "@/lib/live/executors";
+import {
   IconBranch,
   IconCheck,
   IconExtLink,
@@ -14,7 +19,6 @@ import {
   IconX,
 } from "@/components/brand/VFIcons";
 
-type Executor = "auto" | "codex" | "claude" | "grok" | "team";
 type RunStatus =
   | "preparing"
   | "queued"
@@ -51,11 +55,10 @@ interface QueueJob {
 interface AgentRun {
   id: string;
   instruction: string;
-  requested_executor: Executor;
+  requested_executor: string;
   resolved_executor: string;
   status: RunStatus;
   repo_full_name: string;
-  base_branch: string;
   work_branch: string;
   queue_jobs: QueueJobRef[];
   preview_url: string | null;
@@ -93,6 +96,7 @@ export function VControlPanel({
   const [canWrite, setCanWrite] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [repository, setRepository] = useState("");
+  const [picked, setPicked] = useState<FactoryExecutor[]>(["grok"]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pollingRef = useRef(false);
@@ -149,6 +153,17 @@ export function VControlPanel({
   );
   const jobMap = useMemo(() => new Map(jobs.map((job) => [job.id, job])), [jobs]);
 
+  function toggleExecutor(id: FactoryExecutor) {
+    setPicked((current) => {
+      if (current.includes(id)) {
+        const next = current.filter((item) => item !== id);
+        return next.length ? next : [id];
+      }
+      if (current.length >= 2) return [current[1], id];
+      return [...current, id];
+    });
+  }
+
   async function launchRun(nextInstruction: string) {
     const text = nextInstruction.trim().slice(0, 12000);
     if (text.length < 3 || !repository || busy) return;
@@ -158,7 +173,7 @@ export function VControlPanel({
       const response = await fetch(`/api/live/${encodeURIComponent(projectId)}/runs`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ instruction: text, executor: "grok", repository }),
+        body: JSON.stringify({ instruction: text, executors: picked, repository }),
       });
       const payload = (await response.json().catch(() => null)) as {
         run?: AgentRun;
@@ -252,8 +267,25 @@ export function VControlPanel({
           <header className="border-b border-[var(--border-1)] px-3 py-2">
             <p className="text-[13px] font-medium">Hetzner</p>
             <p className="mt-0.5 text-[11px] text-[var(--fg-muted)]">
-              Grok y Claude corren allá. Aquí sólo el resultado.
+              Elige uno o dos. Si no hay cuota, igual se encola.
             </p>
+            <div className="mt-2 flex flex-wrap gap-1">
+              {FACTORY_EXECUTORS.map((id) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => toggleExecutor(id)}
+                  className={cn(
+                    "rounded-md border px-2 py-1 font-mono text-[8px] uppercase tracking-[0.08em]",
+                    picked.includes(id)
+                      ? "border-[#1c1917] bg-[#1c1917] text-[#f6f3ec]"
+                      : "border-[var(--border-1)] bg-white text-[#1c1917]",
+                  )}
+                >
+                  {EXECUTOR_LABEL[id]}
+                </button>
+              ))}
+            </div>
           </header>
           {runs.length ? (
             <div className="divide-y divide-[var(--border-1)]">
@@ -264,11 +296,11 @@ export function VControlPanel({
                   onClick={() => setSelectedId(run.id)}
                   className={cn(
                     "w-full p-3 text-left text-[12px] hover:bg-[var(--color-background)]",
-                    selected?.id === run.id && "bg-black text-white hover:bg-black",
+                    selected?.id === run.id && "bg-[#1c1917] text-[#f6f3ec] hover:bg-[#1c1917]",
                   )}
                 >
                   <span className="line-clamp-2">{run.instruction}</span>
-                  <span className={cn("mt-1 block font-mono text-[8px] uppercase", selected?.id === run.id ? "text-white/65" : "text-[var(--fg-muted)]")}>
+                  <span className={cn("mt-1 block font-mono text-[8px] uppercase", selected?.id === run.id ? "text-[#f6f3ec]/70" : "text-[var(--fg-muted)]")}>
                     {run.resolved_executor} · {STATUS_LABELS[run.status]}
                   </span>
                 </button>

--- a/lib/live/executors.ts
+++ b/lib/live/executors.ts
@@ -1,0 +1,28 @@
+export const FACTORY_EXECUTORS = ["grok", "cursor", "claude", "codex"] as const;
+export type FactoryExecutor = (typeof FACTORY_EXECUTORS)[number];
+
+export const EXECUTOR_LABEL: Record<FactoryExecutor, string> = {
+  grok: "Grok",
+  cursor: "Cursor",
+  claude: "Claude Code",
+  codex: "Codex",
+};
+
+export function parseRequestedExecutors(raw: unknown): FactoryExecutor[] {
+  const values = Array.isArray(raw)
+    ? raw
+    : typeof raw === "string"
+      ? raw.split(/[+|,\s]+/)
+      : [];
+  const picked: FactoryExecutor[] = [];
+  for (const value of values) {
+    const key = String(value).trim().toLowerCase();
+    if (key === "auto") continue;
+    const mapped =
+      key === "claude-code" || key === "claudecode" ? "claude" : key;
+    if (!FACTORY_EXECUTORS.includes(mapped as FactoryExecutor)) continue;
+    if (!picked.includes(mapped as FactoryExecutor)) picked.push(mapped as FactoryExecutor);
+    if (picked.length === 2) break;
+  }
+  return picked.length ? picked : ["grok"];
+}

--- a/lib/live/loosen-executors.ts
+++ b/lib/live/loosen-executors.ts
@@ -1,0 +1,9 @@
+import "server-only";
+import { queryOne } from "@/lib/db/client";
+
+export async function loosenExecutorConstraint(): Promise<void> {
+  await queryOne(
+    `ALTER TABLE project_agent_runs
+       DROP CONSTRAINT IF EXISTS project_agent_runs_requested_executor_check`,
+  ).catch(() => null);
+}

--- a/tests/executors.test.ts
+++ b/tests/executors.test.ts
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseRequestedExecutors } from "../lib/live/executors";
+
+test("picks one or two factory executors", () => {
+  assert.deepEqual(parseRequestedExecutors("grok"), ["grok"]);
+  assert.deepEqual(parseRequestedExecutors(["claude", "codex"]), ["claude", "codex"]);
+  assert.deepEqual(parseRequestedExecutors(["grok", "cursor", "codex"]), ["grok", "cursor"]);
+  assert.deepEqual(parseRequestedExecutors("claude-code"), ["claude"]);
+  assert.deepEqual(parseRequestedExecutors([]), ["grok"]);
+});


### PR DESCRIPTION
Chips en el panel Hetzner: Grok, Cursor, Claude Code, Codex. Uno o dos a la vez. Si no hay cuota, se encola igual.

No mergear hasta que lo veas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Run creation now runs `ALTER TABLE … DROP CONSTRAINT` on the hot path and fans out multiple dispatch jobs while existing `advanceRun` logic still keys off the last queue job, which may not match parallel dual-executor behavior.
> 
> **Overview**
> **Live runs can target one or two factory agents** (Grok, Cursor, Claude Code, Codex) instead of a single fixed or auto-resolved executor.
> 
> The Hetzner panel adds toggle chips (max two) and POSTs an `executors` array. The runs API parses `executors` or legacy `executor` via `parseRequestedExecutors`, stores `requested`/`resolved` as joined values like `grok+cursor`, drops the DB `requested_executor` check on create, and **dispatches one queue job per picked agent** (Cursor still dispatches as `cursor` but is recorded in `queue_jobs` as Claude). **Team** mode is unchanged (`executor === "team"`).
> 
> `resolveExecutor` is no longer used on this POST path for non-team runs. Small unit tests cover executor parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec6ddbdc2e1471b24e6bdab18d656b76febfc31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->