### PR TITLE
fix(webhooks): matcher real — matched honesto, upsert atómico, estados sin degradar, projects.status vivo

### DIFF
--- a/app/api/webhooks/github/route.ts
+++ b/app/api/webhooks/github/route.ts
@@ -29,11 +29,12 @@ export async function POST(req: Request) {
     }
   }
 
-  let matched = false;
-  let payload: Record<string, unknown> = {};
+  let projectId: string | null = null;
+  let repo: string | null = null;
+  let action: string | null = null;
   try {
-    payload = JSON.parse(raw) as Record<string, unknown>;
-    const repo = (payload.repository as { full_name?: string } | undefined)?.full_name ?? null;
+    const payload = JSON.parse(raw) as Record<string, unknown>;
+    repo = (payload.repository as { full_name?: string } | undefined)?.full_name ?? null;
 
     if (repo && event === "push") {
       const ref = String(payload.ref ?? "");
@@ -44,13 +45,13 @@ export async function POST(req: Request) {
         sha: (c as { id?: string }).id,
       }));
       const headSha = String((payload.after as string) ?? "") || null;
-      matched = await recordGithubPush(repo, branch, commits, headSha);
+      projectId = await recordGithubPush(repo, branch, commits, headSha);
     } else if (repo && event === "pull_request") {
-      const action = String(payload.action ?? "");
+      action = String(payload.action ?? "");
       const pr = (payload.pull_request as
         | { title?: string; number?: number; merged?: boolean }
         | undefined) ?? {};
-      matched = await recordGithubPR(
+      projectId = await recordGithubPR(
         repo,
         action,
         String(pr.title ?? ""),
@@ -62,7 +63,9 @@ export async function POST(req: Request) {
     /* ignore parse errors */
   }
 
-  logWebhook("github", event, null, { matched }).catch(() => null);
+  const matched = Boolean(projectId);
+  // Auditable: repo y acción, no solo {matched}.
+  logWebhook("github", event, projectId, { matched, repo, action }, matched).catch(() => null);
   return json({ ok: true, event, matched }, 200);
 }
 

--- a/app/api/webhooks/vercel/route.ts
+++ b/app/api/webhooks/vercel/route.ts
@@ -4,6 +4,18 @@ import { recordVercelDeploy, logWebhook, type DeployInfo } from "@/lib/projects/
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/** Mapa explícito de tipo de evento → estado del deploy.
+ *  null = evento que NO cambia el estado (checks, alias, etc.).
+ *  OJO: deployment.promoted llega después de succeeded en producción; antes
+ *  caía al default 'building' y pisaba el 'ready' para siempre. */
+function stateForType(type: string): string | null {
+  if (type.endsWith(".succeeded") || type.endsWith(".ready") || type.endsWith(".promoted")) return "ready";
+  if (type.endsWith(".error")) return "error";
+  if (type.endsWith(".canceled")) return "canceled";
+  if (type.endsWith(".created")) return "building";
+  return null;
+}
+
 /**
  * POST /api/webhooks/vercel — eventos de Vercel (deployment.succeeded,
  * deployment.error, deployment.created…). Verifica x-vercel-signature
@@ -23,7 +35,9 @@ export async function POST(req: Request) {
     }
   }
 
-  let matched = false;
+  let projectId: string | null = null;
+  let type = "deployment";
+  let info: DeployInfo | null = null;
   try {
     const body = JSON.parse(raw) as {
       type?: string;
@@ -35,17 +49,9 @@ export async function POST(req: Request) {
         deploymentId?: string;
       };
     };
-    const type = body.type ?? "";
+    type = body.type || "deployment";
     const p = body.payload ?? {};
     const dep = p.deployment ?? {};
-    const state =
-      type.endsWith(".succeeded") || type.endsWith(".ready")
-        ? "ready"
-        : type.endsWith(".error")
-          ? "error"
-          : type.endsWith(".canceled")
-            ? "canceled"
-            : "building";
     const sha =
       (dep.meta?.githubCommitSha as string | undefined) ??
       (dep.meta?.gitCommitSha as string | undefined) ??
@@ -54,21 +60,34 @@ export async function POST(req: Request) {
       (dep.meta?.githubCommitRef as string | undefined) ??
       (dep.meta?.gitCommitRef as string | undefined) ??
       null;
-    const info: DeployInfo = {
+    info = {
       vercelProjectId: p.project?.id ?? null,
       name: dep.name ?? p.name ?? null,
       url: dep.url ?? p.url ?? null,
-      state,
+      state: stateForType(type),
       deploymentId: dep.id ?? p.deploymentId ?? null,
       commitSha: sha,
       branch,
     };
-    matched = await recordVercelDeploy(info);
+    projectId = await recordVercelDeploy(info);
   } catch {
     /* ignore */
   }
 
-  logWebhook("vercel", "deployment", null, { matched }).catch(() => null);
+  const matched = Boolean(projectId);
+  // Auditable: identidad del evento, no solo {matched} (antes se tiraba el
+  // payload y era imposible re-matchear ni depurar).
+  logWebhook("vercel", type, projectId, {
+    matched,
+    type,
+    vercelProjectId: info?.vercelProjectId ?? null,
+    deploymentId: info?.deploymentId ?? null,
+    name: info?.name ?? null,
+    state: info?.state ?? null,
+    url: info?.url ?? null,
+    commitSha: info?.commitSha ?? null,
+    branch: info?.branch ?? null,
+  }, matched).catch(() => null);
   return json({ ok: true, matched }, 200);
 }
 

