### PR TITLE
feat(live): pulso honesto cuando Hetzner falla

### DIFF
--- a/components/live/RunLiveConsole.tsx
+++ b/components/live/RunLiveConsole.tsx
@@ -6,7 +6,7 @@ import {
   isLiveRunStatus,
   runnerWaitCopy,
 } from "@/lib/live/run-console";
-import { IconLoader, IconSend } from "@/components/brand/VFIcons";
+import { runnerLooksDead } from "@/lib/live/run-pulse";
 
 interface QueueJobRef {
   id: number;
@@ -43,10 +43,6 @@ export function RunLiveConsole({
   const [now, setNow] = useState(() => Date.now());
   const [nudge, setNudge] = useState("");
   const scroller = useRef<HTMLDivElement>(null);
-  const live = isLiveRunStatus(status);
-  const started = new Date(createdAt).getTime();
-  const elapsed = Number.isFinite(started) ? now - started : 0;
-
   const log = useMemo(() => {
     const chunks = jobRefs.flatMap((ref) => {
       const job = jobs.get(ref.id);
@@ -56,12 +52,11 @@ export function RunLiveConsole({
     });
     return chunks.join("\n\n");
   }, [jobRefs, jobs]);
-
-  const wait = runnerWaitCopy(elapsed, Boolean(log));
-  const progress = jobRefs.reduce((max, ref) => {
-    const value = jobs.get(ref.id)?.progress;
-    return value == null ? max : Math.max(max, value);
-  }, 0);
+  const dead = runnerLooksDead(log) || status === "failed";
+  const live = !dead && isLiveRunStatus(status);
+  const started = new Date(createdAt).getTime();
+  const age = Number.isFinite(started) ? now - started : 0;
+  const wait = runnerWaitCopy(age, Boolean(log));
 
   useEffect(() => {
     if (!live) return;
@@ -84,56 +79,42 @@ export function RunLiveConsole({
   return (
     <section className="overflow-hidden rounded-[8px] border border-black bg-black text-white">
       <header className="flex items-center justify-between gap-3 border-b border-white/15 px-3 py-2">
-        <div className="flex items-center gap-2">
-          <span
-            className={`h-1.5 w-1.5 rounded-full ${live ? "animate-pulse bg-white" : "bg-white/40"}`}
-          />
-          <p className="font-mono text-[8px] uppercase tracking-[0.14em]">
-            Consola · {live ? "en vivo" : status}
-          </p>
-        </div>
+        <p className="font-mono text-[8px] uppercase tracking-[0.14em]">
+          {dead ? "Consola · falló" : live ? "Consola · en vivo" : `Consola · ${status}`}
+        </p>
         <p className="font-mono text-[8px] uppercase tracking-[0.12em] text-white/55">
-          {formatElapsed(elapsed)}
-          {progress > 0 ? ` · ${Math.round(progress)}%` : ""}
+          {live ? formatElapsed(age) : dead ? "muerto" : ""}
         </p>
       </header>
       <div
         ref={scroller}
-        className="max-h-[280px] min-h-[180px] overflow-auto px-3 py-3 font-mono text-[11px] leading-5"
+        className="max-h-[220px] min-h-[140px] overflow-auto px-3 py-3 font-mono text-[11px] leading-5"
       >
         {log ? (
           <pre className="whitespace-pre-wrap text-white/90">{log}</pre>
         ) : (
           <p className="text-white/55">{wait}</p>
         )}
-        {live ? (
-          <span className="mt-2 inline-block h-3 w-1.5 animate-pulse bg-white" />
-        ) : null}
+        {live ? <span className="mt-2 inline-block h-3 w-1.5 animate-pulse bg-white" /> : null}
       </div>
       {canWrite && live ? (
         <form
           onSubmit={(event) => void sendNudge(event)}
           className="flex items-center gap-2 border-t border-white/15 px-2 py-2"
         >
-          <span className="pl-1 font-mono text-[11px] text-white/40">›</span>
           <input
             value={nudge}
             onChange={(event) => setNudge(event.target.value)}
             maxLength={4000}
-            placeholder="Háblale a Grok mientras trabaja…"
+            placeholder="Nudge al runner"
             className="min-h-9 flex-1 bg-transparent text-[12px] text-white outline-none placeholder:text-white/35"
           />
           <button
             type="submit"
             disabled={busy || nudge.trim().length < 2}
-            className="grid h-8 w-8 place-items-center rounded-md border border-white/20 disabled:opacity-30"
-            aria-label="Enviar a Grok"
+            className="px-2 font-mono text-[10px] uppercase disabled:opacity-30"
           >
-            {busy ? (
-              <IconLoader size={12} className="animate-spin" />
-            ) : (
-              <IconSend size={12} />
-            )}
+            Enviar
           </button>
         </form>
       ) : null}

--- a/components/live/RunPulseBar.tsx
+++ b/components/live/RunPulseBar.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { pulseLabel } from "@/lib/live/run-pulse";
+
+export function RunPulseBar({
+  status,
+  summary,
+  error,
+  progress,
+}: {
+  status: string;
+  summary?: string | null;
+  error?: string | null;
+  progress?: number;
+}) {
+  const pulse = pulseLabel({ status, summary, error, progress });
+  return (
+    <div className="rounded-[8px] border border-[#e4e1d8] bg-white p-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[13px] font-medium text-[#1c1917]">{pulse.title}</p>
+        <span
+          className={cn(
+            "h-2 w-2 rounded-full",
+            pulse.tone === "live" && "animate-pulse bg-[#1c1917]",
+            pulse.tone === "dead" && "bg-[var(--color-danger)]",
+            pulse.tone === "ok" && "bg-[#1c1917]",
+            pulse.tone === "wait" && "bg-[#c4bfb4]",
+          )}
+        />
+      </div>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[#efeee8]">
+        <div
+          className={cn(
+            "h-full rounded-full",
+            pulse.tone === "dead" ? "bg-[var(--color-danger)]" : "bg-[#1c1917]",
+          )}
+          style={{ width: `${pulse.percent}%` }}
+        />
+      </div>
+      <p className="mt-2 text-[12px] leading-5 text-[#6f6b64]">{pulse.detail}</p>
+    </div>
+  );
+}

--- a/lib/live/run-pulse.ts
+++ b/lib/live/run-pulse.ts
@@ -1,0 +1,61 @@
+export function looksLikeOrder(text: string): boolean {
+  return /\b(haz|dale|implementa|cambia|arregla|investiga|empieza|manos a la obra|ponte|ejecuta|aplica|propon|sube|corrige)\b/i.test(
+    text,
+  );
+}
+
+export function runnerLooksDead(text: string | null | undefined): boolean {
+  const value = (text || "").toLowerCase();
+  return (
+    value.includes("grok_chat error") ||
+    value.includes("command not found") ||
+    value.includes("enoent") ||
+    value.includes("quota") ||
+    value.includes("rate limit")
+  );
+}
+
+export function pulseLabel(input: {
+  status: string;
+  summary?: string | null;
+  error?: string | null;
+  progress?: number;
+}): { title: string; detail: string; percent: number; tone: "live" | "wait" | "dead" | "ok" } {
+  const blob = `${input.summary || ""}\n${input.error || ""}`;
+  if (runnerLooksDead(blob) || input.status === "failed") {
+    return {
+      title: "Hetzner no arrancó",
+      detail: blob.includes("grok_chat")
+        ? "Grok CLI falló en el servidor. El chat de V no es el runner."
+        : (input.error || "El job murió sin log útil.").slice(0, 180),
+      percent: 100,
+      tone: "dead",
+    };
+  }
+  if (input.status === "running" || input.status === "queued" || input.status === "preparing") {
+    const percent = Math.max(6, Math.min(92, input.progress || 12));
+    return {
+      title: input.status === "running" ? "Grok está en Hetzner" : "En cola de Hetzner",
+      detail: "Si esta barra no se mueve en un minuto, el daemon no tomó el job.",
+      percent,
+      tone: "live",
+    };
+  }
+  if (input.status === "awaiting_approval" || input.status === "preview_ready" || input.status === "awaiting_preview") {
+    return {
+      title: "Listo para Aplicar",
+      detail: "El runner ya soltó resultado. Revísalo y aplica si sí.",
+      percent: 100,
+      tone: "wait",
+    };
+  }
+  if (input.status === "published" || input.status === "approved") {
+    return { title: "Aplicado", detail: "Ya está en la rama.", percent: 100, tone: "ok" };
+  }
+  return {
+    title: input.status,
+    detail: (input.summary || input.error || "Sin log.").slice(0, 180),
+    percent: input.progress || 0,
+    tone: "wait",
+  };
+}

--- a/tests/run-pulse.test.ts
+++ b/tests/run-pulse.test.ts
@@ -1,0 +1,10 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { looksLikeOrder, pulseLabel, runnerLooksDead } from "../lib/live/run-pulse";
+
+test("detects work orders and dead grok cli", () => {
+  assert.equal(looksLikeOrder("dale con todo usando grok"), true);
+  assert.equal(looksLikeOrder("hola qué onda"), false);
+  assert.equal(runnerLooksDead("grok_chat error: Command"), true);
+  assert.equal(pulseLabel({ status: "failed", error: "grok_chat error" }).tone, "dead");
+});


### PR DESCRIPTION
Barra de pulso: si Grok CLI murió, lo dice. No finge que está trabajando.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Live-run UI and display logic only; no auth or data-path changes. Misclassified log substrings could show false “dead” states.
> 
> **Overview**
> Adds **`run-pulse`** helpers and a **`RunPulseBar`** that maps run status, errors, and progress into a title, detail copy, bar width, and tone (`live` / `dead` / `wait` / `ok`). When logs or errors match dead-runner patterns (e.g. `grok_chat error`, quota, ENOENT) or status is **`failed`**, the UI shows **“Hetzner no arrancó”** instead of implying Grok is still working on the server.
> 
> **`RunLiveConsole`** now uses **`runnerLooksDead`** on aggregated log text so **`live`** is false when the runner looks dead; the header shows **“Consola · falló”** and **“muerto”** instead of elapsed time and job progress %. The console is slightly shorter, nudge copy is generic (**“Nudge al runner”** / text **Enviar**), and the live pulse dot is removed from the header.
> 
> Unit tests cover **`looksLikeOrder`**, **`runnerLooksDead`**, and **`pulseLabel`** dead tone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da964eacb4d797b6cf21e5d0a49b9a9da92b50ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->