### PR TITLE
fix(live): los tres hallazgos de Codex sobre el chat de V

### DIFF
--- a/app/api/live/[projectId]/assistant/route.ts
+++ b/app/api/live/[projectId]/assistant/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { askV } from "@/lib/forge/ask-v";
+import { askV, type AskVResult } from "@/lib/forge/ask-v";
 import {
   ROOM_CEREBRAS_MODEL,
   cerebrasTalkModel,
@@ -179,19 +179,47 @@ export async function POST(
       }
     }
 
-    const result = await askV({
-      mode,
-      projectId,
-      repository: repoContext,
-      message: spoken,
-      history,
-      preferredModel: cerebrasTalkModel(images.length > 0),
-      roomContext: brief || null,
-      images,
-      runId,
-      runAgent,
-      dispatchError,
-    });
+    // Si la orden YA se encoló, este turno no puede terminar en 502: el
+    // cliente devuelve el mensaje al composer y el reintento crea otra rama
+    // y otro job pagado por la misma instrucción. Cuando hay runId, el fallo
+    // del motor de V se cuenta, no se lanza.
+    let result: AskVResult;
+    let providerFailure: ProviderUnavailable | null = null;
+    try {
+      result = await askV({
+        mode,
+        projectId,
+        repository: repoContext,
+        message: spoken,
+        history,
+        preferredModel: cerebrasTalkModel(images.length > 0),
+        roomContext: brief || null,
+        images,
+        runId,
+        runAgent,
+        dispatchError,
+      });
+    } catch (caught) {
+      if (!runId) throw caught;
+      providerFailure =
+        caught instanceof ProviderUnavailable ? caught : null;
+      console.warn("[project assistant] orden encolada sin respuesta de V", {
+        projectId,
+        runId,
+        cause: providerFailure?.cause ?? "unknown",
+      });
+      result = {
+        text: "",
+        provider: "cerebras",
+        model: cerebrasTalkModel(images.length > 0),
+        status: "fallback",
+        durationMs: providerFailure?.durationMs ?? 0,
+        notice: null,
+        attempts: [],
+        usage: null,
+        blind: false,
+      };
+    }
     const extracted = extractMemoryBlocks(result.text);
     for (const memory of extracted.memories) {
       await saveUserMemory(access.identity.userId, memory.key, memory.value).catch(
@@ -208,6 +236,10 @@ export async function POST(
     if (result.blind && attachments.length) {
       reply = `${reply}\n\nNo pude abrir ${attachments.length} foto(s) en este turno; quedaron guardadas en el expediente.`;
     }
+    if (providerFailure) {
+      reply = `${reply}\n\nNo te pude contestar en este turno: mi motor no alcanzó a responder. La orden ya salió, no la mandes otra vez.`;
+    }
+    reply = reply.trim();
 
     await saveProjectAssistantTurn({
       projectId,
@@ -228,8 +260,8 @@ export async function POST(
     }).catch(() => null);
     await recordCerebrasPulse({
       projectId,
-      ok: true,
-      cause: result.status,
+      ok: !providerFailure,
+      cause: providerFailure?.cause ?? result.status,
       durationMs: result.durationMs,
       usage: result.usage,
     }).catch(() => null);
@@ -242,11 +274,13 @@ export async function POST(
       runAgent,
       dispatchError,
       blind: result.blind,
+      notice: providerFailure
+        ? `${humanProviderLabel(providerFailure.provider)} no respondió; la orden ya está encolada`
+        : result.notice,
       provider: result.provider,
       model: result.model,
       status: result.status,
       durationMs: result.durationMs,
-      notice: result.notice,
       usage: result.usage,
       translator: {
         provider: "cerebras",

--- a/app/globals.css
+++ b/app/globals.css
@@ -64,6 +64,17 @@
   --vf-fg: #090909;
   --vf-fg-1: #34363a;
   --vf-fg-2: #73767b;
+
+  /* Sala de V — papel cálido, a propósito distinto del gris del resto de la
+     app: es una conversación, no un panel. --vchat-muted está en 7:1 sobre
+     el papel. */
+  --vchat-paper: #efeee8;
+  --vchat-card: #ffffff;
+  --vchat-field: #f7f6f2;
+  --vchat-line: #e4e1d8;
+  --vchat-ink: #1c1917;
+  --vchat-on-ink: #f6f3ec;
+  --vchat-muted: #57534e;
 }
 
 *,

--- a/components/live/MobileLiveShell.tsx
+++ b/components/live/MobileLiveShell.tsx
@@ -234,7 +234,7 @@ export function MobileLiveShell({
             className="flex h-14 w-16 flex-col items-center justify-center gap-1 text-black"
             aria-label="Hablar con V"
           >
-            <span className="grid h-11 w-11 place-items-center rounded-full bg-[#1c1917] text-[15px] font-semibold text-[#f6f3ec]">
+            <span className="grid h-11 w-11 place-items-center rounded-full bg-[var(--vchat-ink)] text-[15px] font-semibold text-[var(--vchat-on-ink)]">
               V
             </span>
             <span className="font-mono text-[8px] uppercase tracking-[0.08em]">Hablar</span>
@@ -259,7 +259,7 @@ export function MobileLiveShell({
       </div>
 
       {vOpen ? (
-        <div className="fixed inset-0 z-50 bg-[#efeee8]" role="dialog" aria-modal="true" aria-label="Chat con V">
+        <div className="fixed inset-0 z-50 bg-[var(--vchat-paper)]" role="dialog" aria-modal="true" aria-label="Chat con V">
           <VConversationPanel
             projectId={project.id}
             variant="mobile"

--- a/components/live/VConversationPanel.tsx
+++ b/components/live/VConversationPanel.tsx
@@ -29,13 +29,15 @@ interface PendingPhoto {
   preview: string;
 }
 
-/** Paleta de la sala de V. Papel cálido, tinta casi negra. */
-const INK = "#1c1917";
-const PAPER = "#efeee8";
-const CARD = "#ffffff";
-const LINE = "#e4e1d8";
-/** 7.0:1 sobre el papel — el #6f6b64 anterior se perdía en móvil. */
-const MUTED = "#57534e";
+/** Paleta de la sala de V. Los valores viven en el token system
+ *  (app/globals.css, bloque --vchat-*), aquí sólo se consumen. */
+const INK = "var(--vchat-ink)";
+const ON_INK = "var(--vchat-on-ink)";
+const PAPER = "var(--vchat-paper)";
+const CARD = "var(--vchat-card)";
+const FIELD = "var(--vchat-field)";
+const LINE = "var(--vchat-line)";
+const MUTED = "var(--vchat-muted)";
 
 const THINKING = ["Pensando", "Leyendo la sala", "Revisando el expediente", "Escribiendo"];
 
@@ -101,8 +103,8 @@ function ThinkingLine({ hasPhotos }: { hasPhotos: boolean }) {
   return (
     <div className="flex items-center gap-2 pl-1 pt-1">
       <span className="relative grid h-3.5 w-3.5 place-items-center">
-        <span className="absolute inset-0 rounded-full bg-[#1c1917]/15 animate-ping" />
-        <span className="h-1.5 w-1.5 rounded-full bg-[#1c1917]" />
+        <span className="absolute inset-0 rounded-full bg-[var(--vchat-ink)]/15 animate-ping" />
+        <span className="h-1.5 w-1.5 rounded-full bg-[var(--vchat-ink)]" />
       </span>
       <p className="text-[13px] tracking-[-0.01em]" style={{ color: MUTED }}>
         {steps[index]}
@@ -372,7 +374,7 @@ export function VConversationPanel({
         ) : null}
         <span
           className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-[12px] font-semibold"
-          style={{ backgroundColor: INK, color: "#f6f3ec" }}
+          style={{ backgroundColor: INK, color: ON_INK }}
         >
           V
         </span>
@@ -388,7 +390,7 @@ export function VConversationPanel({
           <button
             type="button"
             onClick={onClose}
-            className="grid h-9 w-9 shrink-0 place-items-center rounded-full hover:bg-[#efeee8]"
+            className="grid h-9 w-9 shrink-0 place-items-center rounded-full hover:bg-[var(--vchat-paper)]"
             style={{ color: INK }}
             aria-label="Cerrar V"
           >
@@ -423,7 +425,7 @@ export function VConversationPanel({
                     )}
                     style={{
                       backgroundColor: mine ? INK : CARD,
-                      color: mine ? "#f6f3ec" : INK,
+                      color: mine ? ON_INK : INK,
                     }}
                   >
                     {mine && thumbs.length ? (
@@ -560,7 +562,7 @@ export function VConversationPanel({
                   <img src={photo.preview} alt="" className="h-full w-full object-cover" />
                   <span
                     className="absolute right-0.5 top-0.5 grid h-5 w-5 place-items-center rounded-full"
-                    style={{ backgroundColor: INK, color: "#f6f3ec" }}
+                    style={{ backgroundColor: INK, color: ON_INK }}
                   >
                     <IconX size={10} />
                   </span>
@@ -612,7 +614,7 @@ export function VConversationPanel({
                   ? "min-h-12 max-h-[132px] py-3 text-[16px] leading-6"
                   : "min-h-10 max-h-28 py-2.5 text-[15px] leading-5",
               )}
-              style={{ borderColor: LINE, backgroundColor: "#f7f6f2", color: INK }}
+              style={{ borderColor: LINE, backgroundColor: FIELD, color: INK }}
             />
             <button
               type="submit"
@@ -621,7 +623,7 @@ export function VConversationPanel({
                 "grid shrink-0 place-items-center rounded-full disabled:opacity-30",
                 mobile ? "h-12 w-12" : "h-10 w-10",
               )}
-              style={{ backgroundColor: INK, color: "#f6f3ec" }}
+              style={{ backgroundColor: INK, color: ON_INK }}
               aria-label="Enviar"
             >
               {busy ? (

--- a/lib/live/start-owner-run.ts
+++ b/lib/live/start-owner-run.ts
@@ -40,6 +40,33 @@ export async function startOwnerRun(args: {
   const agent: BuilderExecutor = args.executor ?? "claude";
 
   await ensureProjectAgentRunsTable();
+
+  // Idempotencia: la misma instrucción, en la misma sala, con un run todavía
+  // vivo, devuelve ese run en vez de abrir otra rama y pagar otro job. Cubre
+  // el reintento manual y la respuesta que se pierde en la red después de
+  // que el servidor ya encoló.
+  const vivo = await queryOne<{ id: string; resolved_executor: string }>(
+    `SELECT id::text, resolved_executor
+       FROM project_agent_runs
+      WHERE project_id = $1
+        AND instruction = $2
+        AND status NOT IN ('failed', 'cancelled', 'published', 'approved')
+        AND created_at > now() - interval '10 minutes'
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [args.projectId, instruction],
+  ).catch(() => null);
+  if (vivo) {
+    console.info("[start-owner-run] orden repetida, reuso el run", {
+      projectId: args.projectId,
+      runId: vivo.id,
+    });
+    return {
+      runId: vivo.id,
+      agent: (vivo.resolved_executor === "codex" ? "codex" : "claude") as BuilderExecutor,
+    };
+  }
+
   const runId = randomUUID();
   const baseBranch = args.repository.default_branch || "main";
   const workBranch = `vforge/run-${runId.slice(0, 8)}`;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "start": "next start",
         "lint": "eslint .",
         "typecheck": "tsc --noEmit",
-        "test": "tsc -p tsconfig.test.json && node --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \".test-dist/tests/project-tools.test.js\" \".test-dist/tests/see-page.test.js\" \".test-dist/tests/work-order.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
+        "test": "tsc -p tsconfig.test.json && node --require \"./.test-dist/tests/alias-hook.js\" --test \".test-dist/tests/roles.test.js\" \".test-dist/tests/invite-token.test.js\" \".test-dist/tests/owner-auth.test.js\" \".test-dist/tests/viewport-url.test.js\" \".test-dist/tests/review-context.test.js\" \".test-dist/tests/archive-text.test.js\" \".test-dist/tests/provider-errors.test.js\" \".test-dist/tests/room-context.test.js\" \".test-dist/tests/factory-spine.test.js\" \".test-dist/tests/read-page.test.js\" \".test-dist/tests/project-tools.test.js\" \".test-dist/tests/see-page.test.js\" \".test-dist/tests/work-order.test.js\" \".test-dist/tests/v-factory-hands.test.js\" \".test-dist/tests/chat-attachments.test.js\" \"tests/vforge-api-viewport.test.mjs\"",
         "audit:contrast": "python3 scripts/contrast_audit.py"
     },
     "dependencies": {

--- a/tests/alias-hook.ts
+++ b/tests/alias-hook.ts
@@ -1,0 +1,31 @@
+/**
+ * Puente de resolución para `node --test`.
+ *
+ * Los tests se compilan a CommonJS en .test-dist, pero el código de la app
+ * importa con el alias `@/...` (que sólo entiende TypeScript/Next) y algunos
+ * módulos de servidor importan `server-only`, que lanza a propósito fuera de
+ * un React Server Component. Por eso dos archivos de prueba no corrían: no
+ * estaban mal escritos, no podían ni cargarse.
+ *
+ * Este hook los hace ejecutables sin dependencias nuevas: mapea `@/x` a la
+ * raíz compilada y convierte `server-only` en un módulo vacío.
+ */
+import Module from "node:module";
+import path from "node:path";
+
+interface ResolverHost {
+  _resolveFilename(request: string, ...rest: unknown[]): string;
+}
+
+const host = Module as unknown as ResolverHost;
+const raiz = path.resolve(__dirname, "..");
+const vacio = path.join(__dirname, "server-only-stub.js");
+const original = host._resolveFilename;
+
+host._resolveFilename = function (request: string, ...rest: unknown[]): string {
+  if (request === "server-only") return vacio;
+  const destino = request.startsWith("@/")
+    ? path.join(raiz, request.slice(2))
+    : request;
+  return original.call(this, destino, ...rest);
+};

--- a/tests/server-only-stub.ts
+++ b/tests/server-only-stub.ts
@@ -1,0 +1,2 @@
+/** Reemplazo inerte de `server-only` para las pruebas. Ver tests/alias-hook.ts. */
+export {};

--- a/tests/v-factory-hands.test.ts
+++ b/tests/v-factory-hands.test.ts
@@ -10,5 +10,8 @@ test("factory hands trigger on skills and brain", () => {
 
 test("talk never asks the owner for curl", () => {
   assert.match(modeSystemRules("talk"), /curl/i);
-  assert.match(modeSystemRules("talk"), /no pidas/i);
+  // La regla se endureció de "no pidas" a "Nunca pidas"; la aserción se
+  // quedó con el literal viejo y nadie lo vio porque este archivo llevaba
+  // meses sin ejecutarse.
+  assert.match(modeSystemRules("talk"), /nunca pidas/i);
 });


### PR DESCRIPTION
Codex revisó el #205 justo antes de que se mergeara y dejó tres hallazgos. Los tres eran válidos y el código ya estaba en `main`, así que van aquí. Un commit por hallazgo (AGENTS.md §6).

## P1 · Una orden, un job (`1f0ac6d`)

**El bug era real y mío.** El #205 movió el encolado para que ocurra *antes* de hablar, y eso abrió una fuga: si `askV` tronaba (Cerebras sin responder), el turno caía al catch externo, devolvía 502 y **perdía el `runId`**. El cliente regresaba el mensaje al composer, Luis reintentaba, y se abría **otra rama y otro job pagado** por la misma instrucción.

Dos candados:
- Con la orden ya encolada, el fallo del motor se cuenta en vez de lanzarse: el turno se guarda, se devuelve el `runId` y V dice *"la orden ya salió, no la mandes otra vez"*.
- `startOwnerRun` deduplica: misma instrucción, misma sala, run vivo de menos de 10 minutos → devuelve ese run. Esto cubre lo que el primer candado no puede: la respuesta que se pierde en la red *después* de que el servidor ya encoló.

## P1 · La paleta al token system (`96fe379`)

AGENTS.md §5: *"Ningún color hardcoded en código de producción"*. El chat traía la paleta como hex literales —venía así de antes y en el #205 la consolidé en constantes, que es peor: la formalicé.

Los siete colores viven ahora en `app/globals.css` como `--vchat-*` y el componente los consume con `var()`. El papel cálido se queda: es una conversación, no un panel, y `--vchat-muted` mantiene 7:1 sobre él. Sólo se tocan los hex que introdujo el #205; los preexistentes de `MobileLiveShell` quedan para su propio turno.

## P2 · Los tests que no corrían (`c0f2f0d`)

Codex pidió regresar `v-factory-hands` y `chat-attachments` al comando. Regresarlos solos no bastaba: **no fallaban por estar mal escritos, no podían ni cargarse.** Uno importa `server-only`, que lanza a propósito fuera de un RSC; el otro resuelve `@/...`, alias que node no entiende en CommonJS.

`tests/alias-hook.ts` los hace ejecutables sin dependencias nuevas: mapea `@/x` a la raíz compilada y deja `server-only` inerte, cargado con `--require`.

Al correr por primera vez en meses salió **un rojo real**: la aserción esperaba el literal `"no pidas"` y la regla dice `"Nunca pidas que el owner corra curl"`. La regla está y es más fuerte, así que se actualizó la aserción — no se debilitó el prompt.

## Verificación

`npx tsc --noEmit` limpio · `npm run lint` 0 errores · `npm run build` completo · **`npm test` 90 pruebas en verde** (eran 86; los dos archivos recuperados aportan 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o851Av3tKYJnsCLJxnP1p

---
_Generated by [Claude Code](https://claude.ai/code/session_014o851Av3tKYJnsCLJxnP1p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live assistant POST behavior and paid run dispatch idempotency; incorrect dedup or error handling could still double-charge or hide real failures, though scope is bounded to queued-run paths.
> 
> **Overview**
> Addresses three Codex findings on the live V chat: **duplicate factory jobs**, **hardcoded chat colors**, and **tests that could not load**.
> 
> **One instruction, one job.** If a work order is queued before `askV` and the LLM provider fails, the assistant route no longer returns **502** (which made the client retry and spawn another branch/job). With an existing `runId`, provider errors are absorbed: the turn is persisted, `runId` is returned, copy tells the owner not to resend, and pulse/notice reflect the failure. **`startOwnerRun`** adds **10-minute idempotency** for the same instruction in the same room when a run is still active.
> 
> **V chat palette** moves from inline hex to **`--vchat-*` tokens** in `globals.css`; `VConversationPanel` and mobile shell consume them via `var()`.
> 
> **Test runner** loads `tests/alias-hook.ts` (maps `@/` and stubs `server-only`) so `v-factory-hands` and `chat-attachments` suites run again; one assertion in `v-factory-hands.test.ts` is updated to match the stricter talk-mode prompt wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed35037ee0bf30c0d9e64583485bae3fdd1ffd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->