### PR TITLE
fix(live): build de Vercel + fotos del chat

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -12,7 +12,10 @@ import {
 import { loadRoomContextBrief } from "@/lib/live/load-room-context";
 import { listExpedienteEyes, saveProjectEye } from "@/lib/live/project-eyes";
 import { pickExpedienteFrames } from "@/lib/live/expediente-vision";
-import { parseChatAttachments } from "@/lib/live/chat-attachments";
+import {
+  framesFromAttachments,
+  parseChatAttachments,
+} from "@/lib/live/chat-attachments";
 import {
   factoryHandsBrief,
   persistRoomMemory,
@@ -122,10 +125,12 @@ export async function POST(
     const brief = [roomContext, hands, memoryPromptSection(memories)]
       .filter(Boolean)
       .join("\n\n");
-    const images = pickExpedienteFrames(
+    const attached = framesFromAttachments(attachments);
+    const archived = pickExpedienteFrames(
       await listExpedienteEyes(projectId).catch(() => []),
       4,
     );
+    const images = [...attached, ...archived].slice(0, 4);
     const result = await askV({
       mode,
       projectId,

--- a/components/live/VControlPanel.tsx
+++ b/components/live/VControlPanel.tsx
@@ -44,6 +44,7 @@ interface QueueJob {
   id: number;
   agent: string | null;
   status: string;
+  progress: number | null;
   result: string | null;
   logTail: string | null;
 }

--- a/lib/live/chat-attachments.ts
+++ b/lib/live/chat-attachments.ts
@@ -1,3 +1,6 @@
+import type { VisionFrame } from "@/lib/live/expediente-vision";
+import { parseEyeImage } from "@/lib/live/see-page";
+
 export interface ChatAttachment {
   name: string;
   mime: string;
@@ -14,8 +17,22 @@ export function parseChatAttachments(raw: unknown): ChatAttachment[] {
     const mime = typeof rec.mime === "string" ? rec.mime : "image/jpeg";
     const data = typeof rec.data === "string" ? rec.data.trim() : "";
     if (!data) continue;
-    if (!/^image\/(png|jpeg|jpg)$/i.test(mime) && !data.startsWith("data:image/")) continue;
+    if (!/^image\//i.test(mime) && !data.startsWith("data:image/")) continue;
     out.push({ name, mime, data });
   }
   return out;
+}
+
+export function framesFromAttachments(files: ChatAttachment[]): VisionFrame[] {
+  const frames: VisionFrame[] = [];
+  for (const file of files) {
+    const parsed = parseEyeImage(file.data);
+    if (!parsed) continue;
+    frames.push({
+      mimeType: parsed.mimeType,
+      data: parsed.data,
+      label: `attach · ${file.name}`,
+    });
+  }
+  return frames;
 }


### PR DESCRIPTION
El deploy de producción falló por un type de QueueJob. Además V no veía la foto del turno si el expediente no la había guardado. Este PR: 1) desbloquea el build 2) pega el adjunto al modelo en el mismo request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small typing fix plus vision input wiring in the live assistant path; no auth or payment changes.
> 
> **Overview**
> **Unblocks production builds** by aligning the `QueueJob` type in `VControlPanel` with the API/`RunLiveConsole` shape, adding the missing `progress` field.
> 
> **Chat images reach the assistant on the same request** instead of relying only on expediente frames. The assistant route builds vision input from **current attachments first** (`framesFromAttachments`), then fills up to four slots with archived expediente eyes. `parseChatAttachments` now accepts any `image/*` MIME (not only PNG/JPEG), and attachments are normalized to `VisionFrame`s via `parseEyeImage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fcedcb52ca903fd063140d31b192e5b3ed5df32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->