### PR TITLE
fix(mcp): produccion/delivery_priority no se caen del LIMIT en project_status y apps_health

### DIFF
--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -835,10 +835,10 @@ export async function runMcpTool(
       // otro tenant para luego filtrarlas en memoria.
       const rows = isAdminScope
         ? await queryAll<{ name: string; category: string; status: string; vercel_url: string | null }>(
-            "SELECT name, category, status, vercel_url FROM projects ORDER BY name LIMIT 60",
+            "SELECT name, category, status, vercel_url FROM projects ORDER BY (category = 'produccion') DESC, delivery_priority DESC, name LIMIT 60",
           ).catch(() => [])
         : await queryAll<{ name: string; category: string; status: string; vercel_url: string | null }>(
-            "SELECT name, category, status, vercel_url FROM projects WHERE org_id = $1 ORDER BY name LIMIT 60",
+            "SELECT name, category, status, vercel_url FROM projects WHERE org_id = $1 ORDER BY (category = 'produccion') DESC, delivery_priority DESC, name LIMIT 60",
             [orgId],
           ).catch(() => []);
       if (rows.length === 0) {
@@ -1147,10 +1147,10 @@ export async function runMcpTool(
       // AISLAMIENTO: admin ve la salud de todas las apps; client SOLO su org_id.
       const rows = isAdminScope
         ? await queryAll<{ name: string; status: string; category: string; vercel_url: string | null; last_audit_score: number | null }>(
-            "SELECT name, status, category, vercel_url, last_audit_score FROM projects ORDER BY name LIMIT 100",
+            "SELECT name, status, category, vercel_url, last_audit_score FROM projects ORDER BY (category = 'produccion') DESC, delivery_priority DESC, name LIMIT 100",
           ).catch(() => [])
         : await queryAll<{ name: string; status: string; category: string; vercel_url: string | null; last_audit_score: number | null }>(
-            "SELECT name, status, category, vercel_url, last_audit_score FROM projects WHERE org_id = $1 ORDER BY name LIMIT 100",
+            "SELECT name, status, category, vercel_url, last_audit_score FROM projects WHERE org_id = $1 ORDER BY (category = 'produccion') DESC, delivery_priority DESC, name LIMIT 100",
             [orgId],
           ).catch(() => []);
       if (rows.length === 0) {


### PR DESCRIPTION
Con 242 filas en `projects`, `ORDER BY name LIMIT 60/100` dejaba fuera proyectos cuyo nombre empieza tarde en el abecedario. V&LIVING, Zuxen, Vedika y Premmex — 4 de los 8 proyectos que importan — no aparecían en `vforge_project_status` ni en `vforge_apps_health`. Fix: ordenar primero por `category='produccion'` y `delivery_priority`, luego por `name`, antes de aplicar el LIMIT.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only SQL ordering in two MCP list tools; no auth, writes, or limit semantics changes.
> 
> **Overview**
> **`vforge_project_status`** and **`vforge_apps_health`** no longer sort projects only by name before applying their **60/100 row caps**. Both admin and tenant-scoped queries now use **`ORDER BY (category = 'produccion') DESC, delivery_priority DESC, name`**, so production and higher-priority deliveries stay in the truncated list instead of being dropped when the catalog is large.
> 
> Tenant isolation (`org_id` for clients, full list for admin) and the existing **LIMIT** values are unchanged; only which rows surface first in MCP responses changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9f526a1593a0c1cb6875fa86b90f12621afd10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->