--- a/lib/projects/live.ts
+++ b/lib/projects/live.ts
@@ -5,23 +5,29 @@
  * actividad REAL (commits, PRs, deploys) a la DB del proyecto. Un proyecto
  * puede tener VARIOS repos y VARIOS deploys: todo se agrega por project_id.
  *
- * Todo es best-effort: cualquier error se traga (el webhook responde 200).
+ * Todo es best-effort: cualquier error se traga (el webhook responde 200),
+ * pero un fallo en un efecto secundario (integración/timeline) NUNCA debe
+ * borrar el hecho de que el evento SÍ matcheó con un proyecto.
  */
 import { queryOne } from "@/lib/db/client";
 import { addTimelineEvent } from "@/lib/projects/timeline";
 
-/** Registra el evento crudo (auditoría) y devuelve si se asoció a un proyecto. */
+/**
+ * Registra el evento crudo (auditoría). `matched` refleja el resultado REAL
+ * del matcheo (antes se calculaba de un projectId que siempre llegaba null).
+ */
 export async function logWebhook(
   source: "github" | "vercel",
   event: string,
   projectId: string | null,
   payload: unknown,
+  matched?: boolean,
 ): Promise<void> {
   try {
     await queryOne(
       `INSERT INTO webhook_events (source, event, project_id, matched, payload)
        VALUES ($1, $2, $3, $4, $5::jsonb)`,
-      [source, event, projectId, Boolean(projectId), JSON.stringify(payload ?? {})],
+      [source, event, projectId, matched ?? Boolean(projectId), JSON.stringify(payload ?? {})],
     );
   } catch {
     /* ignore */
@@ -45,8 +51,8 @@ export async function resolveProjectByRepo(
     [repoFullName],
   );
   if (viaProjects?.id) {
-    // Auto-siembra el repo primario en project_repos.
-    await upsertRepo(viaProjects.id, repoFullName, viaProjects.github_default_branch, true);
+    // Auto-siembra el repo primario en project_repos (best-effort).
+    await upsertRepo(viaProjects.id, repoFullName, viaProjects.github_default_branch, true).catch(() => null);
     return viaProjects.id;
   }
   return null;
@@ -101,7 +107,12 @@ async function upsertRepo(
   );
 }
 
-/** Upsert del estado de una integración (github/vercel/etc) del proyecto. */
+/**
+ * Upsert del estado de una integración (github/vercel/etc) del proyecto.
+ * Atómico: el viejo SELECT→INSERT chocaba con el unique (project_id, kind)
+ * cuando dos webhooks del mismo proyecto llegaban a la vez (p.ej. vforge y
+ * vforge-engine deployean el mismo repo) y el 23505 tumbaba todo el record.
+ */
 export async function upsertIntegration(
   projectId: string,
   kind: string,
@@ -109,43 +120,34 @@ export async function upsertIntegration(
   status: string,
   meta: Record<string, unknown> = {},
 ): Promise<void> {
-  const existing = await queryOne<{ id: string }>(
-    `SELECT id FROM project_integrations WHERE project_id = $1 AND kind = $2 LIMIT 1`,
-    [projectId, kind],
+  await queryOne(
+    `INSERT INTO project_integrations (project_id, kind, label, status, meta)
+     VALUES ($1, $2, $3, $4, $5::jsonb)
+     ON CONFLICT (project_id, kind) DO UPDATE
+        SET status = EXCLUDED.status,
+            label = EXCLUDED.label,
+            meta = EXCLUDED.meta`,
+    [projectId, kind, label, status, JSON.stringify(meta)],
   );
-  if (existing?.id) {
-    await queryOne(
-      `UPDATE project_integrations
-          SET status = $1, label = $2, meta = $3::jsonb
-        WHERE id = $4`,
-      [status, label, JSON.stringify(meta), existing.id],
-    );
-  } else {
-    await queryOne(
-      `INSERT INTO project_integrations (project_id, kind, label, status, meta)
-       VALUES ($1, $2, $3, $4, $5::jsonb)`,
-      [projectId, kind, label, status, JSON.stringify(meta)],
-    );
-  }
 }
 
 export interface PushCommit { message: string; sha?: string }
 
-/** Webhook push de GitHub → repo + timeline + integración. */
+/** Webhook push de GitHub → repo + timeline + integración. Devuelve el project_id matcheado (o null). */
 export async function recordGithubPush(
   repoFullName: string,
   branch: string,
   commits: PushCommit[],
   headSha: string | null,
-): Promise<boolean> {
+): Promise<string | null> {
   const projectId = await resolveProjectByRepo(repoFullName);
-  if (!projectId) return false;
-  await upsertRepo(projectId, repoFullName, branch, false, headSha);
+  if (!projectId) return null;
+  await upsertRepo(projectId, repoFullName, branch, false, headSha).catch(() => null);
   await upsertIntegration(projectId, "github", repoFullName, "connected", {
     last_branch: branch,
     last_push_at: new Date().toISOString(),
     last_commit_sha: headSha,
-  });
+  }).catch(() => null);
   const n = commits.length;
   if (n > 0) {
     const detail = commits.slice(0, 8).map((c) => `• ${c.message.split("\n")[0]}`).join("\n");
@@ -154,53 +156,73 @@ export async function recordGithubPush(
       status: "in_progress",
       title: `${n} commit${n > 1 ? "s" : ""} → ${repoFullName} (${branch})`,
       detail,
-    });
+    }).catch(() => null);
   }
