### PR TITLE
feat(live): V manda a Hetzner

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -20,6 +20,7 @@ import {
   factoryHandsBrief,
   persistRoomMemory,
 } from "@/lib/live/v-factory-hands";
+import { looksLikeWorkOrder } from "@/lib/live/work-order";
 import { recordCerebrasPulse, todayCerebrasUsage } from "@/lib/forge/cerebras-pulse";
 import {
   extractMemoryBlocks,
@@ -147,7 +148,33 @@ export async function POST(
         () => null,
       );
     }
-    const reply = extracted.cleaned.slice(0, 12000);
+    let reply = extracted.cleaned.slice(0, 12000);
+    let runId: string | null = null;
+    if (looksLikeWorkOrder(spoken) && repository) {
+      const queued = await fetch(
+        new URL(`/api/live/${encodeURIComponent(projectId)}/runs`, req.url),
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            cookie: req.headers.get("cookie") ?? "",
+          },
+          body: JSON.stringify({
+            instruction: spoken,
+            executor: "grok",
+            repository: repository.repo_full_name,
+          }),
+        },
+      );
+      const body = (await queued.json().catch(() => null)) as {
+        run?: { id?: string };
+        error?: string;
+      } | null;
+      runId = body?.run?.id ?? null;
+      reply = runId
+        ? `${reply}\n\nLo mandé a Hetzner. Mira la terminal.`
+        : `${reply}\n\nNo pude encolar en Hetzner${body?.error ? `: ${body.error}` : "."}`;
+    }
 
     await saveProjectAssistantTurn({
       projectId,
@@ -178,6 +205,7 @@ export async function POST(
     return json({
       messages,
       reply,
+      runId,
       provider: result.provider,
       model: result.model,
       status: result.status,

--- a/lib/live/work-order.ts
+++ b/lib/live/work-order.ts
@@ -1,0 +1,8 @@
+export function looksLikeWorkOrder(text: string): boolean {
+  const t = text.trim();
+  if (t.length < 12) return false;
+  if (/^(di |dec[ií] )?(listo|hola|ok|ping)([.!]*)?$/i.test(t)) return false;
+  return /(haz|arregla|cambia|implementa|construye|monta|sube|merge|deploy|hero|lutor|diseño|codigo|código|pantalla|app)/i.test(
+    t,
+  );
+}


### PR DESCRIPTION
Si le pides trabajo a V (cambia, haz, hero, lutor, código), ella misma POST /runs. Tú sólo hablas. La terminal muestra el job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auto-enqueues real agent runs on a keyword heuristic, so false positives or ambiguous phrasing could trigger unintended Grok/Hetzner jobs when a repository is selected.
> 
> **Overview**
> When a user talks to the live project assistant, messages that look like **work orders** (Spanish action keywords such as *haz*, *cambia*, *implementa*, *deploy*, etc., via `looksLikeWorkOrder`) and a **repository** is selected now **automatically POST** to `/api/live/{projectId}/runs` with the spoken instruction, `executor: "grok"`, and the chosen repo—after the normal `askV` reply is generated.
> 
> The assistant **appends** a short Spanish status line (queued on Hetzner vs. enqueue failure) and the JSON response includes **`runId`** when a run was created, so the terminal/UI can show the job without a separate manual enqueue step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15f72ba0fecffc393ee85f0fbb0b4cee811203f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->