### PR TITLE
fix(live): ping no se vuelve obra

### DIFF
--- a/lib/live/agent-prompt.ts
+++ b/lib/live/agent-prompt.ts
@@ -1,0 +1,52 @@
+export function isPingInstruction(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  if (t.length > 80) return false;
+  return /^(di |dec[ií] |responde |solo |solamente )?(listo|hola|ok|ping|s[ií]|aqui|aquí)([.!]*)?$/.test(
+    t,
+  );
+}
+
+export function buildAgentPrompt(args: {
+  runId: string;
+  projectId: string;
+  repo: string;
+  baseBranch: string;
+  workBranch: string;
+  instruction: string;
+  role: "planner" | "builder" | "reviewer";
+  priorResult?: string | null;
+}): string {
+  const task = args.instruction.trim();
+  if (isPingInstruction(task)) {
+    return [
+      "PING. No clones repo. No abras ramas. No inventes obra.",
+      "Responde sólo lo que pide la tarea, una o dos palabras.",
+      "",
+      `TAREA\n${task}`,
+    ].join("\n");
+  }
+  const roleRules =
+    args.role === "planner"
+      ? "Analiza y entrega un plan verificable. NO escribas código ni cambies ramas."
+      : args.role === "reviewer"
+        ? "Revisa la rama de trabajo, pruebas y riesgos. NO escribas ni hagas merge. Emite APROBADO, REVISION o RECHAZADO con evidencia."
+        : "Eres el único escritor. Implementa, prueba y haz push exclusivamente a la rama de trabajo indicada.";
+  return `VFORGE RUN ${args.runId}
+PROYECTO ${args.projectId}
+REPOSITORIO ${args.repo}
+RAMA BASE ${args.baseBranch}
+RAMA DE TRABAJO ${args.workBranch}
+ROL ${args.role.toUpperCase()}
+
+REGLAS OBLIGATORIAS
+- ${roleRules}
+- Esto es un SANDBOX. Trabaja sólo en ${args.workBranch}. Nunca escribas, hagas push ni merge directo a ${args.baseBranch}.
+- No abras un pull request. El owner lo crea al aprobar.
+- No despliegues producción.
+- No leas ni expongas secretos ajenos al proyecto.
+- Reporta archivos tocados, comandos de validación, resultado y bloqueos reales.
+
+TAREA
+${task}
+${args.priorResult ? `\nCONTEXTO DE LA ETAPA ANTERIOR\n${args.priorResult.slice(0, 8000)}` : ""}`;
+}

--- a/lib/live/agent-runs.ts
+++ b/lib/live/agent-runs.ts
@@ -9,9 +9,15 @@ import {
 } from "@/lib/api/vforge-owned";
 import type { LiveRole } from "@/lib/projects/roles";
 
+export { buildAgentPrompt, isPingInstruction } from "@/lib/live/agent-prompt";
+
 export type AgentExecutor = "auto" | "codex" | "claude" | "grok" | "team";
 export type AgentPhase =
-  "planning" | "building" | "reviewing" | "validation" | "complete";
+  | "planning"
+  | "building"
+  | "reviewing"
+  | "validation"
+  | "complete";
 export type AgentRunStatus =
   | "preparing"
   | "queued"
@@ -162,42 +168,6 @@ export function resolveExecutor(
   if (/arquitectura|planea|estrategia|diseño de sistema/.test(normalized))
     return "claude";
   return "codex";
-}
-
-export function buildAgentPrompt(args: {
-  runId: string;
-  projectId: string;
-  repo: string;
-  baseBranch: string;
-  workBranch: string;
-  instruction: string;
-  role: "planner" | "builder" | "reviewer";
-  priorResult?: string | null;
-}): string {
-  const roleRules =
-    args.role === "planner"
-      ? "Analiza y entrega un plan verificable. NO escribas código ni cambies ramas."
-      : args.role === "reviewer"
-        ? "Revisa la rama de trabajo, pruebas y riesgos. NO escribas ni hagas merge. Emite APROBADO, REVISION o RECHAZADO con evidencia."
-        : "Eres el único escritor. Implementa, prueba y haz push exclusivamente a la rama de trabajo indicada.";
-  return `VFORGE RUN ${args.runId}
-PROYECTO ${args.projectId}
-REPOSITORIO ${args.repo}
-RAMA BASE ${args.baseBranch}
-RAMA DE TRABAJO ${args.workBranch}
-ROL ${args.role.toUpperCase()}
-
-REGLAS OBLIGATORIAS
-- ${roleRules}
-- Esto es un SANDBOX. Trabaja sólo en ${args.workBranch}. Nunca escribas, hagas push ni merge directo a ${args.baseBranch}.
-- No abras un pull request. El owner lo crea al aprobar.
-- No despliegues producción.
-- No leas ni expongas secretos ajenos al proyecto.
-- Reporta archivos tocados, comandos de validación, resultado y bloqueos reales.
-
-TAREA
-${args.instruction.trim()}
-${args.priorResult ? `\nCONTEXTO DE LA ETAPA ANTERIOR\n${args.priorResult.slice(0, 8000)}` : ""}`;
 }
 
 export async function listProjectAgentRuns(

--- a/tests/agent-prompt.test.ts
+++ b/tests/agent-prompt.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildAgentPrompt, isPingInstruction } from "../lib/live/agent-prompt";
+
+test("ping no envuelve obra", () => {
+  assert.equal(isPingInstruction("di listo"), true);
+  assert.equal(isPingInstruction("haz LUTOR con vibe neon"), false);
+  const ping = buildAgentPrompt({
+    runId: "x",
+    projectId: "lutor",
+    repo: "turbillon50/lutor",
+    baseBranch: "main",
+    workBranch: "vforge/run-x",
+    instruction: "di listo",
+    role: "builder",
+  });
+  assert.equal(ping.includes("VFORGE RUN"), false);
+  assert.equal(ping.includes("No clones repo"), true);
+  const obra = buildAgentPrompt({
+    runId: "x",
+    projectId: "lutor",
+    repo: "turbillon50/lutor",
+    baseBranch: "main",
+    workBranch: "vforge/run-x",
+    instruction: "cambia el hero a neon",
+    role: "builder",
+  });
+  assert.equal(obra.includes("VFORGE RUN"), true);
+});


### PR DESCRIPTION
Si la tarea es un ping (di listo, hola), Grok no recibe el molde de builder. No clona. Responde la palabra.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change for a narrow instruction pattern; re-exports preserve the public API with unit test coverage.
> 
> **Overview**
> **Ping-style tasks** (e.g. `di listo`, `hola`, short acknowledgments) no longer get the full VForge builder/planner/reviewer run template, so agents are told not to clone, open branches, or treat the message as real work—only reply in one or two words.
> 
> `buildAgentPrompt` and new **`isPingInstruction`** live in `lib/live/agent-prompt.ts`; `agent-runs.ts` re-exports them so existing imports keep working. Non-ping instructions still use the same sandbox rules and role text as before.
> 
> Adds **`tests/agent-prompt.test.ts`** to assert pings omit `VFORGE RUN` and real tasks still include it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9df38fac5afd3b903f9b7f4f0e786777c41f532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->