### PR TITLE
fix(live): V encola directo

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -21,6 +21,7 @@ import {
   persistRoomMemory,
 } from "@/lib/live/v-factory-hands";
 import { looksLikeWorkOrder } from "@/lib/live/work-order";
+import { startOwnerGrokRun } from "@/lib/live/start-owner-run";
 import { recordCerebrasPulse, todayCerebrasUsage } from "@/lib/forge/cerebras-pulse";
 import {
   extractMemoryBlocks,
@@ -151,29 +152,18 @@ export async function POST(
     let reply = extracted.cleaned.slice(0, 12000);
     let runId: string | null = null;
     if (looksLikeWorkOrder(spoken) && repository) {
-      const queued = await fetch(
-        new URL(`/api/live/${encodeURIComponent(projectId)}/runs`, req.url),
-        {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            cookie: req.headers.get("cookie") ?? "",
-          },
-          body: JSON.stringify({
-            instruction: spoken,
-            executor: "grok",
-            repository: repository.repo_full_name,
-          }),
-        },
-      );
-      const body = (await queued.json().catch(() => null)) as {
-        run?: { id?: string };
-        error?: string;
-      } | null;
-      runId = body?.run?.id ?? null;
-      reply = runId
-        ? `${reply}\n\nLo mandé a Hetzner. Mira la terminal.`
-        : `${reply}\n\nNo pude encolar en Hetzner${body?.error ? `: ${body.error}` : "."}`;
+      const queued = await startOwnerGrokRun({
+        projectId,
+        access,
+        repository,
+        instruction: spoken,
+      });
+      if ("runId" in queued) {
+        runId = queued.runId;
+        reply = `${reply}\n\nLo mandé a Hetzner. Mira la terminal.`;
+      } else {
+        reply = `${reply}\n\nNo pude encolar en Hetzner: ${queued.error}`;
+      }
     }
 
     await saveProjectAssistantTurn({

--- a/lib/live/start-owner-run.ts
+++ b/lib/live/start-owner-run.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from "node:crypto";
+import { queryOne } from "@/lib/db/client";
+import { dispatchJob } from "@/lib/vulcano/operator";
+import { parseRepoFullName, withUserGithub } from "@/lib/live/github-user";
+import {
+  buildAgentPrompt,
+  ensureProjectAgentRunsTable,
+  type AgentRunAccess,
+  type AgentRunRepository,
+  type AgentRunRow,
+} from "@/lib/live/agent-runs";
+
+export async function startOwnerGrokRun(args: {
+  projectId: string;
+  access: AgentRunAccess;
+  repository: AgentRunRepository;
+  instruction: string;
+}): Promise<{ runId: string } | { error: string }> {
+  const instruction = args.instruction.trim().slice(0, 12000);
+  if (instruction.length < 3) return { error: "instrucción vacía" };
+  const parsed = parseRepoFullName(args.repository.repo_full_name);
+  if (!parsed) return { error: "repo inválido" };
+
+  await ensureProjectAgentRunsTable();
+  const runId = randomUUID();
+  const baseBranch = args.repository.default_branch || "main";
+  const workBranch = `vforge/run-${runId.slice(0, 8)}`;
+
+  await queryOne(
+    `INSERT INTO project_agent_runs
+      (id, project_id, instruction, requested_executor, resolved_executor, phase, status,
+       repo_full_name, base_branch, work_branch, created_by_user_id, created_by_email)
+     VALUES ($1,$2,$3,'grok','grok','building','preparing',$4,$5,$6,$7,$8)`,
+    [
+      runId,
+      args.projectId,
+      instruction,
+      args.repository.repo_full_name,
+      baseBranch,
+      workBranch,
+      args.access.identity.userId,
+      args.access.identity.email,
+    ],
+  );
+
+  try {
+    const [owner, repo] = parsed;
+    const branch = await withUserGithub(
+      args.access.identity.userId,
+      async (github) => {
+        const source = await github.request(
+          "GET /repos/{owner}/{repo}/git/ref/{ref}",
+          { owner, repo, ref: `heads/${baseBranch}` },
+        );
+        return github.request("POST /repos/{owner}/{repo}/git/refs", {
+          owner,
+          repo,
+          ref: `refs/heads/${workBranch}`,
+          sha: source.data.object.sha,
+        });
+      },
+    );
+    if (!branch) throw new Error("Conecta GitHub para crear la rama aislada.");
+    const prompt = buildAgentPrompt({
+      runId,
+      projectId: args.projectId,
+      repo: args.repository.repo_full_name,
+      baseBranch,
+      workBranch,
+      instruction,
+      role: "builder",
+    });
+    const dispatched = await dispatchJob({
+      agent: "grok",
+      prompt,
+      priority: 3,
+      source: `vforge:${args.projectId}:${runId}:${args.access.identity.userId}`,
+    });
+    await queryOne(
+      `UPDATE project_agent_runs SET queue_jobs = $1::jsonb, status = 'queued', updated_at = now()
+        WHERE id = $2`,
+      [JSON.stringify([{ id: dispatched.id, agent: "grok", role: "builder" }]), runId],
+    );
+    return { runId };
+  } catch (caught) {
+    const message =
+      caught instanceof Error ? caught.message.slice(0, 500) : "No se pudo iniciar el run";
+    await queryOne(
+      `UPDATE project_agent_runs SET status = 'failed', error = $1, updated_at = now() WHERE id = $2`,
+      [message, runId],
+    ).catch(() => null);
+    return { error: message };
+  }
+}

--- a/lib/live/work-order.ts
+++ b/lib/live/work-order.ts
@@ -1,8 +1,11 @@
 export function looksLikeWorkOrder(text: string): boolean {
   const t = text.trim();
-  if (t.length < 12) return false;
-  if (/^(di |dec[ií] )?(listo|hola|ok|ping)([.!]*)?$/i.test(t)) return false;
-  return /(haz|arregla|cambia|implementa|construye|monta|sube|merge|deploy|hero|lutor|diseño|codigo|código|pantalla|app)/i.test(
+  if (t.length < 8) return false;
+  if (/^(di |dec[ií] )?(listo|hola|ok|ping|gracias|buenas)([.!]*)?$/i.test(t)) {
+    return false;
+  }
+  if (t.length >= 40) return true;
+  return /(haz|arregla|cambia|implementa|construye|monta|sube|merge|deploy|hero|lutor|diseño|codigo|código|pantalla|app|trabajo|grok|hetzner)/i.test(
     t,
   );
 }


### PR DESCRIPTION
V ya no se llama por HTTP. Encola Grok en la misma petición.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> In-process run startup touches DB, user GitHub refs, and job dispatch on the hot assistant path; mis-detection could enqueue unintended Grok runs.
> 
> **Overview**
> When the live assistant detects a work order, it **no longer self-POSTs** to `/api/live/.../runs`; it calls new **`startOwnerGrokRun`** in the same request.
> 
> That helper creates the `project_agent_runs` row, opens an isolated GitHub work branch, builds the builder prompt, **`dispatchJob`** to Grok on Hetzner, and marks the run queued—or records failure and returns an error string for the Spanish reply footer.
> 
> **`looksLikeWorkOrder`** is tuned to queue more often: shorter minimum length, extra greeting filters, auto-match for messages ≥40 chars, and keywords like `trabajo`, `grok`, and `hetzner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87a4abed4c100eb741bb447197b9828c967e605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->