-  return true;
+  return projectId;
 }
 
-/** Webhook pull_request de GitHub → timeline. */
+/** Webhook pull_request de GitHub → timeline. Devuelve el project_id matcheado (o null). */
 export async function recordGithubPR(
   repoFullName: string,
   action: string,
   title: string,
   merged: boolean,
   num: number,
-): Promise<boolean> {
+): Promise<string | null> {
   const projectId = await resolveProjectByRepo(repoFullName);
-  if (!projectId) return false;
+  if (!projectId) return null;
   const verb = merged ? "PR mergeado" : `PR ${action}`;
   await addTimelineEvent(projectId, {
     stage: "dev",
     status: merged ? "done" : "in_progress",
     title: `${verb} #${num} — ${repoFullName}`,
     detail: title,
-  });
-  return true;
+  }).catch(() => null);
+  return projectId;
 }
 
 export interface DeployInfo {
   vercelProjectId: string | null;
   name: string | null;
   url: string | null;
-  state: string; // ready|building|error|canceled
+  /** ready|building|error|canceled — null = evento sin cambio de estado (no pisar). */
+  state: string | null;
   deploymentId: string | null;
   commitSha: string | null;
   branch: string | null;
 }
 
-/** Webhook de Vercel → project_deploys + timeline + integración. */
-export async function recordVercelDeploy(d: DeployInfo): Promise<boolean> {
+/** Webhook de Vercel → project_deploys + timeline + integración. Devuelve el project_id matcheado (o null). */
+export async function recordVercelDeploy(d: DeployInfo): Promise<string | null> {
   const projectId = await resolveProjectByVercel(d.vercelProjectId, d.name);
-  if (!projectId) return false;
+  if (!projectId) return null;
 
-  // Idempotente por deployment_id.
+  // Estado previo (para no duplicar timeline en re-entregas/promoted).
+  const prev = d.deploymentId
+    ? await queryOne<{ state: string }>(
+        `SELECT state FROM project_deploys
+          WHERE provider = 'vercel' AND deployment_id = $1 LIMIT 1`,
+        [d.deploymentId],
+      ).catch(() => null)
+    : null;
+
+  // Idempotente por deployment_id. Un estado terminal (ready/error/canceled)
+  // nunca se degrada a 'building' por eventos tardíos o fuera de orden
+  // (deployment.promoted llega DESPUÉS de succeeded y antes caía al default
+  // 'building', dejando deploys READY como 'building' eterno en la sala live).
   await queryOne(
     `INSERT INTO project_deploys
         (project_id, provider, vercel_project_id, deployment_id, name, url, state, commit_sha, meta)
-     VALUES ($1, 'vercel', $2, $3, $4, $5, $6, $7, $8::jsonb)
+     VALUES ($1, 'vercel', $2, $3, $4, $5, COALESCE($6, 'building'), $7, $8::jsonb)
      ON CONFLICT (provider, deployment_id) WHERE deployment_id IS NOT NULL
-     DO UPDATE SET state = EXCLUDED.state, url = COALESCE(EXCLUDED.url, project_deploys.url)`,
+     DO UPDATE SET
+        state = CASE
+                  WHEN $6 IS NULL THEN project_deploys.state
+                  WHEN $6 = 'building' AND project_deploys.state IN ('ready', 'error', 'canceled')
+                       THEN project_deploys.state
+                  ELSE $6
+                END,
+        url = COALESCE(EXCLUDED.url, project_deploys.url)`,
     [projectId, d.vercelProjectId, d.deploymentId, d.name, d.url, d.state, d.commitSha, JSON.stringify({ branch: d.branch })],
   );
 
@@ -219,19 +241,38 @@ export async function recordVercelDeploy(d: DeployInfo): Promise<boolean> {
 
   const ok = d.state === "ready" || d.state === "succeeded";
   const err = d.state === "error" || d.state === "canceled";
-  await upsertIntegration(projectId, "vercel", d.name ?? "vercel", ok ? "connected" : err ? "error" : "building", {
-    last_url: d.url,
-    last_state: d.state,
-    last_deploy_at: new Date().toISOString(),
-  });
-
   if (ok || err) {
+    await upsertIntegration(projectId, "vercel", d.name ?? "vercel", ok ? "connected" : "error", {
+      last_url: d.url,
+      last_state: d.state,
+      last_deploy_at: new Date().toISOString(),
+    }).catch(() => null);
+  } else if (d.state === "building") {
+    await upsertIntegration(projectId, "vercel", d.name ?? "vercel", "building", {
+      last_url: d.url,
+      last_state: d.state,
+      last_deploy_at: new Date().toISOString(),
+    }).catch(() => null);
+  }
+
+  // El proyecto cobra vida cuando un deploy queda READY (antes nada tocaba
+  // projects.status y los 249 proyectos se quedaban en 'unknown' eterno).
+  if (ok) {
+    await queryOne(
+      `UPDATE projects SET status = 'live', updated_at = now()
+        WHERE id = $1 AND status IS DISTINCT FROM 'live'`,
+      [projectId],
+    ).catch(() => null);
+  }
+
+  const transitioned = (prev?.state ?? null) !== d.state;
+  if ((ok || err) && transitioned) {
     await addTimelineEvent(projectId, {
       stage: "deploy",
       status: ok ? "done" : "blocked",
       title: ok ? `Deploy listo — ${d.name ?? "vercel"}` : `Deploy falló — ${d.name ?? "vercel"}`,
       detail: d.url ? `https://${d.url.replace(/^https?:\/\//, "")}` : null,
-    });
+    }).catch(() => null);
   }
