### PR TITLE
fix(live): la dedupe distingue repo, agente y despacho confirmado

### DIFF
--- a/lib/live/start-owner-run.ts
+++ b/lib/live/start-owner-run.ts
@@ -41,29 +41,63 @@ export async function startOwnerRun(args: {
 
   await ensureProjectAgentRunsTable();
 
-  // Idempotencia: la misma instrucción, en la misma sala, con un run todavía
-  // vivo, devuelve ese run en vez de abrir otra rama y pagar otro job. Cubre
-  // el reintento manual y la respuesta que se pierde en la red después de
-  // que el servidor ya encoló.
-  const vivo = await queryOne<{ id: string; resolved_executor: string }>(
-    `SELECT id::text, resolved_executor
-       FROM project_agent_runs
-      WHERE project_id = $1
+  // Idempotencia. Dos reglas, porque un run pasa por dos momentos:
+  //
+  // 1. Ya despachado (queued en adelante): la orden existe de verdad en la
+  //    cola, así que se reutiliza. Decir "encolada" ahí es cierto.
+  // 2. Todavía naciendo ('preparing'): la fila existe pero la rama y el job
+  //    aún no. Ni se reutiliza (podría acabar en 'failed' y ya habríamos
+  //    dicho que salió) ni se duplica: se pide esperar unos segundos.
+  //
+  // La llave incluye repo y agente: el mismo texto mandado a otro repo o a
+  // otro constructor es OTRO trabajo, no un reintento.
+  const mismaOrden = `project_id = $1
         AND instruction = $2
-        AND status NOT IN ('failed', 'cancelled', 'published', 'approved')
+        AND lower(repo_full_name) = lower($3)
+        AND resolved_executor = $4`;
+  const llave = [
+    args.projectId,
+    instruction,
+    args.repository.repo_full_name,
+    agent,
+  ];
+
+  const despachado = await queryOne<{ id: string }>(
+    `SELECT id::text
+       FROM project_agent_runs
+      WHERE ${mismaOrden}
+        AND status IN ('queued', 'running', 'awaiting_preview', 'preview_ready', 'awaiting_approval')
         AND created_at > now() - interval '10 minutes'
       ORDER BY created_at DESC
       LIMIT 1`,
-    [args.projectId, instruction],
+    llave,
   ).catch(() => null);
-  if (vivo) {
-    console.info("[start-owner-run] orden repetida, reuso el run", {
+  if (despachado) {
+    console.info("[start-owner-run] orden repetida, reuso el run despachado", {
       projectId: args.projectId,
-      runId: vivo.id,
+      runId: despachado.id,
+      agent,
+    });
+    return { runId: despachado.id, agent };
+  }
+
+  const naciendo = await queryOne<{ id: string }>(
+    `SELECT id::text
+       FROM project_agent_runs
+      WHERE ${mismaOrden}
+        AND status = 'preparing'
+        AND created_at > now() - interval '2 minutes'
+      LIMIT 1`,
+    llave,
+  ).catch(() => null);
+  if (naciendo) {
+    console.info("[start-owner-run] orden idéntica todavía saliendo", {
+      projectId: args.projectId,
+      runId: naciendo.id,
     });
     return {
-      runId: vivo.id,
-      agent: (vivo.resolved_executor === "codex" ? "codex" : "claude") as BuilderExecutor,
+      error:
+        "ya hay una orden idéntica saliendo en este momento; dame unos segundos y te digo cómo quedó",
     };
   }
 


### PR DESCRIPTION
Codex revisó el #207 y encontró **dos huecos en la deduplicación que yo mismo metí ahí**. Los dos son reales y ya estaban en `main`, así que van aquí.

## La llave ignoraba el repositorio y el agente

La dedupe filtraba sólo por `(project_id, instruction)`. En un proyecto con varios repos, mandar la misma orden a **otro** repo dentro de 10 minutos devolvía el run del primero y **nunca despachaba al repo que el owner eligió**. Lo mismo pedir la misma orden con Codex después de Claude Code.

La llave ahora incluye `repo_full_name` y el agente resuelto: el mismo texto para otro repo o para otro constructor es **otro trabajo**, no un reintento.

## Reutilizaba runs que todavía no existían en la cola

`preparing` es la fila recién insertada, **antes** de crear la rama en GitHub y despachar el job. La dedupe la aceptaba como buena, así que un reintento que cayera en esa ventana recibía ese `runId` y el chat decía *"Orden encolada"* — aunque el original acabara en `failed` un segundo después. Justo la clase de mentira que este trabajo vino a quitar.

Ahora son dos reglas, porque un run pasa por dos momentos:

| Momento | Qué se hace |
| --- | --- |
| Despachado (`queued` en adelante) | Se reutiliza. La orden existe de verdad en la cola, decir "encolada" es cierto. |
| Naciendo (`preparing`, < 2 min) | Ni se reutiliza ni se duplica: *"ya hay una orden idéntica saliendo; dame unos segundos"*. |

Un `preparing` huérfano (si el proceso muere) se destraba solo a los 2 minutos.

## Verificación

`npx tsc --noEmit` limpio · `npm run lint` 0 errores · `npm run build` completo · `npm test` 90 pruebas en verde.

Producción comprobada durante el trabajo: `vforge.site` responde 200 y `/app/live/lutor` 307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o851Av3tKYJnsCLJxnP1p

---
_Generated by [Claude Code](https://claude.ai/code/session_014o851Av3tKYJnsCLJxnP1p)_