-  return true;
+  return projectId;
 }


### PR DESCRIPTION
Causa raíz (demostrada contra datos de Neon + API de Vercel):
1. `logWebhook(source, event, null, {matched})` — projectId hardcodeado en null y `matched = Boolean(projectId)` → 12,901/12,901 eventos con matched=false aunque el matcheo SÍ funcionaba (el resultado quedaba enterrado en `payload={"matched":true}` y el payload real se tiraba).
2. `upsertIntegration` hacía SELECT→INSERT y chocaba con el unique `(project_id, kind)` cuando vforge y vforge-engine deployaban a la vez; el 23505 tumbaba `recordVercelDeploy` DESPUÉS de insertar el deploy (fila insertada 02:17:40.187, log matched=false .222).
3. `deployment.promoted` (llega ~6s tras succeeded en producción) caía al default `building` y el ON CONFLICT pisaba `ready`→`building` eterno: `dpl_9VPRtdaEsPyj7aptcXk4mCaz7Hag` = READY en Vercel, `building` en DB (513 filas así). Además nada actualizaba `projects.status` → 238/249 en 'unknown'.

Fix: record* devuelven project_id y el log guarda matched real + identidad del evento; upsert atómico ON CONFLICT; estados terminales nunca se degradan; deploy READY marca el proyecto 'live'. Typecheck limpio en los 3 archivos tocados. Backfill de históricos va aparte (dry-run listo, espera aprobación).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPv4uQnvbuBggFSpYVEy8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches webhook ingestion, deploy state persistence, and project status—core live data paths—but changes are targeted fixes with best-effort error isolation rather than broad refactors.
> 
> **Overview**
> Fixes **live ingestion and audit** for GitHub and Vercel webhooks so matched events are recorded correctly and deploy/project state stays consistent under concurrency and out-of-order events.
> 
> **Audit:** `recordGithubPush`, `recordGithubPR`, and `recordVercelDeploy` now return the matched **`project_id`** (or `null`) instead of a boolean. Routes pass that id into **`logWebhook`** with an explicit **`matched`** flag and richer payloads (repo/action on GitHub; deploy type, ids, state, url, sha, branch on Vercel) instead of logging with a hardcoded null project id.
> 
> **Resilience:** Secondary writes (repo seed, integrations, timeline) are wrapped in **`.catch`** so a failure there no longer implies the event did not match. **`upsertIntegration`** uses a single **INSERT … ON CONFLICT** upsert to avoid unique-constraint races when parallel webhooks hit the same project.
> 
> **Vercel deploy state:** **`stateForType`** maps event suffixes (including **`.promoted` → ready**); unknown types yield **`null`** so they do not overwrite state. Deploy upserts use SQL **`CASE`** so terminal states (**ready/error/canceled**) are never downgraded to **building**; timeline entries fire only on **state transitions**. Successful ready deploys set **`projects.status`** to **`live`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7792ec4ac00ff6a7e984133f1abd4e504362be8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->